### PR TITLE
Mise à jour du validateur BAL

### DIFF
--- a/components/bases-locales/publication/manage-file.js
+++ b/components/bases-locales/publication/manage-file.js
@@ -17,7 +17,7 @@ const ManageFile = React.memo(({error, handleError, handleFile}) => {
 
   const parseFile = useCallback(async file => {
     try {
-      const report = await prevalidate(file)
+      const report = await prevalidate(file, {relaxFieldsDetection: true})
       const communes = uniq(report.rows.map(r => r.parsedValues.commune_insee || r.additionalValues.cle_interop.codeCommune))
 
       if (communes.length !== 1) {

--- a/components/bases-locales/validator/index.js
+++ b/components/bases-locales/validator/index.js
@@ -24,7 +24,7 @@ function BALValidator() {
   const parseFile = async file => {
     setInProgress(true)
     try {
-      const report = await prevalidate(file)
+      const report = await prevalidate(file, {relaxFieldsDetection: true})
       if (report.parseOk) {
         setReport(report)
       } else {

--- a/components/bases-locales/validator/report/summary/index.js
+++ b/components/bases-locales/validator/report/summary/index.js
@@ -56,13 +56,13 @@ function Summary({rows, fields}) {
   return (
     <div>
       {rowsWithIssuesCount === 0 ? (
-        <h4>Aucune ligne avec anomalies trouvée <span className='valid'><Check /></span></h4>
+        <h4>Aucune ligne comprenant des alertes n’a été trouvée <span className='valid'><Check /></span></h4>
       ) : (
         <div>
           {rowsWithIssuesCount > 1 ? (
-            <h4>{rowsWithIssuesCount} lignes avec anomalies trouvées</h4>
+            <h4>{rowsWithIssuesCount} lignes comprenant des alertes</h4>
           ) : (
-            <h4>{rowsWithIssuesCount} ligne avec anomalies trouvée</h4>
+            <h4>{rowsWithIssuesCount} ligne comprenant des alertes</h4>
           )}
         </div>
       )}

--- a/components/bases-locales/validator/report/summary/index.js
+++ b/components/bases-locales/validator/report/summary/index.js
@@ -11,6 +11,7 @@ function Summary({rows, fields}) {
   const rowsWithIssuesCount = rows.filter(row => row.errors && row.errors.length > 0).length
   const errorsGroups = {}
   const warningsGroups = {}
+  const infosGroups = {}
 
   rows.forEach(row => {
     row.errors.forEach(({code, level}) => {
@@ -29,11 +30,20 @@ function Summary({rows, fields}) {
 
         errorsGroups[code].push(row)
       }
+
+      if (level === 'I') {
+        if (!infosGroups[code]) {
+          infosGroups[code] = []
+        }
+
+        infosGroups[code].push(row)
+      }
     })
   })
 
   const errorsCount = Object.keys(errorsGroups).length
   const warningsCount = Object.keys(warningsGroups).length
+  const infosCount = Object.keys(infosGroups).length
 
   const unknowFields = []
 
@@ -45,7 +55,6 @@ function Summary({rows, fields}) {
 
   return (
     <div>
-
       {rowsWithIssuesCount === 0 ? (
         <h4>Aucune ligne avec anomalies trouvée <span className='valid'><Check /></span></h4>
       ) : (
@@ -71,6 +80,15 @@ function Summary({rows, fields}) {
         <IssuesSumup
           issues={warningsGroups}
           issueType='warning'
+          totalRowsCount={rows.length}
+          handleSelect={setSelectedIssue}
+        />
+      )}
+
+      {infosCount > 0 && (
+        <IssuesSumup
+          issues={infosGroups}
+          issueType='information'
           totalRowsCount={rows.length}
           handleSelect={setSelectedIssue}
         />

--- a/components/bases-locales/validator/report/summary/issue-dialog.js
+++ b/components/bases-locales/validator/report/summary/issue-dialog.js
@@ -25,7 +25,7 @@ function IssueDialog({issue, unknowFields, handleClose}) {
         <div className='scroll'>
 
           {issue.rows.length > ROWS_LIMIT && (
-            <Notification message={`Seules les ${ROWS_LIMIT} premières lignes avec anomalies sont affichées ici`} />
+            <Notification message={`Seules les ${ROWS_LIMIT} premières lignes avec des alertes sont affichées ici`} />
           )}
 
           {take(issue.rows, ROWS_LIMIT).map(row => (

--- a/components/bases-locales/validator/report/summary/issue-dialog.js
+++ b/components/bases-locales/validator/report/summary/issue-dialog.js
@@ -31,6 +31,7 @@ function IssueDialog({issue, unknowFields, handleClose}) {
           {take(issue.rows, ROWS_LIMIT).map(row => (
             <Row
               key={`row-${row.line}`}
+              issueType={issue.type}
               row={row}
               unknowFields={unknowFields}
               isForcedShowIssues={issue.rows.length === 1}
@@ -86,6 +87,7 @@ function IssueDialog({issue, unknowFields, handleClose}) {
 IssueDialog.propTypes = {
   issue: PropTypes.shape({
     code: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
     rows: PropTypes.array.isRequired
   }),
   unknowFields: PropTypes.array.isRequired,

--- a/components/bases-locales/validator/report/summary/issue-rows.js
+++ b/components/bases-locales/validator/report/summary/issue-rows.js
@@ -34,7 +34,7 @@ function IssueRows({issue, rows, isOnAllLines, onClick, type}) {
         }
 
         .colored {
-          color: ${type === 'error' ? theme.errorBorder : theme.warningBorder};
+          color: ${type === 'error' ? theme.errorBorder : (type === 'warning' ? theme.warningBorder : theme.infoBorder)};
         }
 
         .issue:hover {
@@ -54,7 +54,7 @@ IssueRows.propTypes = {
     })
   ).isRequired,
   isOnAllLines: PropTypes.bool.isRequired,
-  type: PropTypes.oneOf(['error', 'warning']).isRequired,
+  type: PropTypes.oneOf(['error', 'warning', 'information']).isRequired,
   onClick: PropTypes.func.isRequired
 }
 

--- a/components/bases-locales/validator/report/summary/issues-sumup.js
+++ b/components/bases-locales/validator/report/summary/issues-sumup.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import {X, AlertTriangle} from 'react-feather'
+import {X, AlertTriangle, Info} from 'react-feather'
 import {flattenDeep, groupBy} from 'lodash'
 
 import theme from '@/styles/theme'
@@ -20,13 +20,17 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
   return (
     <div className='issues-container'>
       <h4>
-        {issuesRowsCount} {issueType === 'error' ? 'Erreur' : 'Avertissement'}{issuesRowsCount > 1 ? 's' : ''}
+        {issuesRowsCount} {issueType === 'error' ? 'Erreur' : (issueType === 'warning' ? 'Avertissement' : 'Information')}{issuesRowsCount > 1 ? 's' : ''}
         &nbsp;({issuesCount} ligne{issuesCount > 1 ? 's' : ''}) {percentageIssues}%
         <div className={`summary-icon ${issueType}`}>
           {issueType === 'error' ? (
             <X style={{verticalAlign: 'bottom'}} />
           ) : (
-            <AlertTriangle style={{verticalAlign: 'bottom'}} />
+            issueType === 'warning' ? (
+              <AlertTriangle style={{verticalAlign: 'bottom'}} />
+            ) : (
+              <Info style={{verticalAlign: 'bottom'}} />
+            )
           )}
         </div>
       </h4>
@@ -38,7 +42,7 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
             rows={issues[issue]}
             isOnAllLines={issues[issue].length === totalRowsCount}
             type={issueType}
-            onClick={() => handleSelect({code: issue, rows: issues[issue]})}
+            onClick={() => handleSelect({code: issue, type: issueType, rows: issues[issue]})}
           />
         ))}
       </div>
@@ -62,6 +66,10 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
           color: ${theme.warningBorder};
         }
 
+        .information {
+          color: ${theme.infoBorder};
+        }
+
         .list {
           display: grid;
         }
@@ -76,7 +84,7 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
 
 IssuesSumup.propTypes = {
   issues: PropTypes.object.isRequired,
-  issueType: PropTypes.oneOf(['error', 'warning']).isRequired,
+  issueType: PropTypes.oneOf(['error', 'warning', 'information']).isRequired,
   totalRowsCount: PropTypes.number.isRequired,
   handleSelect: PropTypes.func.isRequired
 }

--- a/components/bases-locales/validator/report/summary/line-value.js
+++ b/components/bases-locales/validator/report/summary/line-value.js
@@ -4,12 +4,11 @@ import theme from '@/styles/theme'
 
 function LineValue({value, errors, handleHover, hasUnknowFields}) {
   const hasErrors = errors && errors.length > 0
-
   return (
     <>
       {hasErrors ? (
         <td
-          className={errors[0].level === 'E' ? 'error' : 'warning'}
+          className={errors[0].level === 'E' ? 'error' : (errors[0].level === 'W' ? 'warning' : 'information')}
           onMouseOver={() => handleHover(errors)}
           onMouseOut={() => handleHover(null)}
         >
@@ -32,6 +31,10 @@ function LineValue({value, errors, handleHover, hasUnknowFields}) {
 
         td.warning {
           background: ${theme.warningBg};
+        }
+
+        td.information {
+          background: ${theme.infoBg};
         }
 
         td.error:hover {

--- a/components/bases-locales/validator/report/summary/line.js
+++ b/components/bases-locales/validator/report/summary/line.js
@@ -5,6 +5,7 @@ import theme from '@/styles/theme'
 import LineValue from './line-value'
 
 function Line({line, errors, onHover, unknowFields}) {
+  console.log(errors)
   return (
     <div className='line-container'>
       <table>

--- a/components/bases-locales/validator/report/summary/row-issues.js
+++ b/components/bases-locales/validator/report/summary/row-issues.js
@@ -9,7 +9,7 @@ function RowIssues({errors, hoveredFieldErrors}) {
       <div className='error-list'>
         {errors.map(error => {
           const {code, level} = error
-          const color = level === 'E' ? 'error' : 'warning'
+          const color = level === 'E' ? 'error' : (level === 'W' ? 'warning' : 'information')
           return (
             <div key={code} className={`issue ${color} ${hoveredFieldErrors && (hoveredFieldErrors.includes(error)) ? 'select' : ''}`}>
               {getLabel(code)}
@@ -17,6 +17,7 @@ function RowIssues({errors, hoveredFieldErrors}) {
           )
         })}
       </div>
+
       <style jsx>{`
       .abnormalities {
         display: flex;
@@ -38,6 +39,10 @@ function RowIssues({errors, hoveredFieldErrors}) {
         background: ${theme.warningBg};
       }
 
+      .information {
+        background: ${theme.infoBg};
+      }
+
       .issue.select {
         color: ${theme.colors.white};
       }
@@ -48,6 +53,10 @@ function RowIssues({errors, hoveredFieldErrors}) {
 
       .warning.select {
         background: ${theme.warningBorder};
+      }
+
+      .information.select {
+        background: ${theme.infoBorder};
       }
       `}</style>
     </div>

--- a/components/bases-locales/validator/report/summary/row.js
+++ b/components/bases-locales/validator/report/summary/row.js
@@ -7,11 +7,12 @@ import Line from './line'
 import RowIssues from './row-issues'
 import {ChevronDown, ChevronUp} from 'react-feather'
 
-function Row({row, isForcedShowIssues, unknowFields}) {
+function Row({row, isForcedShowIssues, unknowFields, issueType}) {
   const [showIssues, setShowIssues] = useState(false)
   const [hoveredFieldErrors, setHoveredFieldErrors] = useState()
-  const issuesCount = row.errors.length
-  const issueLevel = row.errors.map(({level}) => level).includes('E') ? 'error' : 'warning'
+  const sanitedIssueType = issueType === 'error' ? 'E' : (issueType === 'warning' ? 'W' : 'I')
+  const filteredErrors = row.errors.filter(error => error.level === sanitedIssueType)
+  const issuesCount = filteredErrors.length
 
   const handleError = useCallback(() => {
     setShowIssues(!showIssues)
@@ -27,11 +28,11 @@ function Row({row, isForcedShowIssues, unknowFields}) {
           </div>
           <div>
             {issuesCount === 1 ? (
-              <div className={issueLevel}>
+              <div className={issueType}>
                 {showIssues ? 'Masquer' : 'Afficher'} l’anomalie
               </div>
             ) : (
-              <div className={issueLevel}>
+              <div className={issueType}>
                 {showIssues ? 'Masquer' : 'Afficher'} les {issuesCount} anomalies
               </div>
             )}
@@ -49,13 +50,13 @@ function Row({row, isForcedShowIssues, unknowFields}) {
         <div className='issue'>
           <Line
             line={row.rawValues}
-            errors={row.errors}
+            errors={filteredErrors}
             onHover={setHoveredFieldErrors}
             unknowFields={unknowFields}
           />
 
           {(issuesCount > 0 || isForcedShowIssues) && (
-            <RowIssues errors={row.errors} hoveredFieldErrors={hoveredFieldErrors} />
+            <RowIssues errors={filteredErrors} hoveredFieldErrors={hoveredFieldErrors} />
           )}
         </div>}
 
@@ -89,6 +90,10 @@ function Row({row, isForcedShowIssues, unknowFields}) {
           color: ${theme.warningBorder};
         }
 
+        .information {
+          color: ${theme.infoBorder};
+        }
+
         .line:hover {
           cursor: pointer;
           background-color: #f8f8f8;
@@ -101,7 +106,8 @@ function Row({row, isForcedShowIssues, unknowFields}) {
 Row.propTypes = {
   row: PropTypes.object.isRequired,
   isForcedShowIssues: PropTypes.bool,
-  unknowFields: PropTypes.array.isRequired
+  unknowFields: PropTypes.array.isRequired,
+  issueType: PropTypes.string.isRequired
 }
 
 Row.defaultProps = {

--- a/components/bases-locales/validator/report/summary/row.js
+++ b/components/bases-locales/validator/report/summary/row.js
@@ -29,11 +29,11 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
           <div>
             {issuesCount === 1 ? (
               <div className={issueType}>
-                {showIssues ? 'Masquer' : 'Afficher'} l’anomalie
+                {showIssues ? 'Masquer' : 'Afficher'} l’alerte
               </div>
             ) : (
               <div className={issueType}>
-                {showIssues ? 'Masquer' : 'Afficher'} les {issuesCount} anomalies
+                {showIssues ? 'Masquer' : 'Afficher'} les {issuesCount} alertes
               </div>
             )}
           </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.5",
-    "@etalab/bal": "^1.8.0",
+    "@etalab/bal": "^2.1.0",
     "@etalab/project-legal": "^0.4.1",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -42,7 +42,7 @@ function Contribuer() {
 
       <Section title='En tant qu’utilisateur des données'>
         <div style={{textAlign: 'center'}}>
-          <p style={{margin: '3em 0'}}>Vous utilisez les données diffusées par ce site et vous avez identifié des anomalies récurrentes sur une typologie d’adresse particulière ou dans une zone ?</p>
+          <p style={{margin: '3em 0'}}>Vous utilisez les données diffusées par ce site et vous avez identifié des alertes récurrentes sur une typologie d’adresse particulière ou dans une zone ?</p>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
             <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,20 +532,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/bal@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-1.8.0.tgz#9a33f6849c4f574404477d10ba7fdc3167d9fd93"
-  integrity sha512-fz6Rs+YFjwmAcd4zvkbI4ZHixnSYaOjxpGsc4OUMJCN1imsEOz8PsJX9w4oLo1dBr7bBqxWqfR59pbH3Xsw0rA==
+"@etalab/bal@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.1.0.tgz#3f9ee18b3526eff898ea7f27bea3e68b1113c53d"
+  integrity sha512-hyD8E0VHTvCTP2zsoiN9EMbF8qWsSM1MrHHD3t0sJyJL1VzF5m5MjzFZzUiZjoKkdfiv4fNzEIea6MeisfyKFQ==
   dependencies:
     blob-to-buffer "^1.2.9"
+    bluebird "^3.7.2"
     chalk "^4.1.2"
     chardet "^1.4.0"
-    date-fns "^2.26.0"
+    date-fns "^2.28.0"
     file-type "^12.4.2"
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
     papaparse "^5.3.1"
-    yargs "^17.2.1"
+    yargs "^17.3.1"
 
 "@etalab/project-legal@^0.4.1":
   version "0.4.1"
@@ -1329,6 +1330,11 @@ blob-to-buffer@^1.2.9:
   resolved "https://registry.yarnpkg.com/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz#a17fd6c1c564011408f8971e451544245daaa84a"
   integrity sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==
 
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
@@ -2055,10 +2061,10 @@ data-uri-to-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
-date-fns@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.26.0.tgz#fa45305543c392c4f914e50775fd2a4461e60fbd"
-  integrity sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg==
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -7265,28 +7271,28 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@^20.2.2:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
 yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@^17.2.1:
-  version "17.2.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
-  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
+yargs@^17.3.1:
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    string-width "^4.2.0"
+    string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    yargs-parser "^21.0.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Depuis la version `2.0.0` le validateur est strict par défaut. Cette PR rétablit un fonctionnement souple pour afficher plus d'erreurs.

La version `2.1.0` introduit par ailleurs de nouvelles règles classées "informations" que ne sont pas nécessairement des problèmes.

Les niveaux sont donc désormais :
- `error` : erreur qui empêche la prise en compte de la ligne
- `warning` : avertissement qui indique un écart avec la spécification ou une anomalie non bloquante. Dans certains cas la donnée litigieuse est corrigée, dans d'autres elle est ignorée.
- `info` : autre information remontée par le validateur