### PR TITLE
Corrige la taille des cartes après la modification de la taille du header

### DIFF
--- a/components/doughnut-counter.js
+++ b/components/doughnut-counter.js
@@ -13,7 +13,7 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
       <div className='value-down'>{valueDown}</div>
       <style jsx>{`
         .donut {
-          width: 50%;
+          max-width: 35%;
           margin: auto;
         }
 

--- a/layouts/base-adresse-nationale.js
+++ b/layouts/base-adresse-nationale.js
@@ -75,24 +75,16 @@ export function Mobile({address, bbox, handleSelect, hash}) {
 
       <style jsx>{`
         .ban-container {
-          position: absolute;
-          top: 77px;
+          position: relative;
           bottom: 0;
           display: flex;
           flex-direction: column;
           width: 100%;
-          height: calc(${viewHeight} - 77px); // Max heigth available - header height
-        }
-
-        @media (max-width: ${theme.breakPoints.laptop}) {
-          .ban-container {
-            top: 67px;
-          }
         }
 
         .mobile-container {
           width: 100%;
-          height: calc(${viewHeight} - 190px); // Max heigth available - sum of header, searchbar and layout selector heights
+          height: calc(${viewHeight} - 202px); // Max heigth available - sum of header, searchbar and layout selector heights
         }
 
         .show {
@@ -108,7 +100,7 @@ export function Mobile({address, bbox, handleSelect, hash}) {
           flex-direction: column;
           width: 100%;
           height: 100%;
-          padding: 1em 0.5em;
+          padding: 0 0.5em;
           background-color: #fff;
         }
 
@@ -150,7 +142,7 @@ export function Desktop({address, bbox, handleSelect, hash}) {
       <style jsx>{`
         .ban-container {
           display: flex;
-          height: calc(100vh - 77px);
+          height: calc(100vh - 107px);
         }
 
         .sidebar {


### PR DESCRIPTION
Depuis la mise à jour du logo dans le header, celui ci étant plus grand que le précédent logo, la cartes de la BAN et du déploiement ont été décalées et débordent légèrement dans le bas de la fenêtre.
Cette PR propose d'ajuster les valeurs de taille pour éviter d'avoir un débordement et conserver un comportement sans barre de défilement.

### Avant : 

![image](https://user-images.githubusercontent.com/56537238/144057530-842fa2cc-7f8a-43e0-b7a2-a6049ed66187.png)

![image](https://user-images.githubusercontent.com/56537238/144057714-9088e8d1-7618-4352-a9a7-ee304f72b078.png)


### Après : 

![image](https://user-images.githubusercontent.com/56537238/144057611-e6fc4f0d-ed21-431f-acde-50a6aed1aed1.png)

![image](https://user-images.githubusercontent.com/56537238/144057757-3c8704f3-d1a0-4feb-bd91-546f92a653b9.png)
