### PR TITLE
Suppression de la dépendance à unpkg.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dropzone": "^11.4.2",
     "react-feather": "^2.0.9",
     "sharp": "^0.29.1",
+    "template.data.gouv.fr": "1.2.1",
     "underscore.string": "^3.3.5"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
+import 'template.data.gouv.fr/dist/main.css'
 
 import {DeviceContextProvider} from '@/contexts/device'
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,9 +14,6 @@ class MyDocument extends Document {
       <Html lang='fr'>
         <Head>
           <meta httpEquiv='x-ua-compatible' content='ie=edge' />
-
-          <link href='https://unpkg.com/template.data.gouv.fr@1.2.1/dist/main.min.css' rel='stylesheet' />
-
           <link rel='icon' href='/favicon.ico' />
         </Head>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6372,6 +6372,11 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+template.data.gouv.fr@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/template.data.gouv.fr/-/template.data.gouv.fr-1.2.1.tgz#e5a7acfb9de287d571258733ccffb7292ff1decd"
+  integrity sha512-GD+KgjKmEXf3md749u5AB78raZ3OWPuizQ09Bj0aLF+j1YhlU+5aIKECQ/OyrxxuTesuVwoLxhWAPdF481atTg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
La feuille de style https://template.data.gouv.fr est désormais chargée via `node_modules` et `next`.