### PR TITLE
Adapter l'affichage des statistiques du déploiement des BAL aux grands écrans

### DIFF
--- a/components/doughnut-counter.js
+++ b/components/doughnut-counter.js
@@ -20,14 +20,14 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
         }
 
         .stat {
-          height: 300px;
-          display: flex;
-          flex-direction: column;
+          display: grid;
+          grid-template-rows: 24px 45px 1fr 70px;
           margin: 1em;
-          padding: .5em;
+          padding: 1em;
           border: 1px solid lightgrey;
           border-radius: 5px;
-          box-shadow: 1px 1px 5px lightgrey;
+          margin-top: 0.5em;
+          gap: 1em;
         }
 
         .title {
@@ -42,14 +42,10 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
 
         .value-down {
           padding: .5em 0;
-          margin-top: .5em;
+          align-self: flex-start;
         }
 
-        @media (max-width: ${theme.breakPoints.desktop}) {
-            .stat {
-              padding: 1em;
-            }
-          }
+
       `}</style>
     </div>
   )

--- a/components/doughnut-counter.js
+++ b/components/doughnut-counter.js
@@ -18,14 +18,13 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
         }
 
         .stat {
-          display: grid;
-          grid-template-rows: 24px 45px 1fr 70px;
-          margin: 1em;
-          padding: 1em;
+          max-height: 300px;
+          display: flex;
+          flex-direction: column;
+          padding: .5em;
           border: 1px solid lightgrey;
           border-radius: 5px;
-          margin-top: 0.5em;
-          gap: 1em;
+          gap: 10px;
         }
 
         .title {
@@ -34,13 +33,7 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
         }
 
         .value-up {
-          font-size: 1.5em;
-          padding: .5em;
-        }
-
-        .value-down {
-          padding: .5em 0;
-          align-self: flex-start;
+          font-size: 1.3em;
         }
       `}</style>
     </div>

--- a/components/doughnut-counter.js
+++ b/components/doughnut-counter.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
-
 import {Doughnut} from 'react-chartjs-2'
+
+import theme from '@/styles/theme'
 
 function DoughnutCounter({title, valueUp, valueDown, data, options}) {
   return (
@@ -11,6 +12,7 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
         <Doughnut data={data} options={options} />
       </div>
       <div className='value-down'>{valueDown}</div>
+
       <style jsx>{`
         .donut {
           max-width: 35%;
@@ -18,11 +20,10 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
         }
 
         .stat {
-          align-self: stretch;
+          height: 300px;
           display: flex;
           flex-direction: column;
           margin: 1em;
-          justify-content: space-around;
           padding: .5em;
           border: 1px solid lightgrey;
           border-radius: 5px;
@@ -43,6 +44,12 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
           padding: .5em 0;
           margin-top: .5em;
         }
+
+        @media (max-width: ${theme.breakPoints.desktop}) {
+            .stat {
+              padding: 1em;
+            }
+          }
       `}</style>
     </div>
   )

--- a/components/doughnut-counter.js
+++ b/components/doughnut-counter.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types'
 import {Doughnut} from 'react-chartjs-2'
 
-import theme from '@/styles/theme'
-
 function DoughnutCounter({title, valueUp, valueDown, data, options}) {
   return (
     <div className='stat'>
@@ -44,8 +42,6 @@ function DoughnutCounter({title, valueUp, valueDown, data, options}) {
           padding: .5em 0;
           align-self: flex-start;
         }
-
-
       `}</style>
     </div>
   )

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -152,7 +152,7 @@ function EtatDeploiement({datasets, stats}) {
             height: fit-content;
             flex: 1;
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            grid-template-columns: repeat( auto-fit, minmax(250px, 1fr) );
           }
 
           .bal-cover-map-container {

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -149,9 +149,10 @@ function EtatDeploiement({datasets, stats}) {
           }
 
           .stats {
+            height: fit-content;
             flex: 1;
             display: grid;
-            grid-template-columns: repeat( auto-fit, minmax(250px, 1fr) );
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
           }
 
           .bal-cover-map-container {
@@ -167,10 +168,6 @@ function EtatDeploiement({datasets, stats}) {
           @media (max-width: ${theme.breakPoints.desktop}) {
             .map-stats-container {
               flex-direction: column;
-            }
-
-            .stat {
-              padding: 1em;
             }
           }
           `}</style>

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -153,6 +153,8 @@ function EtatDeploiement({datasets, stats}) {
             flex: 1;
             display: grid;
             grid-template-columns: repeat( auto-fit, minmax(250px, 1fr) );
+            gap: 1em;
+            padding: 1em;
           }
 
           .bal-cover-map-container {


### PR DESCRIPTION
Close #982

### AVANT
![147911439-f293102d-e594-4c2d-9b5](https://user-images.githubusercontent.com/66621960/148221991-6d77d652-343e-4183-a381-3721c19311de.jpg)


### APRÈS
![Capture d’écran 2022-01-05 à 13 48 42](https://user-images.githubusercontent.com/66621960/148221871-a2fbee8d-bf0d-499c-b0ca-eae0e39fc348.png)
