### PR TITLE
Corrections et améliorations de l'expérience utilisateur lors de la publication

### DIFF
--- a/lib/bal/api.js
+++ b/lib/bal/api.js
@@ -54,6 +54,11 @@ export async function uploadCSV(file) {
   }
   const response = await fetch(href, options)
 
+  if (!response.ok) {
+    const {message} = await response.json()
+    throw new Error(message)
+  }
+
   if (response.ok) {
     return response.json()
   }

--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -38,11 +38,11 @@ const getStep = submission => {
   }
 }
 
-const PublicationPage = React.memo(({isRedirected, defaultSubmission, initialError, submissionId}) => {
+const PublicationPage = React.memo(({isRedirected, defaultSubmission, submissionError, submissionId}) => {
   const [submission, setSubmission] = useState(defaultSubmission)
   const [step, setStep] = useState(getStep(submission))
   const [authType, setAuthType] = useState()
-  const [error, setError] = useState(initialError)
+  const [error, setError] = useState(submissionError)
 
   const handleFile = async file => {
     try {
@@ -81,7 +81,10 @@ const PublicationPage = React.memo(({isRedirected, defaultSubmission, initialErr
   }, [submission])
 
   useEffect(() => {
-    setError(null)
+    // Prevent reset submissionError at first render
+    if (step !== 1) {
+      setError(null)
+    }
   }, [step])
 
   useEffect(() => {
@@ -122,7 +125,8 @@ const PublicationPage = React.memo(({isRedirected, defaultSubmission, initialErr
         )}
 
         <div className='current-step'>
-          {step === 1 && (
+          {/* Hide file handler to prevent the submitmission of a different file from the original */}
+          {!submissionError && step === 1 && (
             <ManageFile handleFile={handleFile} error={error} handleError={setError} />
           )}
 
@@ -171,6 +175,7 @@ const PublicationPage = React.memo(({isRedirected, defaultSubmission, initialErr
 
 PublicationPage.getInitialProps = async ({query}) => {
   const {url, submissionId} = query
+  const isRedirected = Boolean(url)
   let submission
 
   if (submissionId) {
@@ -180,13 +185,14 @@ PublicationPage.getInitialProps = async ({query}) => {
       submission = await submissionsBal(decodeURIComponent(url))
     } catch (error) {
       return {
-        initialError: error.message
+        isRedirected,
+        submissionError: error.message
       }
     }
   }
 
   return {
-    isRedirected: Boolean(url),
+    isRedirected,
     defaultSubmission: submission,
     submissionId,
     user: {}
@@ -205,14 +211,14 @@ PublicationPage.propTypes = {
     publicationUrl: PropTypes.string
   }),
   submissionId: PropTypes.string,
-  initialError: PropTypes.string
+  submissionError: PropTypes.string
 }
 
 PublicationPage.defaultProps = {
   isRedirected: false,
   defaultSubmission: null,
   submissionId: null,
-  initialError: null
+  submissionError: null
 }
 
 export default PublicationPage

--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -178,9 +178,9 @@ PublicationPage.getInitialProps = async ({query}) => {
   } else if (url) {
     try {
       submission = await submissionsBal(decodeURIComponent(url))
-    } catch {
+    } catch (error) {
       return {
-        initialError: 'Une erreur est survenue lors de la récupération du fichier'
+        initialError: error.message
       }
     }
   }


### PR DESCRIPTION
## Contexte
Si une BAL invalide est soumise via le paramètre `url` de la `/bases-locales/publication`, une erreur générique est affichée à l'utilisateur : `Une erreur est survenue lors de la récupération du fichier`.

Cependant ce message d'erreur est immédiatement effacé par un `useEffect` permettant de réinitialisé le message d'erreur si l'étape du formulaire venait à changer. Dans notre cas, c'est dès le premier rendu que cette valeur `step` change et donc passe la valeur `error` à `null`.

De plus, l'en-tête permettant aux utilisateurs venant de Mes Adresses de pouvoir y retourner via un lien n'est pas affiché car la variable `isRedirected` n'est pas encore renseigné au moment où l'erreur est capturée.

## Évolutions
- Amélioration du message d'erreur affiché à l'utilisateur en cas d'échec de la soumission d'une BAL via l'url en affichant le message d'erreur renvoyé par l'API
- En cas d'erreur de soumission, la zone de dépôt de fichier est cachée afin de ne pas encourager l'utilisateur à déposer un nouveau fichier (qui pourrait être différent de l'original provenant de Mes Adresses)
- Correction de la réinitialisation du message d'erreur à la mise à jour de `step` afin de ne plus effacer le message d'erreur provenant d'un échec de soumission
- Correction de l'affichage de l'en-tête redirigeant vers Mes Adresses
- Amélioration du message d'erreur lors de l'échec de soumission d'un fichier via le dépôt de fichier