### PR TITLE
Prise en charge du CSS des blocs du blog Ghost

### DIFF
--- a/components/post.js
+++ b/components/post.js
@@ -390,6 +390,23 @@ function Post({title, published_at, feature_image, html, backLink}) {
           color: white;
           margin-bottom: 1em;
         }
+
+        .kg-product-card {
+          display: flex;
+          align-items: center;
+          flex-direction: column;
+          width: 100%;
+        }
+
+        .kg-product-card-container {
+          align-items: center;
+          background: 0 0;
+          max-width: 550px;
+          padding: 20px;
+          border-radius: 5px;
+          box-shadow: inset 0 0 0 1px rgb(124 139 154/25%);
+          margin-bottom: 1em;
+        }
         `}</style>
     </Section>
   )

--- a/components/post.js
+++ b/components/post.js
@@ -379,6 +379,17 @@ function Post({title, published_at, feature_image, html, backLink}) {
           min-width: 80px;
           background-color: ${colors.lighterGrey}
         }
+
+        .kg-header-card {
+          padding: 4em;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          text-align: center;
+          background-color: black;
+          color: white;
+          margin-bottom: 1em;
+        }
         `}</style>
     </Section>
   )

--- a/components/post.js
+++ b/components/post.js
@@ -3,43 +3,52 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Image from 'next/image'
 import {ArrowLeftCircle} from 'react-feather'
