### PR TITLE
Corrige l’affichage du déploiement des Bases Adresses Locales sur la page d'accueil

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -121,14 +121,14 @@ function Home({stats}) {
 Home.getInitialProps = async () => {
   try {
     return {
-      stat: await getStats()
+      stats: await getStats()
     }
   } catch (error) {
     console.log('Erreur lors de la récupération des stats BAN:', error)
   }
 
   return {
-    stat: null
+    stats: null
   }
 }
 


### PR DESCRIPTION
Corrige une faute de frappe dans le `getInitialProps` de la page d’accueil empéchant l’affichage du composant `MapBalSection`