### PR TITLE
Corriger l'erreur de DOM nesting

### DIFF
--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -48,13 +48,13 @@ function DonneesNatioales() {
       <Section title='Comment est construite la Base Adresse Nationale ?' background='color'>
 
         <SectionText color='secondary'>
-          <p>
+          <div>
             La Base Adresse Nationale est <b>constituée commune par commune</b>, sur le principe suivant :
             <ul>
               <li>si la commune dispose d’une <Link href='/bases-locales'><a>Base Adresse Locale</a></Link>, ce sont ces adresses qui sont incluses dans la Base Adresse Nationale ;</li>
               <li>dans le cas contraire, la liste des adresses est générée par défaut à partir des <b>meilleures sources disponibles</b> (DGFiP, IGN, La Poste, ARCEP, Guichet Adresse, SDIS…).</li>
             </ul>
-          </p>
+          </div>
         </SectionText>
         <div className='adjust-img'>
           <Image width={1000} height={386} src='/images/donnees-nationales/schema-donnees-ban.svg' alt='Schéma représentant les sources de données présentes dans la Base Adresse Nationale' />


### PR DESCRIPTION
Close #991

Remplacer la balise parente `<p>` de la liste par une `<div>`

Résout l'erreur : `Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>.`