### PR TITLE
Correction format date sous Safari et IE

### DIFF
--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -16,7 +16,7 @@ import Loader from '@/components/loader'
 function sortEventsByDate(events, order) {
   return orderBy(events, [
     function (event) {
-      return Date.parse(`${event.date} ${event.startHour}`)
+      return Date.parse(`${event.date}T${event.startHour}`)
     },
   ], [order])
 }


### PR DESCRIPTION
Utilisation d'un format standard de date afin de garantir un traitement fonctionnel et universel à chaque navigateur.
[Documentation date.parse()](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#description)

### **Avant (Safari)**
![Capture d’écran 2022-02-28 à 17 43 38](https://user-images.githubusercontent.com/66621960/156023480-ed5fca5d-97e9-4f92-894a-4592de30acfa.png)

### **Après (Safari)**
![Capture d’écran 2022-02-28 à 10 19 22](https://user-images.githubusercontent.com/66621960/156023484-d63a2eaf-b8bf-4655-a0db-3a9ca0a0c0ff.png)
