### PR TITLE
Mise à jour du validateur BAL @etalab/bal (2.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.5",
-    "@etalab/bal": "^2.1.1",
+    "@etalab/bal": "^2.2.0",
     "@etalab/project-legal": "^0.4.1",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,10 +532,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/bal@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.1.1.tgz#dae1a567e1c846d512b7cad771aff2bba28ad725"
-  integrity sha512-HpTev84ssrMSdrd57b3L4v54gRPd3tZO/kfs+IaDkzKHbwmwDaufwTSi3iyRmnBjxVAf/dqPTzMcfC/YijHyjg==
+"@etalab/bal@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.2.0.tgz#70451ffb65e49b1b0ae9b8cfcd56a288ece60ee6"
+  integrity sha512-HakYHtu2XwNr6/xkKU6Uu98U5jlhuF4AuF6WD7QJKI8k2mwkP5X5i/opA6oKkcdSm55ShsC2tDTxecaTFkTpQQ==
   dependencies:
     blob-to-buffer "^1.2.9"
     bluebird "^3.7.2"


### PR DESCRIPTION
Ce dernier est désormais aligné avec le Code Officiel Géographique 2022