### PR TITLE
Ajout du composant de recherche du contact d’une commune à la page contribuer

### DIFF
--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -4,6 +4,7 @@ import Page from '@/layouts/main'
 import theme from '@/styles/theme'
 import Head from '@/components/head'
 import Section from '@/components/section'
+import SearchCommuneContact from '@/components/search-commune-contact'
 import ButtonLink from '@/components/button-link'
 import SectionText from '@/components/section-text'
 
@@ -35,6 +36,7 @@ function Contribuer() {
         <SectionText >
           <p>Il n’existe pas encore de <strong>dispositif national</strong> permettant aux citoyens de contribuer directement, mais de nombreux guichets de signalement existent à l’échelon local. Ce site a vocation à les référencer à moyen terme.</p>
           <p>En attendant, <strong>contactez votre mairie ou votre EPCI</strong>, et parlez-leur de nous !</p>
+          <SearchCommuneContact />
         </SectionText>
       </Section>
 


### PR DESCRIPTION
Certains utilisateurs contactent le support pour des problèmes d’adresse. 

Cette PR propose d’ajouter le composant permettant la recherche du contact d’une commune pour que ces utilisateurs se dirigent directement vers leur mairie.

![image](https://user-images.githubusercontent.com/56537238/144069701-0fdb2948-0798-40f3-9a36-67e2e3a21388.png)
 

