### PR TITLE
Section vers la carte de déploiement de la bal dans la page bal

### DIFF
--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -13,8 +13,9 @@ import BaseAdresseLocale from './bases-adresse-locales/base-adresse-locale'
 import Notification from '../notification'
 import allPartners from '../../partners.json'
 import SectionText from '../section-text'
+import MapBalSection from '../map-bal-section'
 
-const BasesLocales = React.memo(({datasets}) => {
+const BasesLocales = React.memo(({datasets, stats}) => {
   const [balSamples, setBalSamples] = useState([])
   const shufflePartners = shuffle(allPartners).slice(0, 3)
 
@@ -122,6 +123,10 @@ const BasesLocales = React.memo(({datasets}) => {
         </div>
       </Section>
 
+      <Section background='color' title='État du déploiement des Bases Adresses Locales'>
+        <MapBalSection stats={stats} />
+      </Section>
+
       <style jsx>{`
         .notification-content {
           display: flex;
@@ -183,7 +188,8 @@ const BasesLocales = React.memo(({datasets}) => {
 })
 
 BasesLocales.propTypes = {
-  datasets: PropTypes.array.isRequired
+  datasets: PropTypes.array.isRequired,
+  stats: PropTypes.object.isRequired
 }
 
 export default BasesLocales

--- a/components/map-bal-section.js
+++ b/components/map-bal-section.js
@@ -1,0 +1,69 @@
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import Image from 'next/image'
+
+import {numFormater} from '@/lib/format-numbers'
+
+import theme from '@/styles/theme'
+
+import ButtonLink from '@/components/button-link'
+import Metric from '@/components/metric'
+
+function MapBalSection({stats}) {
+  const populationCouvertePercent = Math.round((stats.bal.populationCouverte * 100) / stats.france.population)
+
+  return (
+    <div className='deployement-container'>
+      <div className='map-illustration'>
+        <Link href='/deploiement-bal'>
+          <a>
+            <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} />
+          </a>
+        </Link>
+      </div>
+      <div className='metrics-container'>
+        <Metric metric={stats.bal.nbCommunesCouvertes}> communes couvertes</Metric>
+        <Metric metric={numFormater(stats.bal.nbAdresses)}> d’adresses issues des BAL</Metric>
+        <Metric metric={populationCouvertePercent} isPercent>de la population couverte</Metric>
+      </div>
+      <ButtonLink href='/deploiement-bal' isOutlined color='white'>Carte de couverture des BAL</ButtonLink>
+
+      <style jsx>{`
+        .deployement-container {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 3em;
+          margin-top: 3em;
+        }
+
+        .map-illustration {
+          min-width: 290px;
+          max-width: 400px;
+        }
+
+        .metrics-container {
+          width: 100%;
+          display: grid;
+          justify-content: center;
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          padding: 1em;
+          gap: 3em;
+          text-align: center;
+          background: ${theme.colors.white};
+          color: ${theme.darkText};
+          border-radius: ${theme.borderRadius};
+        }
+      `}</style>
+    </div>
+  )
+}
+
+MapBalSection.propTypes = {
+  stats: PropTypes.shape({
+    france: PropTypes.object.isRequired,
+    bal: PropTypes.object.isRequired,
+    ban: PropTypes.object.isRequired
+  }).isRequired
+}
+export default MapBalSection

--- a/pages/bases-locales.js
+++ b/pages/bases-locales.js
@@ -4,7 +4,7 @@ import {Database} from 'react-feather'
 
 import Page from '@/layouts/main'
 
-import {getDatasets} from '@/lib/bal/api'
+import {getDatasets, getBALStats} from '@/lib/bal/api'
 import withErrors from '@/components/hoc/with-errors'
 
 import Head from '@/components/head'
@@ -15,16 +15,17 @@ const description = 'Bases de données Adresse de périmètre local, éditées s
 
 class BasesAdressesLocalesPage extends React.Component {
   static propTypes = {
-    datasets: PropTypes.array.isRequired
+    datasets: PropTypes.array.isRequired,
+    stats: PropTypes.object.isRequired,
   }
 
   render() {
-    const {datasets} = this.props
+    const {datasets, stats} = this.props
 
     return (
       <Page title={title} description={description}>
         <Head title={title} icon={<Database size={56} />} />
-        <BasesLocales datasets={datasets} />
+        <BasesLocales datasets={datasets} stats={stats} />
       </Page>
     )
   }
@@ -32,7 +33,8 @@ class BasesAdressesLocalesPage extends React.Component {
 
 BasesAdressesLocalesPage.getInitialProps = async () => {
   return {
-    datasets: await getDatasets()
+    datasets: await getDatasets(),
+    stats: await getBALStats()
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
-import Image from 'next/image'
 
 import {getBALStats} from '@/lib/bal/api'
-import {numFormater} from '@/lib/format-numbers'
 
 import theme from '@/styles/theme'
 import Page from '@/layouts/main'
@@ -11,14 +9,12 @@ import Hero from '@/components/hero'
 import Section from '@/components/section'
 import SectionText from '@/components/section-text'
 import ButtonLink from '@/components/button-link'
-import Metric from '@/components/metric'
+import MapBalSection from '@/components/map-bal-section'
 import DocDownload from '@/components/doc-download'
 import Temoignages from '@/components/temoignages'
 import SocialMedia from '@/components/social-media'
 
 function Home({stats}) {
-  const populationCouvertePercent = Math.round((stats.bal.populationCouverte * 100) / stats.france.population)
-
   return (
     <Page>
       <Hero
@@ -74,48 +70,7 @@ function Home({stats}) {
       </Section>
 
       <Section background='color' title='État du déploiement des Bases Adresses Locales'>
-        <div className='deployement-container'>
-          <div className='map-illustration'>
-            <Link href='/deploiement-bal'>
-              <a>
-                <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} />
-              </a>
-            </Link>
-          </div>
-          <div className='metrics-container'>
-            <Metric metric={stats.bal.nbCommunesCouvertes}> communes couvertes</Metric>
-            <Metric metric={numFormater(stats.bal.nbAdresses)}> d’adresses issues des BAL</Metric>
-            <Metric metric={populationCouvertePercent} isPercent>de la population couverte</Metric>
-          </div>
-          <ButtonLink href='/deploiement-bal' isOutlined color='white'>Carte de couverture des BAL</ButtonLink>
-        </div>
-        <style jsx>{`
-          .deployement-container {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 3em;
-            margin-top: 3em;
-          }
-
-          .map-illustration {
-            min-width: 290px;
-            max-width: 400px;
-          }
-
-          .metrics-container {
-            width: 100%;
-            display: grid;
-            justify-content: center;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            padding: 1em;
-            gap: 3em;
-            text-align: center;
-            background: ${theme.colors.white};
-            color: ${theme.darkText};
-            border-radius: ${theme.borderRadius};
-          }
-        `}</style>
+        <MapBalSection stats={stats} />
       </Section>
 
       <Section background='grey' title='La fibre arrive dans la commune' subtitle='Communes et opérateurs, vous pouvez gagner du temps'>
@@ -172,6 +127,7 @@ Home.propTypes = {
     france: PropTypes.object.isRequired,
     bal: PropTypes.object.isRequired,
     ban: PropTypes.object.isRequired
-  }).isRequired}
+  }).isRequired
+}
 
 export default Home


### PR DESCRIPTION
Ajout de la même section présente dans la homepage afin que l'utilisateur puisse retrouver les infos pertinentes également dans la page /bases-locales

<img width="1149" alt="Capture d’écran 2021-11-16 à 10 50 36" src="https://user-images.githubusercontent.com/66621960/141962462-dba22861-8fda-4436-ae36-f98e5ab7e10b.png">
