### PR TITLE
Suppression affichage du nom du svg de la frise lors d'un hover

### DIFF
--- a/components/frise.js
+++ b/components/frise.js
@@ -150,7 +150,6 @@ function Frise() {
   return (
     <div className='frise'>
       <svg id='background' viewBox='0 0 1020 264' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink'>
-        <title>Group 5</title>
         <defs>
           <polygon id='path-1' points='13.8916531 -0.0970873786 64.4268644 -0.0970873786 78.1592587 32.9029126 0.159258749 32.9029126' />
           <polygon id='path-3' points='13.8712116 -0.0970873786 64.4064229 -0.0970873786 78.1388172 32.9029126 0.138817228 32.9029126' />


### PR DESCRIPTION
Close #1006

### AVANT
![Capture d’écran 2022-01-20 à 10 29 10](https://user-images.githubusercontent.com/66621960/150316117-60fda175-5666-4cf8-9a9e-fa38adbf747b.png)

### APRÈS
![Capture d’écran 2022-01-20 à 10 58 17](https://user-images.githubusercontent.com/66621960/150316236-277e1746-1b82-48d1-bbf1-07f56496affd.png)

