### PR TITLE
Ajout d’une page pour naviguer dans les données FANTOIR

### DIFF
--- a/components/fantoir/body-list-fantoir.js
+++ b/components/fantoir/body-list-fantoir.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types'
+import {uniqueId} from 'lodash'
+
+import theme from '@/styles/theme'
+
+function BodyListFantoir({contents, onSelect, isCanceled}) {
+  return (
+    <div>
+      <div onClick={onSelect}>
+        <div className={isCanceled ? 'line canceled' : 'line'}>
+          {contents.map(item => (
+            <div key={uniqueId('_infos')} className='infos'>{item}</div>
+          ))}
+        </div>
+      </div>
+      <style jsx>{`
+        .line {
+          display: flex;
+          padding: .5em;
+          border-bottom: 1px solid ${theme.border};
+          border-left: 1px solid ${theme.border};
+          border-right: 1px solid ${theme.border};
+          border-top: 1px solid rgba(0, 0, 0, 0);
+        }
+
+        .line:hover {
+          cursor: pointer;
+          color: #000;
+          background-color: ${theme.colors.lighterGrey};
+        }
+
+        .infos {
+          flex: 1;
+          text-align: center;
+        }
+
+        .canceled {
+          color: #000;
+          background-color: ${theme.errorBg};
+        }
+      `}</style>
+    </div>
+  )
+}
+
+BodyListFantoir.defaultProps = {
+  isCanceled: false
+}
+
+BodyListFantoir.propTypes = {
+  contents: PropTypes.array.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  isCanceled: PropTypes.bool
+}
+
+export default BodyListFantoir