+
 import colors from '@/styles/colors'
 
 import Section from '@/components/section'
 
 function Post({title, published_at, feature_image, html, backLink}) {
   useEffect(() => {
-    if (html) {
-      const audioPlayer = [...document.querySelectorAll('audio')]
-      const videoPlayer = [...document.querySelectorAll('video')]
-      const dropdownDiv = [...document.querySelectorAll('div.kg-card.kg-toggle-card')]
+    const audioPlayers = [...document.querySelectorAll('audio')]
+    const videoPlayers = [...document.querySelectorAll('video')]
+    const dropdownDivs = [...document.querySelectorAll('div.kg-card.kg-toggle-card')]
 
-      // Add controls to Vidéo player
-      if (videoPlayer) {
-        videoPlayer.forEach(v => {
-          v.setAttribute('controls', true)
-        })
+    function toggleDiv(d) {
+      if (d.attributes['data-kg-toggle-state'].value === 'close') {
+        d.dataset.kgToggleState = 'open'
+        d.children[0].lastChild.lastChild.classList.add('toggled')
+      } else {
+        d.dataset.kgToggleState = 'close'
+        d.children[0].lastChild.lastChild.classList.remove('toggled')
       }
+    }
 
-      // Add controls to Audio player
-      if (audioPlayer) {
-        audioPlayer.forEach(a => {
-          a.setAttribute('controls', true)
-        })
-      }
+    // Add controls to Vidéo player
+    if (videoPlayers.length > 0) {
+      videoPlayers.forEach(v => {
+        v.setAttribute('controls', true)
+      })
+    }
 
-      // Add onClick event on Toggle
-      if (dropdownDiv) {
-        dropdownDiv.forEach(d => {
-          d.addEventListener('click', () => {
-            if (d.attributes['data-kg-toggle-state'].value === 'close') {
-              d.dataset.kgToggleState = 'open'
-              d.children[0].lastChild.lastChild.classList.add('toggled')
-            } else {
-              d.dataset.kgToggleState = 'close'
-              d.children[0].lastChild.lastChild.classList.remove('toggled')
-            }
-          })
+    // Add controls to Audio player
+    if (audioPlayers.length > 0) {
+      audioPlayers.forEach(a => {
+        a.setAttribute('controls', true)
+      })
+    }
+
+    // Add onClick event on Toggle
+    if (dropdownDivs.length > 0) {
+      dropdownDivs.forEach(d => {
+        d.addEventListener('click', () => toggleDiv(d))
+      })
+    }
+
+    return () => {
+      if (dropdownDivs.length > 0) {
+        dropdownDivs.forEach(d => {
+          d.removeEventListener('click', () => toggleDiv(d))
         })
       }
     }

--- a/components/post.js
+++ b/components/post.js
@@ -332,6 +332,53 @@ function Post({title, published_at, feature_image, html, backLink}) {
         .kg-audio-player, .kg-audio-thumbnail {
           display: none;
         }
+
+        .kg-file-card-container {
+          display: flex;
+          align-items: stretch;
+          justify-content: space-between;
+          padding: 6px;
+          border: 1px solid rgb(124 139 154/25%);
+          border-radius: 3px;
+          transition: all ease-in-out .35s;
+          text-decoration: none;
+          width: 100%;
+          margin-bottom: 1em;
+        }
+
+        .kg-file-card-contents {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          margin: 4px 8px;
+          width: 100%;
+        }
+
+        .kg-file-card-metadata {
+          display: flex;
+          margin-top: 2px;
+          padding: 0 0 .5em .5em;
+          font-style: italic;
+        }
+
+        .kg-file-card-filesize {
+          margin-left: 1em;
+        }
+
+        .kg-file-card-icon svg {
+          height: 24px;
+          width: 24px;
+        }
+
+        .kg-file-card-icon {
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 80px;
+          min-width: 80px;
+          background-color: ${colors.lighterGrey}
+        }
         `}</style>
     </Section>
   )

--- a/components/post.js
+++ b/components/post.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Image from 'next/image'
 import {ArrowLeftCircle} from 'react-feather'
-import colors from  '@/styles/colors'
+import colors from '@/styles/colors'
 
 import Section from '@/components/section'
 
@@ -14,18 +14,21 @@ function Post({title, published_at, feature_image, html, backLink}) {
       const videoPlayer = [...document.querySelectorAll('video')]
       const dropdownDiv = [...document.querySelectorAll('div.kg-card.kg-toggle-card')]
 
+      // Add controls to Vidéo player
       if (videoPlayer) {
-        videoPlayer.forEach(m => {
-          m.setAttribute('controls', true)
+        videoPlayer.forEach(v => {
+          v.setAttribute('controls', true)
         })
       }
 
+      // Add controls to Audio player
       if (audioPlayer) {
         audioPlayer.forEach(a => {
           a.setAttribute('controls', true)
         })
       }
 
+      // Add onClick event on Toggle
       if (dropdownDiv) {
         dropdownDiv.forEach(d => {
           d.addEventListener('click', () => {
@@ -77,7 +80,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           box-shadow: 38px 24px 50px -21px lightGrey;
         }
 
-        .kg-image-card img {
+        .kg-image-card img,
+        .kg-product-card img {
           width: auto;
           max-width: 100%;
           height: auto;
@@ -86,7 +90,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           box-shadow: 38px 24px 50px -21px #C9D3DF;
         }
 
-        .blog-image, .blog-feature-image {
+        .blog-image,
+        .blog-feature-image {
           border-radius: 4px;
         }
 
@@ -107,11 +112,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
           text-align: center;
         }
 
-        .kg-bookmark-card, .kg-callout-card {
-          position: relative;
-          width: 85%;
-          margin: 1em auto;
-        }
+      {/***** Callout Block *****/}
 
         .kg-callout-card {
           width: 100%;
@@ -120,10 +121,19 @@ function Post({title, published_at, feature_image, html, backLink}) {
           padding: 1.2em;
           border-radius: 3px;
           font-size: 1.3rem;
+          margin: 1em auto;
         }
 
         .kg-callout-emoji {
           margin-right: .5em;
+        }
+
+      {/***** Bookmark Block *****/}
+
+        .kg-bookmark-card {
+          position: relative;
+          width: 85%;
+          margin: 1em auto;
         }
 
         .kg-bookmark-card a.kg-bookmark-container {
@@ -151,12 +161,6 @@ function Post({title, published_at, feature_image, html, backLink}) {
           position: relative;
           flex-grow: 1;
           min-width: 33%;
-        }
-
-        .kg-bookmark-title {
-          font-size: 1.5 em;
-          line-height: 1.4 em;
-          font-weight: 600;
         }
 
         .kg-bookmark-description {
@@ -192,6 +196,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           border-radius: 0 2px 2px 0;
         }
 
+      {/***** Gallery Block *****/}
+
         .kg-gallery-row {
           contain: content;
           display: grid;
@@ -206,6 +212,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           border-radius: 8px;
           margin: auto;
         }
+
+      {/***** Button Block *****/}
 
         .kg-align-center {
           text-align: center;
@@ -223,6 +231,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           text-decoration: none;
           transition: all .2s ease;
         }
+
+      {/***** Toggle Block *****/}
 
         .kg-toggle-card {
           background: 0 0;
@@ -248,11 +258,6 @@ function Post({title, published_at, feature_image, html, backLink}) {
           border: none;
         }
 
-        .kg-toggle-card-icon svg {
-          height: 24px;
-          width: 24px;
-        }
-
         .toggled {
           transform: rotate(180deg);
         }
@@ -274,34 +279,14 @@ function Post({title, published_at, feature_image, html, backLink}) {
           position: relative;
         }
 
-        .kg-video-overlay {
-          display: none;
-        }
+      {/***** Video Block *****/}
 
         .kg-video-container video {
           width: 100%;
           height: 100%;
         }
 
-        video {
-          controls: true;
-        }
-
-        .kg-video-large-play-icon, .kg-video-player {
-          display: none;
-        }
-
-        .kg-video-player-container {
-          display: none;
-        }
-
-        .kg-video-player {
-          display: none;
-        }
-
-        .kg-video-play-icon svg {
-          display: none;
-        }
+      {/***** Audio Block *****/}
 
         .kg-audio-card {
           display: flex;
@@ -324,14 +309,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
           border-radius: 5px;
         }
 
-        .kg-audio-title, .kg-file-card-title {
-          padding: .5em;
-          font-size: 1.3em;
-        }
-
-        .kg-audio-player, .kg-audio-thumbnail {
-          display: none;
-        }
+      {/***** File Block *****/}
 
         .kg-file-card-container {
           display: flex;
@@ -365,11 +343,6 @@ function Post({title, published_at, feature_image, html, backLink}) {
           margin-left: 1em;
         }
 
-        .kg-file-card-icon svg {
-          height: 24px;
-          width: 24px;
-        }
-
         .kg-file-card-icon {
           position: relative;
           display: flex;
@@ -379,6 +352,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           min-width: 80px;
           background-color: ${colors.lighterGrey}
         }
+
+      {/***** Header Block *****/}
 
         .kg-header-card {
           padding: 4em;
@@ -390,6 +365,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
           color: white;
           margin-bottom: 1em;
         }
+
+      {/***** Product Block *****/}
 
         .kg-product-card {
           display: flex;
@@ -406,6 +383,38 @@ function Post({title, published_at, feature_image, html, backLink}) {
           border-radius: 5px;
           box-shadow: inset 0 0 0 1px rgb(124 139 154/25%);
           margin-bottom: 1em;
+        }
+
+      {/***** Card Titles *****/}
+
+        .kg-bookmark-title,
+        .kg-audio-title,
+        .kg-file-card-title {
+          color: #111;
+          font-size: 1.5em;
+          line-height: 1.4em;
+          font-weight: 600;
+          padding: .5em;
+        }
+
+      {/***** Hidden Elements *****/}
+
+        .kg-audio-player,
+        .kg-audio-thumbnail,
+        .kg-video-overlay,
+        .kg-video-large-play-icon,
+        .kg-video-player,
+        .kg-video-player-container,
+        .kg-video-play-icon svg {
+          display: none;
+        }
+
+      {/***** Icons *****/}
+
+        .kg-toggle-card-icon svg,
+        .kg-file-card-icon svg {
+          height: 24px;
+          width: 24px;
         }
         `}</style>
     </Section>

--- a/components/post.js
+++ b/components/post.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'

--- a/components/post.js
+++ b/components/post.js
@@ -10,7 +10,14 @@ import Section from '@/components/section'
 function Post({title, published_at, feature_image, html, backLink}) {
   useEffect(() => {
     if (html) {
+      const videoPlayer = [...document.querySelectorAll('video')]
       const dropdownDiv = [...document.querySelectorAll('div.kg-card.kg-toggle-card')]
+
+      if (videoPlayer) {
+        videoPlayer.forEach(m => {
+          m.setAttribute('controls', true)
+        })
+      }
 
       if (dropdownDiv) {
         dropdownDiv.forEach(d => {
@@ -258,6 +265,35 @@ function Post({title, published_at, feature_image, html, backLink}) {
           opacity: 0;
           top: -.5em;
           position: relative;
+        }
+
+        .kg-video-overlay {
+          display: none;
+        }
+
+        .kg-video-container video {
+          width: 100%;
+          height: 100%;
+        }
+
+        video {
+          controls: true;
+        }
+
+        .kg-video-large-play-icon, .kg-video-player {
+          display: none;
+        }
+
+        .kg-video-player-container {
+          display: none;
+        }
+
+        .kg-video-player {
+          display: none;
+        }
+
+        .kg-video-play-icon svg {
+          display: none;
         }
         `}</style>
     </Section>

--- a/components/post.js
+++ b/components/post.js
@@ -141,7 +141,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
 
         .kg-bookmark-card {
           position: relative;
-          width: 85%;
+          width: 100%;
           margin: 1em auto;
         }
 
@@ -186,7 +186,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
           margin-top: 22px;
           width: 100%;
           font-weight: 500;
-          word-break: break-word;
+          white-space: nowrap;
         }
 
         .kg-bookmark-icon {
@@ -215,7 +215,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
           contain: content;
           display: grid;
           grid-gap: .5em;
-          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         }
 
         .kg-gallery-image img {
@@ -404,8 +404,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
         .kg-audio-title,
         .kg-file-card-title {
           color: #111;
-          font-size: 1.5em;
-          line-height: 1.4em;
+          font-size: 1.3em;
+          line-height: 1.1em;
           font-weight: 600;
           padding: .5em;
         }
@@ -429,7 +429,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
           height: 24px;
           width: 24px;
         }
-        `}</style>
+      `}</style>
     </Section>
   )
 }

--- a/components/post.js
+++ b/components/post.js
@@ -1,3 +1,4 @@
+import {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -7,6 +8,26 @@ import colors from  '@/styles/colors'
 import Section from '@/components/section'
 
 function Post({title, published_at, feature_image, html, backLink}) {
+  useEffect(() => {
+    if (html) {
+      const dropdownDiv = [...document.querySelectorAll('div.kg-card.kg-toggle-card')]
+
+      if (dropdownDiv) {
+        dropdownDiv.forEach(d => {
+          d.addEventListener('click', () => {
+            if (d.attributes['data-kg-toggle-state'].value === 'close') {
+              d.dataset.kgToggleState = 'open'
+              d.children[0].lastChild.lastChild.classList.add('toggled')
+            } else {
+              d.dataset.kgToggleState = 'close'
+              d.children[0].lastChild.lastChild.classList.remove('toggled')
+            }
+          })
+        })
+      }
+    }
+  }, [html])
+
   return (
     <Section>
       <Link href={backLink}>
@@ -187,6 +208,56 @@ function Post({title, published_at, feature_image, html, backLink}) {
           margin: auto;
           text-decoration: none;
           transition: all .2s ease;
+        }
+
+        .kg-toggle-card {
+          background: 0 0;
+          box-shadow: inset 0 0 0 1px rgba(124,139,154,.25);
+          border-radius: 4px;
+          padding: 1.2em;
+          margin-bottom: .5em;
+        }
+
+        .kg-toggle-heading {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          cursor: pointer;
+        }
+
+        .kg-toggle-heading h4 {
+          margin-bottom: 0;
+        }
+
+        button.kg-toggle-card-icon {
+          background-color: white;
+          border: none;
+        }
+
+        .kg-toggle-card-icon svg {
+          height: 24px;
+          width: 24px;
+        }
+
+        .toggled {
+          transform: rotate(180deg);
+        }
+
+        .kg-toggle-content {
+          height: auto;
+          opacity: 1;
+          transition: opacity 1s ease,top .35s ease;
+          top: 0;
+          position: relative;
+        }
+
+        .kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content {
+          height: 0;
+          overflow: hidden;
+          transition: opacity .5s ease,top .35s ease;
+          opacity: 0;
+          top: -.5em;
+          position: relative;
         }
         `}</style>
     </Section>

--- a/components/post.js
+++ b/components/post.js
@@ -159,12 +159,12 @@ function Post({title, published_at, feature_image, html, backLink}) {
         .kg-bookmark-content {
           display: flex;
           flex-direction: column;
+          padding: 20px;
+          overflow: hidden;
           flex-grow: 1;
           flex-basis: 100%;
           align-items: flex-start;
           justify-content: flex-start;
-          padding: 20px;
-          overflow: hidden;
         }
 
         .kg-bookmark-thumbnail {
@@ -173,12 +173,19 @@ function Post({title, published_at, feature_image, html, backLink}) {
           min-width: 33%;
         }
 
+        .kg-bookmark-title {
+          color: #111;
+          font-size: 1.1em;
+          line-height: 1.1em;
+          font-weight: 400;
+        }
+
         .kg-bookmark-description {
           margin-top: 3px;
           font-size: 14px;
           max-height: 55px;
-          overflow-y: hidden;
           opacity: .7;
+          overflow: hidden;
         }
 
         .kg-bookmark-metadata {
@@ -198,6 +205,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
 
         .kg-bookmark-author {
           padding-right: .5em;
+          text-overflow: ellipsis;
+          overflow: hidden;
         }
 
         .kg-bookmark-thumbnail img {
@@ -401,7 +410,6 @@ function Post({title, published_at, feature_image, html, backLink}) {
 
       {/***** Card Titles *****/}
 
-        .kg-bookmark-title,
         .kg-audio-title,
         .kg-file-card-title {
           color: #111;

--- a/components/post.js
+++ b/components/post.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Image from 'next/image'
 import {ArrowLeftCircle} from 'react-feather'
+import colors from  '@/styles/colors'
 
 import Section from '@/components/section'
 
@@ -141,6 +142,19 @@ function Post({title, published_at, feature_image, html, backLink}) {
           top: 0;
           left: 0;
           border-radius: 0 2px 2px 0;
+        }
+
+        .kg-button-card a {
+          color: white;
+          background-color: ${colors.blue};
+          border-radius: 5px;
+          font-weight: 1em;
+          padding: .5em 1.2em;
+          height: 2.4em;
+          line-height: 1em;
+          margin: auto;
+          text-decoration: none;
+          transition: all .2s ease;
         }
         `}</style>
     </Section>

--- a/components/post.js
+++ b/components/post.js
@@ -72,10 +72,23 @@ function Post({title, published_at, feature_image, html, backLink}) {
           text-align: center;
         }
 
-        .kg-bookmark-card {
+        .kg-bookmark-card, .kg-callout-card {
           position: relative;
           width: 85%;
           margin: 1em auto;
+        }
+
+        .kg-callout-card {
+          width: 100%;
+          display: flex;
+          background-color: ${colors.lighterBlue};
+          padding: 1.2em;
+          border-radius: 3px;
+          font-size: 1.3rem;
+        }
+
+        .kg-callout-emoji {
+          margin-right: .5em;
         }
 
         .kg-bookmark-card a.kg-bookmark-container {

--- a/components/post.js
+++ b/components/post.js
@@ -10,12 +10,19 @@ import Section from '@/components/section'
 function Post({title, published_at, feature_image, html, backLink}) {
   useEffect(() => {
     if (html) {
+      const audioPlayer = [...document.querySelectorAll('audio')]
       const videoPlayer = [...document.querySelectorAll('video')]
       const dropdownDiv = [...document.querySelectorAll('div.kg-card.kg-toggle-card')]
 
       if (videoPlayer) {
         videoPlayer.forEach(m => {
           m.setAttribute('controls', true)
+        })
+      }
+
+      if (audioPlayer) {
+        audioPlayer.forEach(a => {
+          a.setAttribute('controls', true)
         })
       }
 
@@ -293,6 +300,36 @@ function Post({title, published_at, feature_image, html, backLink}) {
         }
 
         .kg-video-play-icon svg {
+          display: none;
+        }
+
+        .kg-audio-card {
+          display: flex;
+          width: 100%;
+          padding: .5em;
+          margin-bottom: 1em;
+          min-height: 96px;
+          border-radius: 3px;
+          box-shadow: inset 0 0 0 1px rgba(124,139,154,.25);
+        }
+
+        .kg-audio-player-container {
+          display: flex;
+          flex-direction: column-reverse;
+          width: 100%;
+        }
+
+        .kg-audio-player-container audio {
+          width: 100%;
+          border-radius: 5px;
+        }
+
+        .kg-audio-title, .kg-file-card-title {
+          padding: .5em;
+          font-size: 1.3em;
+        }
+
+        .kg-audio-player, .kg-audio-thumbnail {
           display: none;
         }
         `}</style>

--- a/components/post.js
+++ b/components/post.js
@@ -144,6 +144,25 @@ function Post({title, published_at, feature_image, html, backLink}) {
           border-radius: 0 2px 2px 0;
         }
 
+        .kg-gallery-row {
+          contain: content;
+          display: grid;
+          grid-gap: .5em;
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        }
+
+        .kg-gallery-image img {
+          width: auto;
+          max-width: 100%;
+          height: auto;
+          border-radius: 8px;
+          margin: auto;
+        }
+
+        .kg-align-center {
+          text-align: center;
+        }
+
         .kg-button-card a {
           color: white;
           background-color: ${colors.blue};

--- a/components/post.js
+++ b/components/post.js
@@ -186,6 +186,10 @@ function Post({title, published_at, feature_image, html, backLink}) {
           margin-right: 6px;
         }
 
+        .kg-bookmark-author {
+          padding-right: .5em;
+        }
+
         .kg-bookmark-thumbnail img {
           width: 100%;
           height: 100%;


### PR DESCRIPTION
## Prise en charge du CSS des blocs Ghost :  

Les articles en provenance du blog Ghost utilisent certaines classes CSS spéciales qui n’étaient pas prises en charge, créant un affichage chaotique.

Cette PR propose la prise en charge des blocs Ghost principaux : 
- Bookmark (MAJ)
- Image
- Gallery
- HTML
- Markdown
- Divider
- Button
- Toggle
- Header
- File
- Video
- Audio 
- Callout
- Product
