### PR TITLE
Correction du décalage à l'ouverture de la modale 

### DIFF
--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -26,14 +26,6 @@ function EventModal({event, date, isPassed, onClose}) {
   const {nom, numero, voie, codePostal, commune} = address
 
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
-
-    return () => {
-      document.body.style.overflow = 'unset'
-    }
-  }, [])
-
-  useEffect(() => {
     const handleClickOutside = event => {
       if (modalRef.current && !modalRef.current.contains(event.target)) {
         onClose()


### PR DESCRIPTION
Restauration du scrolling de <body> à l'ouverture de la modale sur la page évènement.
Permet d'éviter le décalage de la page se produisant lors de la disparition de la scrollbar

### **AVANT**
![Capture d’écran 2022-03-01 à 10 30 13](https://user-images.githubusercontent.com/66621960/156142732-4c9af4bb-4a63-4e67-92d3-56ec06a6b6c9.png)

### **APRÈS**
![Capture d’écran 2022-03-01 à 10 29 42](https://user-images.githubusercontent.com/66621960/156142727-f2f19874-3cb9-498c-8b7c-c0186d1ec119.png)