--- a/components/fantoir/header-list-fantoir.js
+++ b/components/fantoir/header-list-fantoir.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types'
+
+import theme from '@/styles/theme'
+
+function HeaderListFantoir({headers, hasToggleContent}) {
+  return (
+    <div className='title'>
+      {headers.map(header => (
+        <div key={header} className='infos'>{header}</div>
+      ))}
+      {hasToggleContent && (
+        <div className='margin' />
+      )}
+      <style jsx>{`
+        .title {
+          background-color: ${theme.primary};
+          color: #FFF;
+          display: flex;
+          padding: .5em;
+          border-top: 1px solid ${theme.border};
+          border-left: 1px solid ${theme.border};
+          border-right: 1px solid ${theme.border};
+        }
+
+        .infos {
+          flex: 1;
+          text-align: center;
+        }
+
+        .margin {
+          width: 35px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+HeaderListFantoir.defaultProps = {
+  hasToggleContent: false
+}
+
+HeaderListFantoir.propTypes = {
+  headers: PropTypes.array.isRequired,
+  hasToggleContent: PropTypes.bool
+}
+
+export default HeaderListFantoir

--- a/components/fantoir/voie-information.js
+++ b/components/fantoir/voie-information.js
@@ -1,0 +1,110 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+import {ChevronUp, ChevronDown} from 'react-feather'
+
+import theme from '@/styles/theme'
+
+function VoieInformation({voie}) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className='line-container'>
+      <div className={voie?.dateAnnulation ? 'line title canceled' : 'line title'} onClick={() => setIsOpen(!isOpen)}>
+        <div className='infos'>{voie.libelleVoieComplet}</div>
+        <div className='infos'>{voie.typeVoie}</div>
+        <div className='infos'>{voie.codeRivoli}</div>
+        <div>
+          {isOpen ? <ChevronUp size={35} /> : <ChevronDown size={35} />}
+        </div>
+      </div>
+      {isOpen && (
+        <div className='voie-tags'>
+          <div>Code Rivoli : <span>{voie.codeRivoli}</span></div>
+          <div>Clé Rivoli : <span>{voie.cleRivoli}</span></div>
+          <div>Date d’ajout : <span>{voie.dateAjout}</span></div>
+          {voie.natureVoie && (
+            <div>Nature de la voie : <span>{voie.natureVoie}</span></div>
+          )}
+          <div>Voie privée : <span>{voie.voiePrivee ? 'oui' : 'non'}</span></div>
+          {voie?.dateAnnulation && (
+            <div className='canceled'>Date d’annulation : <span>{voie.dateAnnulation}</span></div>
+          )}
+        </div>
+      )}
+      <style jsx>{`
+        .title {
+          color: ${isOpen ? '#FFF' : '#000'};
+          background-color: ${isOpen ? theme.primary : ''};
+          display: flex;
+          padding: .5em;
+        }
+
+        .line {
+          display: flex;
+          padding: .5em;
+          border-left: 1px solid ${theme.border};
+          border-right: 1px solid ${theme.border};
+          border-bottom: 1px solid ${theme.border};
+        }
+
+        .line:hover {
+          cursor: pointer;
+          color: #000;
+          background-color: ${theme.colors.lighterGrey};
+        }
+
+        .infos {
+          flex: 1;
+          text-align: center;
+          padding: .5em;
+          margin: auto;
+        }
+
+        .voie-tags {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+          padding: .5em;
+          border-left: 1px solid ${theme.border};
+          border-right: 1px solid ${theme.border};
+          border-bottom: 1px solid ${theme.border};
+        }
+
+        .voie-tags div {
+          display: grid;
+          justify-items: center;
+          padding: .5em;
+          margin: .5em;
+          gap: .5em;
+          border: 1px solid ${theme.colors.lighterGrey};
+          border-radius: .5em;
+        }
+
+        .canceled {
+          color: #000;
+          background-color: ${theme.errorBg};
+        }
+
+        .voie-tags .canceled {
+          border-radius: .5em;
+        }
+
+        span {
+          display: inline-flex;
+          border-radius: 3.75em;
+          background-color: ${theme.infoBg};
+          color: ${theme.infoBorder};
+          font-size: .75em;
+          line-height: 1;
+          padding: .4em 1.2em;
+          margin: .1em .5em
+        }
+      `}</style>
+    </div>
+  )
+}
+
+VoieInformation.propTypes = {
+  voie: PropTypes.object.isRequired
+}
+
+export default VoieInformation

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -29,3 +29,15 @@ export function getAddress(idAddress) {
 export function getStats() {
   return _fetch(`${API_BAN_URL}/ban/stats`)
 }
+
+export function getFantoir(departementCode) {
+  return _fetch(`${API_BAN_URL}/api-fantoir/departements/${departementCode}/communes`)
+}
+
+export function getVoiesFantoir(communeCode) {
+  return _fetch(`${API_BAN_URL}/api-fantoir/communes/${communeCode}/voies`)
+}
+
+export function getVoieFantoir(voieCode) {
+  return _fetch(`${API_BAN_URL}/api-fantoir/voies/${voieCode}`)
+}

--- a/lib/api-geo.js
+++ b/lib/api-geo.js
@@ -62,3 +62,11 @@ export function getByCode({postalCode}) {
 
   return _fetch(url)
 }
+
+export function getDepartements() {
+  return _fetch(`${API_GEO_URL}/departements`)
+}
+
+export function getDepartementByCode(code) {
+  return _fetch(`${API_GEO_URL}/departements/${code}`)
+}

--- a/pages/fantoir/departement/[departement]/commune/[commune]/index.js
+++ b/pages/fantoir/departement/[departement]/commune/[commune]/index.js
@@ -1,0 +1,119 @@
+import {useState, useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {sortBy, debounce} from 'lodash'
+
+import {Database} from 'react-feather'
+
+import {getFantoir, getVoiesFantoir} from '@/lib/api-ban'
+
+import theme from '@/styles/theme'
+
+import Page from '@/layouts/main'
+import Head from '@/components/head'
+import withErrors from '@/components/hoc/with-errors'
+import Section from '@/components/section'
+import SearchBar from '@/components/search-bar'
+import HeaderListFantoir from '@/components/fantoir/header-list-fantoir'
+import VoieInformation from '@/components/fantoir/voie-information'
+
+const voieHeader = ['Nom de la  voie', 'type', 'Code Fantoir']
+
+function VoiesList({voies, nomCommune}) {
+  const sortedVoies = useMemo(() => {
+    return sortBy(voies, ['id'])
+  }, [voies])
+
+  const [results, setResults] = useState(sortedVoies)
+
+  const searchVoies = debounce(value => {
+    const foundVoie = sortedVoies.filter(v => v.libelleVoieComplet.toLowerCase().includes(value.toLowerCase()))
+
+    setResults(foundVoie)
+  }, 300)
+
+  return (
+    <Page title='Fantoir'>
+      <Head title={`Fantoir : ${nomCommune}`} icon={<Database size={56} />} />
+      <Section title={`Liste des voies de ${nomCommune}`}>
+        <div className='search'>
+          <SearchBar
+            placeholder='Chercher une voie'
+            onChange={e => searchVoies(e.target.value)}
+          />
+        </div>
+
+        <HeaderListFantoir
+          headers={voieHeader}
+          hasToggleContent
+        />
+
+        {results.length > 0 ? (
+          results.map(voie => (
+            <VoieInformation
+              key={voie.id}
+              voie={voie}
+            />
+          ))
+        ) : (
+          <div className='no-result'>
+            <i>Aucun résultat</i>
+          </div>
+        )}
+      </Section>
+      <style jsx>{`
+        .margin {
+          width: 45px;
+        }
+
+        .title {
+          background-color: ${theme.primary};
+          color: #FFF;
+          display: flex;
+          border-top: 1px solid ${theme.border};
+          border-left: 1px solid ${theme.border};
+          border-right: 1px solid ${theme.border};
+        }
+
+        .name {
+          flex: 2;
+          margin: auto;
+          padding: .5em;
+        }
+
+        .infos {
+          flex: 1;
+          margin: auto;
+          padding: .5em;
+        }
+
+        .search {
+          padding: 1em 0;
+        }
+
+        .no-result {
+          padding: 1em;
+          font-size: 1.2em;
+          text-align: center;
+        }
+      `}</style>
+    </Page>
+  )
+}
+
+VoiesList.getInitialProps = async ({query}) => {
+  const voies = await getVoiesFantoir(query.commune)
+  const communes = await getFantoir(query.departement)
+  const {nomCommune} = communes.find(c => c.codeCommune === query.commune)
+
+  return {
+    voies,
+    nomCommune
+  }
+}
+
+VoiesList.propTypes = {
+  voies: PropTypes.array.isRequired,
+  nomCommune: PropTypes.string.isRequired
+}
+
+export default withErrors(VoiesList)

--- a/pages/fantoir/departement/[departement]/index.js
+++ b/pages/fantoir/departement/[departement]/index.js
@@ -1,0 +1,104 @@
+import {useState, useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
+import {sortBy, debounce, pick} from 'lodash'
+
+import {Database} from 'react-feather'
+
+import {getFantoir} from '@/lib/api-ban'
+import {getDepartementByCode} from '@/lib/api-geo'
+
+import Page from '@/layouts/main'
+import withErrors from '@/components/hoc/with-errors'
+import Head from '@/components/head'
+import Section from '@/components/section'
+import SearchBar from '@/components/search-bar'
+import HeaderListFantoir from '@/components/fantoir/header-list-fantoir'
+import BodyListFantoir from '@/components/fantoir/body-list-fantoir'
+
+const communeHeader = ['Commune', 'Code INSEE', 'Annulée ?']
+const communeInfos = ['nomCommune', 'codeCommune', 'dateAnnulation']
+
+function CommunesList({communes, nomDepartement}) {
+  const router = useRouter()
+  const sortedCommunes = useMemo(() => {
+    return sortBy(communes, ['id'])
+  }, [communes])
+
+  const [results, setResults] = useState(sortedCommunes)
+
+  const searchCommunes = debounce(value => {
+    const foundCommunes = sortedCommunes.filter(c => c.nomCommune.toLowerCase().includes(value.toLowerCase()))
+
+    setResults(foundCommunes)
+  }, 300)
+
+  return (
+    <Page title='Fantoir'>
+      <Head title={`Fantoir : ${nomDepartement}`} icon={<Database size={56} />} />
+      <Section title={`Liste des communes de ${nomDepartement}`}>
+        <div className='search'>
+          <SearchBar
+            placeholder='Chercher une commune'
+            onChange={e => searchCommunes(e.target.value)}
+          />
+        </div>
+
+        <HeaderListFantoir
+          headers={communeHeader}
+        />
+
+        {results.length > 0 ? (
+          results.map(commune => {
+            const formatedCommune = pick(commune, communeInfos)
+
+            if (!formatedCommune.dateAnnulation) {
+              formatedCommune.dateAnnulation = 'non'
+            }
+
+            return (
+              <BodyListFantoir
+                key={commune.id}
+                contents={Object.values(formatedCommune)}
+                isCanceled={formatedCommune.dateAnnulation && formatedCommune.dateAnnulation !== 'non'}
+                onSelect={() => router.push(`/fantoir/departement/${commune.codeDepartement}/commune/${commune.codeCommune}`)}
+              />
+            )
+          })
+        ) : (
+          <div className='no-result'>
+            <i>Aucun résultat</i>
+          </div>
+        )}
+      </Section>
+      <style jsx>{`
+        .search {
+          padding: 1em 0;
+        }
+
+        .no-result {
+          padding: 1em;
+          font-size: 1.2em;
+          text-align: center;
+        }
+      `}</style>
+    </Page>
+  )
+}
+
+CommunesList.getInitialProps = async ({query}) => {
+  const communes = await getFantoir(query.departement)
+  const departementInfos = await getDepartementByCode(query.departement)
+
+  return {
+    communes,
+    nomDepartement: departementInfos.nom
+  }
+}
+
+CommunesList.propTypes = {
+  communes: PropTypes.array.isRequired,
+  nomDepartement: PropTypes.string.isRequired
+}
+
+export default withErrors(CommunesList)

--- a/pages/fantoir/index.js
+++ b/pages/fantoir/index.js
@@ -1,0 +1,93 @@
+import {useState, useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
+import {sortBy, debounce, pick} from 'lodash'
+
+import {getDepartements} from '@/lib/api-geo'
+
+import {Database} from 'react-feather'
+
+import Page from '@/layouts/main'
+import withErrors from '@/components/hoc/with-errors'
+import Head from '@/components/head'
+import Section from '@/components/section'
+import SearchBar from '@/components/search-bar'
+import HeaderListFantoir from '@/components/fantoir/header-list-fantoir'
+import BodyListFantoir from '@/components/fantoir/body-list-fantoir'
+
+const title = 'Fantoir'
+const departementHeader = ['Département', 'Code département']
+const departementInfos = ['nom', 'code']
+
+function Fantoir({departements}) {
+  const router = useRouter()
+  const sortedDepartements = useMemo(() => {
+    return sortBy(departements, ['code'])
+  }, [departements])
+
+  const [results, setResults] = useState(sortedDepartements)
+
+  const searchDepartement = debounce(value => {
+    const foundDepartement = sortedDepartements.filter(c => c.nom.toLowerCase().includes(value.toLowerCase()))
+
+    setResults(foundDepartement)
+  }, 300)
+
+  return (
+    <Page title={title}>
+      <Head title={title} icon={<Database size={56} />} />
+      <Section title='Liste des départements'>
+        <div className='search'>
+          <SearchBar
+            placeholder='Chercher un département'
+            onChange={e => searchDepartement(e.target.value)}
+          />
+        </div>
+
+        <HeaderListFantoir
+          headers={departementHeader}
+        />
+
+        {results.length > 0 ? (
+          results.map(departement => {
+            const formatedDepartement = pick(departement, departementInfos)
+
+            return (
+              <BodyListFantoir
+                key={departement.code}
+                contents={Object.values(formatedDepartement)}
+                onSelect={() => router.push(`/fantoir/departement/${departement.code}`)}
+              />
+            )
+          })
+        ) : (
+          <div className='no-result'>
+            <i>Aucun résultat</i>
+          </div>
+        )}
+      </Section>
+      <style jsx>{`
+        .search {
+          padding: 1em 0;
+        }
+
+        .no-result {
+          padding: 1em;
+          font-size: 1.2em;
+          text-align: center;
+        }
+      `}</style>
+    </Page>
+  )
+}
+
+Fantoir.getInitialProps = async () => {
+  const departements = await getDepartements()
+  return {departements}
+}
+
+Fantoir.propTypes = {
+  departements: PropTypes.array.isRequired
+}
+
+export default withErrors(Fantoir)

--- a/pages/tools.js
+++ b/pages/tools.js
@@ -1,5 +1,5 @@
 import Page from '@/layouts/main'
-import {Map, FileText, Terminal, UserPlus} from 'react-feather'
+import {Map, FileText, Terminal, UserPlus, Archive} from 'react-feather'
 
 import ToolsIcon from '@/components/icons/tools'
 import Head from '@/components/head'
@@ -32,6 +32,12 @@ function ToolsPage() {
       description: 'Découvrez l‘API Adresse, l‘API Base Adresse Locale et l‘API de dépôt...',
       href: '/api-doc',
       icon: <Terminal />
+    },
+    {
+      title: 'L’explorateur FANTOIR',
+      description: 'Naviguez dans les données FANTOIR',
+      href: '/fantoir',
+      icon: <Archive />
     }
   ]
 


### PR DESCRIPTION
Cette PR propose l'ajout d’une page permettant de naviguer dans les données FANTOIR.

Captures : 

![image](https://user-images.githubusercontent.com/56537238/148076508-61fa1593-daf5-4ba8-ad1d-f98defccbcc5.png)

![image](https://user-images.githubusercontent.com/56537238/148076634-d9a112db-1db0-4ed8-9197-ba8f065755f3.png)
