### PR TITLE
Amélioration de la bannière évènements page d'accueil

### DIFF
--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -19,10 +19,10 @@ const events = sortEventsByDate(allEvents, 'asc').filter(event => new Date(event
 
 function EventBanner() {
   const [index, setIndex] = useState(0)
-  const [event, setEvent] = useState(null)
+  const [selectedEvent, setSelectedEvent] = useState(null)
 
   useEffect(() => {
-    if (!event) {
+    if (!selectedEvent) {
       const slideInterval = setTimeout(() => {
         setIndex(index === events.length - 1 ? 0 : index + 1)
       }, 4000)
@@ -31,7 +31,7 @@ function EventBanner() {
         clearInterval(slideInterval)
       }
     }
-  }, [index, event])
+  }, [index, selectedEvent])
 
   return (
     <div className='banner'>
@@ -46,7 +46,7 @@ function EventBanner() {
             const sanitizedDate = new Date(event.date).toLocaleDateString('fr-FR')
             return idx === index && (
               <li className='slide' key={`${event.title}-${sanitizedDate}`}>
-                <div className='event-link' onClick={() => setEvent(event)}>{event.title}</div>
+                <div className='event-link' onClick={() => setSelectedEvent(event)}>{event.title}</div>
                 <div className='date'>le {sanitizedDate}</div>
               </li>
             )
@@ -63,7 +63,7 @@ function EventBanner() {
           />
         ))}
       </div>
-      {event && <EventModal event={event} date={new Date(event.date).toLocaleDateString('fr-FR')} onClose={() => setEvent(null)} />}
+      {selectedEvent && <EventModal event={selectedEvent} date={new Date(selectedEvent.date).toLocaleDateString('fr-FR')} onClose={() => setSelectedEvent(null)} />}
 
       <style jsx>{`
         .banner {

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -2,7 +2,7 @@ import {useState, useEffect} from 'react'
 import Link from 'next/link'
 import {orderBy} from 'lodash'
 
-import events from '../../events.json'
+import allEvents from '../../events.json'
 import theme from '@/styles/theme'
 import EventModal from './event-modal'
 
@@ -14,35 +14,35 @@ function sortEventsByDate(events, order) {
   ], [order])
 }
 
+const today = new Date().setHours(0, 0, 0, 0)
+const events = sortEventsByDate(allEvents, 'asc').filter(event => new Date(event.date).setHours(0, 0, 0, 0) >= today).slice(0, 3)
+
 function EventBanner() {
   const [index, setIndex] = useState(0)
   const [event, setEvent] = useState(null)
 
-  const today = new Date().setHours(0, 0, 0, 0)
-  const selectedFirstEvents = sortEventsByDate(events, 'asc').filter(event => new Date(event.date).setHours(0, 0, 0, 0) >= today).slice(0, 3)
-
   useEffect(() => {
     if (!event) {
       const slideInterval = setTimeout(() => {
-        setIndex(index === selectedFirstEvents.length - 1 ? 0 : index + 1)
+        setIndex(index === events.length - 1 ? 0 : index + 1)
       }, 4000)
 
       return () => {
         clearInterval(slideInterval)
       }
     }
-  }, [index, event, selectedFirstEvents])
+  }, [index, event])
 
   return (
     <div className='banner'>
       <div className='banner-title'>Les prochains évènements autour de l’adresse</div>
       <ul className='slider'>
-        {selectedFirstEvents.length === 0 ? (
+        {events.length === 0 ? (
           <ul className='slide'>
             Aucun évènement n’est actuellement programmé. Retrouvez <Link href='/evenements' passHref><span className='event-link'>ici</span></Link> nos évènements passés.
           </ul>
         ) : (
-          selectedFirstEvents.map((event, idx) => {
+          events.map((event, idx) => {
             const sanitizedDate = new Date(event.date).toLocaleDateString('fr-FR')
             return idx === index && (
               <li className='slide' key={`${event.title}-${sanitizedDate}`}>
@@ -55,7 +55,7 @@ function EventBanner() {
       </ul>
 
       <div className='slideshow-dots'>
-        {selectedFirstEvents.map((event, idx) => (
+        {events.map((event, idx) => (
           <div
             key={`${event.title}-${event.date}`}
             className={`slideshow-dot ${index === idx ? 'active' : ''}`}

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -2,8 +2,10 @@ import {useState, useEffect} from 'react'
 import Link from 'next/link'
 import {orderBy} from 'lodash'
 
-import allEvents from '../../events.json'
 import theme from '@/styles/theme'
+
+import allEvents from '../../events.json'
+
 import EventModal from './event-modal'
 
 function sortEventsByDate(events, order) {

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -26,6 +26,10 @@ function EventBanner() {
     }
   }, [index, selectedEvent])
 
+  if (events.length === 0) {
+    return null
+  }
+
   return (
     <div className='banner'>
       <div className='banner-title'>Les prochains évènements autour de l’adresse</div>

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -1,20 +1,12 @@
 import {useState, useEffect} from 'react'
 import Link from 'next/link'
-import {orderBy} from 'lodash'
 
+import {sortEventsByDate} from '@/lib/date'
 import theme from '@/styles/theme'
 
 import allEvents from '../../events.json'
 
 import EventModal from './event-modal'
-
-function sortEventsByDate(events, order) {
-  return orderBy(events, [
-    function (event) {
-      return Date.parse(`${event.date}T${event.startHour}`)
-    },
-  ], [order])
-}
 
 const today = new Date().setHours(0, 0, 0, 0)
 const events = sortEventsByDate(allEvents, 'asc').filter(event => new Date(event.date).setHours(0, 0, 0, 0) >= today).slice(0, 3)

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -1,0 +1,141 @@
+import {useState, useEffect} from 'react'
+import Link from 'next/link'
+import {orderBy} from 'lodash'
+
+import events from '../../events.json'
+import theme from '@/styles/theme'
+import EventModal from './event-modal'
+
+function sortEventsByDate(events, order) {
+  return orderBy(events, [
+    function (event) {
+      return Date.parse(`${event.date}T${event.startHour}`)
+    },
+  ], [order])
+}
+
+function EventBanner() {
+  const [index, setIndex] = useState(0)
+  const [event, setEvent] = useState(null)
+
+  const today = new Date().setHours(0, 0, 0, 0)
+  const selectedFirstEvents = sortEventsByDate(events, 'asc').filter(event => new Date(event.date).setHours(0, 0, 0, 0) >= today).slice(0, 3)
+
+  useEffect(() => {
+    if (!event) {
+      const slideInterval = setTimeout(() => {
+        setIndex(index === selectedFirstEvents.length - 1 ? 0 : index + 1)
+      }, 4000)
+
+      return () => {
+        clearInterval(slideInterval)
+      }
+    }
+  }, [index, event, selectedFirstEvents])
+
+  return (
+    <div className='banner'>
+      <div className='banner-title'>Les prochains évènements autour de l’adresse</div>
+      <ul className='slider'>
+        {selectedFirstEvents.length === 0 ? (
+          <ul className='slide'>
+            Aucun évènement n’est actuellement programmé. Retrouvez <Link href='/evenements' passHref><span className='event-link'>ici</span></Link> nos évènements passés.
+          </ul>
+        ) : (
+          selectedFirstEvents.map((event, idx) => {
+            const sanitizedDate = new Date(event.date).toLocaleDateString('fr-FR')
+            return idx === index && (
+              <li className='slide' key={`${event.title}-${sanitizedDate}`}>
+                <div className='event-link' onClick={() => setEvent(event)}>{event.title}</div>
+                <div className='date'>le {sanitizedDate}</div>
+              </li>
+            )
+          })
+        )}
+      </ul>
+
+      <div className='slideshow-dots'>
+        {selectedFirstEvents.map((event, idx) => (
+          <div
+            key={`${event.title}-${event.date}`}
+            className={`slideshow-dot ${index === idx ? 'active' : ''}`}
+            onClick={() => setIndex(idx)}
+          />
+        ))}
+      </div>
+      {event && <EventModal event={event} date={new Date(event.date).toLocaleDateString('fr-FR')} onClose={() => setEvent(null)} />}
+
+      <style jsx>{`
+        .banner {
+          background: ${theme.primary};
+          padding: 5px;
+          text-align: center;
+          overflow: hidden;
+        }
+
+        .banner-title {
+          font-size: 20px;
+          margin-bottom: 5px;
+          font-weight: bold;
+          color: ${theme.colors.white};
+        }
+
+        .slider {
+          white-space: nowrap;
+          text-align: center;
+          padding: 0;
+          margin: 0;
+          color: ${theme.colors.white};
+        }
+
+        .slide {
+          text-align: center;
+          display: inline-block;
+          animation: fadeIn linear 1s;
+        }
+
+        .event-link {
+          font-size: 16px;
+          font-weight: bold;
+        }
+
+        .date {
+          font-style: italic
+        }
+
+        @keyframes fadeIn {
+          0% {opacity:0;}
+          100% {opacity:1;}
+        }
+
+          /* Buttons */
+        .slideshow-dots {
+          text-align: center;
+        }
+
+        .slideshow-dot {
+          display: inline-block;
+          height: 7px;
+          width: 7px;
+          border-radius: 50%;
+          cursor: pointer;
+          margin: 15px 7px 0px;
+          background-color: ${theme.colors.white};
+          opacity: 50%;
+        }
+
+        .active {
+          opacity: 100%;
+        }
+
+        .event-link {
+          color: ${theme.colors.white};
+          cursor: pointer;
+          text-decoration: underline;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default EventBanner

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -39,20 +39,16 @@ function EventBanner() {
     <div className='banner'>
       <div className='banner-title'>Les prochains évènements autour de l’adresse</div>
       <ul className='slider'>
-        {events.length === 0 ? (
-          <ul className='slide'>
-            Aucun évènement n’est actuellement programmé. Retrouvez <Link href='/evenements' passHref><span className='event-link'>ici</span></Link> nos évènements passés.
-          </ul>
-        ) : (
-          events.map((event, idx) => {
-            const sanitizedDate = new Date(event.date).toLocaleDateString('fr-FR')
-            return idx === index && (
-              <li className='slide' key={`${event.title}-${sanitizedDate}`}>
-                <div className='event-link' onClick={() => setSelectedEvent(event)}>{event.title}</div>
-                <div className='date'>le {sanitizedDate}</div>
-              </li>
-            )
-          })
+        {events.map((event, idx) => {
+          const sanitizedDate = new Date(event.date).toLocaleDateString('fr-FR')
+
+          return (
+            <li className={idx === index ? 'slide' : 'hidden'} key={`${event.title}-${sanitizedDate}`}>
+              <div className='event-link' onClick={() => setSelectedEvent(event)}>{event.title}</div>
+              <div className='date'>le {sanitizedDate}</div>
+            </li>
+          )
+        }
         )}
       </ul>
 
@@ -134,6 +130,10 @@ function EventBanner() {
           color: ${theme.colors.white};
           cursor: pointer;
           text-decoration: underline;
+        }
+
+        .hidden {
+          display: none;
         }
       `}</style>
     </div>

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -1,5 +1,4 @@
 import {useState, useEffect} from 'react'
-import Link from 'next/link'
 
 import {sortEventsByDate} from '@/lib/date'
 import theme from '@/styles/theme'

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -61,7 +61,14 @@ function EventBanner() {
           />
         ))}
       </div>
-      {selectedEvent && <EventModal event={selectedEvent} date={new Date(selectedEvent.date).toLocaleDateString('fr-FR')} onClose={() => setSelectedEvent(null)} />}
+
+      {selectedEvent && (
+        <EventModal
+          event={selectedEvent}
+          date={new Date(selectedEvent.date).toLocaleDateString('fr-FR')}
+          onClose={() => setSelectedEvent(null)}
+        />
+      )}
 
       <style jsx>{`
         .banner {

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,0 +1,9 @@
+import {orderBy} from 'lodash'
+
+export function sortEventsByDate(events, order) {
+  return orderBy(events, [
+    function (event) {
+      return Date.parse(`${event.date}T${event.startHour}`)
+    },
+  ], [order])
+}

--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react'
-import {orderBy} from 'lodash'
 import {Calendar} from 'react-feather'
 
+import {sortEventsByDate} from '@/lib/date'
 import theme from '@/styles/theme'
 
 import events from '../events.json'
@@ -12,14 +12,6 @@ import Section from '@/components/section'
 import SectionText from '@/components/section-text'
 import Event from '@/components/evenement/event'
 import Loader from '@/components/loader'
-
-function sortEventsByDate(events, order) {
-  return orderBy(events, [
-    function (event) {
-      return Date.parse(`${event.date}T${event.startHour}`)
-    },
-  ], [order])
-}
 
 function Evenements() {
   const [isLoading, setIsLoading] = useState(true)

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Image from 'next/image'
-import {ExternalLink} from 'react-feather'
 
 import {getStats} from '@/lib/api-ban'
 
@@ -16,37 +15,12 @@ import DocDownload from '@/components/doc-download'
 import Temoignages from '@/components/temoignages'
 import SocialMedia from '@/components/social-media'
 import CommuneSearch from '@/components/commune/commune-search'
+import EventBanner from '@/components/evenement/event-banner'
 
 function Home({stats}) {
   return (
     <Page>
-      <div className='bandeau'>
-        <b>📅 &nbsp; À vos agendas ! </b>
-        <a href='https://www.eventbrite.fr/e/billets-adresse-lab1-269490381987'>
-          L’équipe BAN vous invite à participer au premier Adresse Lab qui se tiendra en ligne le 10 Mars 2022 de 10h30 à 12h.
-          <ExternalLink style={{marginLeft: 5}} size={16} />
-        </a>
-
-        <style jsx>{`
-          .bandeau {
-            background: ${theme.primary};
-            text-align: center;
-            padding: .5em;
-            color: ${theme.colors.white};
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-          }
-
-          .bandeau a {
-            color: ${theme.colors.white};
-          }
-
-          .bandeau a:hover {
-            color: ${theme.primary};
-          }
-        `}</style>
-      </div>
+      <EventBanner />
 
       <Hero
         title='Le site national des adresses'


### PR DESCRIPTION
La version précédente de la bannière en page d'accueil n'affichait qu'en "dur", le prochain AdresseLab.
Suite à l'ajout de la page évènements, il est plus pertinent d'afficher de manière dynamique les évènements à venir et de fournir un accès rapide à l'utilisateur concernant les détails des évents.

- Affichage des trois évènements prévus, du premier à venir au dernier, via un système de slides.
- Changement de slide via un timer et un système de contrôle manuel.
- Indique le nom de l'évènement, la date. Affiche la modale avec la totalité des informations lors du click sur le nom de l'évènement.



https://user-images.githubusercontent.com/66621960/156160700-a70c9e91-5714-43c3-8c5d-c24b4fa7550c.mov



![Capture d’écran 2022-03-01 à 11 02 37](https://user-images.githubusercontent.com/66621960/156160087-99cb6edd-0bbc-4404-8acb-319d9abe8a5d.png)
![Capture d’écran 2022-03-01 à 12 12 34](https://user-images.githubusercontent.com/66621960/156160091-6c9aebf8-4610-4626-a8c1-c491be3cd05e.png)
