### PR TITLE
Ajout d'une bannière info en page d'accueil

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -72,7 +72,6 @@ function Hero({title, tagline}) {
 
       <style jsx>{`
         .hero {
-          padding-top: 2em;
           min-height: 100vh;
           background: ${theme.colors.white};
           display: flex;

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,9 +19,37 @@ import CommuneSearch from '@/components/commune/commune-search'
 function Home({stats}) {
   return (
     <Page>
+      <div className='bandeau'>
+        <b>📅 &nbsp; À vos agendas ! </b>
+        <a href='https://www.eventbrite.fr/e/billets-adresse-lab1-269490381987' target='_blank' rel='noreferrer'>
+          L’équipe BAN vous invite à participer au premier Adresse Lab qui se tiendra en ligne le 10 Mars 2022 de 10h30 à 12h.
+        </a>
+
+        <style jsx>{`
+          .bandeau {
+            background: ${theme.primary};
+            text-align: center;
+            padding: .5em;
+            color: ${theme.colors.white};
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+          }
+
+          .bandeau a {
+            color: ${theme.colors.white};
+          }
+
+          .bandeau a:hover {
+            color: ${theme.primary};
+          }
+        `}</style>
+      </div>
+
       <Hero
         title='Le site national des adresses'
-        tagline='Référencer l’intégralité des adresses du territoire et les rendre utilisables par tous.' />
+        tagline='Référencer l’intégralité des adresses du territoire et les rendre utilisables par tous.'
+      />
 
       <Section background='dark'>
         <div className='pitch'>


### PR DESCRIPTION
Indique actuellement le prochain Adresse Lab ainsi qu'un lien vers la page de l'évènement.

Cette feature sera évolutive et proposera par la suite un système de slides incluant les 3 prochains évènements à venir.

<img width="1440" alt="Capture d’écran 2022-02-15 à 14 56 29" src="https://user-images.githubusercontent.com/66621960/154076908-d2f09bf6-942f-42e4-bb5b-e658a356529a.png">
