### PR TITLE
Suppression des EPCI dans la section de contact mairie

### DIFF
--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -35,7 +35,7 @@ function Contribuer() {
       <Section title='En tant que citoyen' background='grey'>
         <SectionText >
           <p>Il n’existe pas encore de <strong>dispositif national</strong> permettant aux citoyens de contribuer directement, mais de nombreux guichets de signalement existent à l’échelon local. Ce site a vocation à les référencer à moyen terme.</p>
-          <p>En attendant, <strong>contactez votre mairie ou votre EPCI</strong>, et parlez-leur de nous !</p>
+          <p>En attendant, <strong>contactez votre mairie</strong>, et parlez-leur de nous !</p>
         </SectionText>
         <SearchCommuneContact />
       </Section>


### PR DESCRIPTION
`En attendant, contactez votre mairie ou votre EPCI, et parlez-leur de nous !`
devient : 
`En attendant, contactez votre mairie, et parlez-leur de nous !`

![Capture d’écran 2022-01-18 à 09 46 27](https://user-images.githubusercontent.com/66621960/149903816-0aed0e09-8a93-4003-8be2-21d669c05bc8.png)
