### PR TITLE
Amélioration de l'affichage des habilités dans la page commune

### DIFF
--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -45,12 +45,8 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
   const adressesSources = uniq(voies.map(voie => voie.sources).flat())
   let userName = hasMigratedBAL && revision.client.chefDeFile
 
-  if (hasMigratedBAL && !userName) {
-    if (revision.habilitation.strategy.type === 'email') {
-      userName = `la mairie de ${nomCommune}`
-    } else if (revision.habilitation.strategy.type === 'franceconnect') {
-      userName = `un(e) élu(e) de ${nomCommune}`
-    }
+  if (hasMigratedBAL && !userName && revision.habilitation.strategy.type === 'email') {
+    userName = `la mairie de ${nomCommune}`
   }
 
   const subtitle = useMemo(() => {
@@ -67,11 +63,17 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
     // BAL créée et migrée
     const clientName = revision.client.nom
 
-    if (clientName) {
+    if (clientName && userName) {
       return `Les adresses de la commune proviennent de la Base Adresse Locale de ${userName}, via ${clientName}`
     }
 
-    return `Les adresses de la commune proviennent de la Base Adresse Locale de ${userName}`
+    if (clientName && !userName) {
+      return `Les adresses de la commune proviennent de la Base Adresse Locale soumise via ${clientName}`
+    }
+
+    if (!clientName && userName) {
+      return `Les adresses de la commune proviennent de la Base Adresse Locale de ${userName}`
+    }
   }, [revision, userName, nomCommune, typeComposition, adressesSources, hasMigratedBAL])
 
   const handleModalOpen = () => {

--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -43,7 +43,7 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
   const {codeCommune, nomCommune, nbNumeros, nbNumerosCertifies, voies} = communeInfos
 
   const adressesSources = uniq(voies.map(voie => voie.sources).flat())
-  let userName = hasMigratedBAL && revision.context.organisation
+  let userName = hasMigratedBAL && revision.client.chefDeFile
 
   if (hasMigratedBAL && !userName) {
     if (revision.habilitation.strategy.type === 'email') {

--- a/components/commune/historique-item.js
+++ b/components/commune/historique-item.js
@@ -11,7 +11,7 @@ function HistoriqueItem({balData, communeName}) {
   const date = new Date(updatedAt)
   const completUpdateTime = `le ${date.toLocaleDateString('fr-FR')} à ${date.getHours()}h${date.getMinutes()}`
 
-  let userName = balData.context.organisation
+  let userName = balData.client.chefDeFile
 
   if (!userName) {
     if (habilitation.strategy.type === 'email') {


### PR DESCRIPTION
- Remplace le nom de l'habilité par défaut par le chef de file.
<img width="1369" alt="Capture d’écran 2022-02-15 à 11 46 01" src="https://user-images.githubusercontent.com/66621960/154046477-72aa80c5-a675-474e-9e38-33e11c92b34c.png">


- Supprime l'affichage de l'habilité(e) dans le sous-titre de la section `État de la Base Adresse Nationale` dans le cas où il/elle est un(e) élu(e).

<img width="1440" alt="Capture d’écran 2022-02-15 à 11 37 02" src="https://user-images.githubusercontent.com/66621960/154046303-e9c55128-f5be-464b-92f2-310ff3d75bcb.png">
