### PR TITLE
Légère réorganisation du code API/Stats

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,6 @@
 NEXT_PUBLIC_API_GEO_URL=https://geo.api.gouv.fr
 NEXT_PUBLIC_BACKEND_URL=https://backend.adresse.data.gouv.fr
 NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
-NEXT_PUBLIC_API_BAL_STATS_URL=https://plateforme.adresse.data.gouv.fr/stats
 NEXT_PUBLIC_API_ADRESSE=https://api-adresse.data.gouv.fr
 NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=https://etablissements-publics.api.gouv.fr/v3
 NEXT_PUBLIC_BAN_DASHBOARD_URL=http://build-1.infra.geo.data.gouv.fr/

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_API_GEO_URL=https://geo.api.gouv.fr
 NEXT_PUBLIC_BACKEND_URL=https://backend.adresse.data.gouv.fr
-NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr/lookup
+NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
 NEXT_PUBLIC_API_BAL_STATS_URL=https://plateforme.adresse.data.gouv.fr/stats
 NEXT_PUBLIC_API_ADRESSE=https://api-adresse.data.gouv.fr
 NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=https://etablissements-publics.api.gouv.fr/v3

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -1,6 +1,6 @@
 import HttpError from './http-error'
 
-export const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr/lookup'
+export const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr'
 
 export async function _fetch(url) {
   const options = {
@@ -23,5 +23,5 @@ export async function _fetch(url) {
 }
 
 export function getAddress(idAddress) {
-  return _fetch(`${API_BAN_URL}/${idAddress}`)
+  return _fetch(`${API_BAN_URL}/lookup/${idAddress}`)
 }

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -27,5 +27,5 @@ export function getAddress(idAddress) {
 }
 
 export function getStats() {
-  return _fetch(`${API_BAN_URL}/stats`)
+  return _fetch(`${API_BAN_URL}/ban/stats`)
 }

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -25,3 +25,7 @@ export async function _fetch(url) {
 export function getAddress(idAddress) {
   return _fetch(`${API_BAN_URL}/lookup/${idAddress}`)
 }
+
+export function getStats() {
+  return _fetch(`${API_BAN_URL}/stats`)
+}

--- a/lib/bal/api.js
+++ b/lib/bal/api.js
@@ -1,5 +1,4 @@
 export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://backend.adresse.data.gouv.fr'
-export const BACKEND_URL_STATS = process.env.NEXT_PUBLIC_API_BAL_STATS_URL || 'https://plateforme.adresse.data.gouv.fr/ban/stats'
 
 async function _fetch(url, method, body) {
   const options = {
@@ -36,10 +35,6 @@ export async function getDatasets() {
 export async function getDataset(id) {
   const url = `${BACKEND_URL}/datasets/${id}`
   return _fetch(url, 'GET')
-}
-
-export async function getBALStats() {
-  return _fetch(BACKEND_URL_STATS, 'GET')
 }
 
 export async function getReport(id) {

--- a/lib/bal/api.js
+++ b/lib/bal/api.js
@@ -38,10 +38,6 @@ export async function getDataset(id) {
   return _fetch(url, 'GET')
 }
 
-export async function getStats() {
-  return _fetch(`${BACKEND_URL}/datasets/stats`, 'GET')
-}
-
 export async function getBALStats() {
   return _fetch(BACKEND_URL_STATS, 'GET')
 }

--- a/pages/bases-locales.js
+++ b/pages/bases-locales.js
@@ -4,7 +4,8 @@ import {Database} from 'react-feather'
 
 import Page from '@/layouts/main'
 
-import {getDatasets, getBALStats} from '@/lib/bal/api'
+import {getDatasets} from '@/lib/bal/api'
+import {getStats} from '@/lib/api-ban'
 import withErrors from '@/components/hoc/with-errors'
 
 import Head from '@/components/head'
@@ -34,7 +35,7 @@ class BasesAdressesLocalesPage extends React.Component {
 BasesAdressesLocalesPage.getInitialProps = async () => {
   return {
     datasets: await getDatasets(),
-    stats: await getBALStats()
+    stats: await getStats()
   }
 }
 

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -5,7 +5,8 @@ import Head from '@/components/head'
 import theme from '@/styles/theme'
 import {Database} from 'react-feather'
 
-import {getDatasets, getBALStats} from '@/lib/bal/api'
+import {getDatasets} from '@/lib/bal/api'
+import {getStats} from '@/lib/api-ban'
 import {numFormater} from '@/lib/format-numbers'
 
 import MapLibre from '@/components/maplibre'
@@ -181,7 +182,7 @@ function EtatDeploiement({datasets, stats}) {
 EtatDeploiement.getInitialProps = async () => {
   return {
     datasets: await getDatasets(),
-    stats: await getBALStats(),
+    stats: await getStats(),
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 
-import {getBALStats} from '@/lib/bal/api'
+import {getStats} from '@/lib/api-ban'
 
 import theme from '@/styles/theme'
 import Page from '@/layouts/main'
@@ -116,7 +116,7 @@ function Home({stats}) {
 }
 
 Home.getInitialProps = async () => {
-  const stats = await getBALStats()
+  const stats = await getStats()
   return {
     stats
   }


### PR DESCRIPTION
L'ancienne API `/stats` n'était plus utilisée (service `backend`) mais le code toujours présent.
J'ai aussi déplacé le nouvel appel `/stats` sur `plateforme.adresse.data.gouv.fr` au bon endroit puisque ce n'est pas un appel BAL.