### PR TITLE
Décalage affichage des partenaires

### DIFF
--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -79,8 +79,9 @@ function Partner({partnerInfos}) {
         .general-partner-infos {
           text-align: left;
           display: grid;
-          grid-template-rows: 1fr 150px 20px;
+          grid-template-rows: 40px 150px 20px;
           grid-template-columns: 1fr;
+          gap: 1em;
           align-items: center;
           width: 100%;
         }

--- a/partners.json
+++ b/partners.json
@@ -498,8 +498,8 @@
             "mise à disposition d’outils mutualisés"
         ],
         "picture": "/images/logos/partners/lisieres-de-oise.png",
-        "height": 164,
-        "width": 200,
+        "height": 105,
+        "width": 128,
         "alt": "Logo de la Communauté de Communes des Lisières de l’Oise"
     },
     {


### PR DESCRIPTION
fix #892

Décalage de l'affichage des partenaires lorsque le titre est sur deux lignes ou plus. Les conteneurs des partenaires doivent être de hauteur et largeur identique.

### AVANT
![135486053-718922eb-c8c9-4af2-ab1](https://user-images.githubusercontent.com/66621960/135603077-32ae4b73-37bb-4c4a-bfaf-067bd7aa51d1.jpg)


### APRÈS
![Capture d’écran 2021-10-01 à 10 11 54](https://user-images.githubusercontent.com/66621960/135587559-90d34f33-1a44-483c-a279-dc8af1706091.png)
