### PR TITLE
Optimisation des appels au listing des BAL

### DIFF
--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -16,15 +16,7 @@ import SectionText from '../section-text'
 import MapBalSection from '../map-bal-section'
 
 const BasesLocales = React.memo(({datasets, stats}) => {
-  const [balSamples, setBalSamples] = useState([])
   const shufflePartners = shuffle(allPartners).slice(0, 3)
-
-  useEffect(() => {
-    if (datasets) {
-      const shuffleBalSamples = () => shuffle(datasets.filter(d => d.model === 'bal-aitf')).slice(0, 3)
-      setBalSamples(shuffleBalSamples)
-    }
-  }, [datasets])
 
   return (
     <div>
@@ -110,7 +102,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
 
       <Section title='Quelques Bases Adresses Locales déjà publiées' background='grey'>
         <div className='bal-grid'>
-          {balSamples.map(dataset => (
+          {datasets.map(dataset => (
             <BaseAdresseLocale key={dataset.id} dataset={dataset} />
           ))}
         </div>

--- a/lib/bal/api.js
+++ b/lib/bal/api.js
@@ -28,8 +28,18 @@ async function _fetch(url, method, body) {
   throw new Error('Une erreur est survenue')
 }
 
-export async function getDatasets() {
-  return _fetch(`${BACKEND_URL}/datasets`, 'GET')
+export async function getDatasets(options = {}) {
+  const queryOptions = []
+
+  if (options.sample) {
+    queryOptions.push(`sample=${options.sample}`)
+  }
+
+  if (options.noContour) {
+    queryOptions.push('noContour=1')
+  }
+
+  return _fetch(`${BACKEND_URL}/datasets?${queryOptions.join('&')}`, 'GET')
 }
 
 export async function getDataset(id) {

--- a/pages/bases-locales.js
+++ b/pages/bases-locales.js
@@ -34,7 +34,7 @@ class BasesAdressesLocalesPage extends React.Component {
 
 BasesAdressesLocalesPage.getInitialProps = async () => {
   return {
-    datasets: await getDatasets(),
+    datasets: await getDatasets({noContour: true, sample: 3}),
     stats: await getStats()
   }
 }

--- a/pages/bases-locales/datasets.js
+++ b/pages/bases-locales/datasets.js
@@ -32,7 +32,7 @@ class Datasets extends React.Component {
 
 Datasets.getInitialProps = async () => {
   return {
-    datasets: await getDatasets()
+    datasets: await getDatasets({noContour: true})
   }
 }
 


### PR DESCRIPTION
Utilise les nouveaux paramètres `noContour` et `sample` pour ne retourner de l'API que ce qui est nécessaire à l'affiche.
Boost conséquent des performances sur les deux pages concernées.