### PR TITLE
Affiche le nombre de communes couvertes par la Base Adresse Locale dans le résumé

### DIFF
--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -24,7 +24,7 @@ class Summary extends React.Component {
       },
       {title: 'Dernière mise à jour', value: dateMAJ ? dateMAJ.split('-').reverse().join('-') : 'inconnue'},
       {title: 'Nombre d’adresses', value: typeof rowsCount === 'number' ? spaceThousands(rowsCount) : '???'},
-      {title: 'Nombre de communes', value: communes.length}
+      {title: 'Communes couvertes', value: communes.length}
     ]
 
     return (

--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -15,21 +15,18 @@ class Summary extends React.Component {
 
   render() {
     const {dataset} = this.props
-    const {id, organization, url, model, dateMAJ, rowsCount, license} = dataset
+    const {id, organization, url, model, dateMAJ, rowsCount, communes} = dataset
     const infos = [
       {
         title: 'Format',
         value: model === 'bal-aitf' ? 'BAL (AITF)' : 'Spécifique',
         type: model === 'bal-aitf' ? 'valid' : 'not-valid'
       },
-      {
-        title: 'Licence',
-        value: license === 'odc-odbl' ? 'ODbL 1.0' : 'Licence Ouverte 2.0',
-        type: license === 'odc-odbl' ? 'not-valid' : 'valid'
-      },
       {title: 'Dernière mise à jour', value: dateMAJ ? dateMAJ.split('-').reverse().join('-') : 'inconnue'},
-      {title: 'Nombre d’adresses', value: typeof rowsCount === 'number' ? spaceThousands(rowsCount) : '???'}
+      {title: 'Nombre d’adresses', value: typeof rowsCount === 'number' ? spaceThousands(rowsCount) : '???'},
+      {title: 'Nombre de communes', value: communes.length}
     ]
+
     return (
       <div>
         <div className='base-adresse-locale'>


### PR DESCRIPTION
Cette PR remplace la ligne `licence` par le nombre de communes couvertes par la Base Adresse Locale.

Avant : 

![image](https://user-images.githubusercontent.com/56537238/133971492-403d98ff-33f8-4bb1-831a-65a020dbb886.png)


Après :

![image](https://user-images.githubusercontent.com/56537238/133971390-dec6f7a6-4d01-423f-af90-2456a95b1a6d.png)

Fix #885 