### PR TITLE
Changer la date du webinaire du 26 mai

### DIFF
--- a/events.json
+++ b/events.json
@@ -455,7 +455,7 @@
     "description": "L’équipe du Programme Bases Adresses Locales propose aux communes qui le souhaitent un webinaire sur l'éditeur Mes Adresses. Au menu, les fonctions de bases à partir de la création d'une BAL et les points de vigilance #qualité",
     "type": "formation",
     "target": "commune",
-    "date": "2022-05-26",
+    "date": "2022-05-20",
     "tags": [
       "Programme Base Adresse Locale",
       "Base Adresse Locale",


### PR DESCRIPTION
Close #1086

Le 26 étant férié, la date change pour le 20 mai