### PR TITLE
Blog: Affichage de l’auteur et optimisations visuelles

### DIFF
--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -78,8 +78,6 @@ function BlogCard({post, onClick}) {
           margin: 0;
           font-size: 0.8em;
           font-style: italic;
-          display: flex;
-          justify-content: end;
         }
 
         .preview {

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -16,6 +16,7 @@ function BlogCard({post, onClick}) {
         <Image src={post.feature_image || '/images/no-img.png'} alt={post.title} layout='fill' objectFit={post.feature_image ? 'cover' : 'contain'} />
       </div>
       <div className='infos-container'>
+        <p>Publié par {post.authors[0].name}</p>
         <p>Le {new Date(post.published_at).toLocaleDateString('fr-FR')}</p>
       </div>
       <p className='preview'>{post.excerpt}</p>
@@ -68,7 +69,9 @@ function BlogCard({post, onClick}) {
 
         .infos-container {
           display: flex;
-          flex-direction: column;
+          justify-content: space-between;
+          padding-top: .5em;
+          border-bottom: 2px solid ${colors.blue};
         }
 
         .infos-container p {
@@ -77,7 +80,6 @@ function BlogCard({post, onClick}) {
           font-style: italic;
           display: flex;
           justify-content: end;
-          border-bottom: 2px solid ${colors.blue};
         }
 
         .preview {

--- a/components/post.js
+++ b/components/post.js
@@ -14,13 +14,12 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
 
       <div className='blog'>
         <h2>{title}</h2>
-        <p className='infos-container'><i>Publié par {authors[0].name}</i> <i>le {new Date(published_at).toLocaleDateString('fr-FR')}</i></p>
         {feature_image && (
           <div className='blog-feature-image-container'>
             <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' />
           </div>
         )}
-        <div className='blog-separator' />
+        <p className='infos-container'><i>Publié par {authors[0].name}</i> <i>le {new Date(published_at).toLocaleDateString('fr-FR')}</i></p>
         <div dangerouslySetInnerHTML={{__html: html}} /* eslint-disable-line react/no-danger */ />
         <div className='blog-separator' />
       </div>

--- a/components/post.js
+++ b/components/post.js
@@ -13,7 +13,7 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
       </Link>
 
       <div className='blog'>
-        <h2>{title}</h2>
+        <h3>{title}</h3>
         {feature_image && (
           <div className='blog-feature-image-container'>
             <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' />
@@ -36,7 +36,7 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
 
         .blog-feature-image-container {
           position: relative;
-          height: 500px;
+          height: 250px;
           box-shadow: 38px 24px 50px -21px lightGrey;
         }
 

--- a/components/post.js
+++ b/components/post.js
@@ -5,7 +5,7 @@ import {ArrowLeftCircle} from 'react-feather'
 
 import Section from '@/components/section'
 
-function Post({title, published_at, feature_image, html, backLink}) {
+function Post({title, published_at, feature_image, authors, html, backLink}) {
   return (
     <Section>
       <Link href={backLink}>
@@ -14,7 +14,7 @@ function Post({title, published_at, feature_image, html, backLink}) {
 
       <div className='blog'>
         <h2>{title}</h2>
-        <p><i>Publié le {new Date(published_at).toLocaleDateString('fr-FR')}</i></p>
+        <p className='infos-container'><i>Publié par {authors[0].name}</i> <i>le {new Date(published_at).toLocaleDateString('fr-FR')}</i></p>
         {feature_image && (
           <div className='blog-feature-image-container'>
             <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' />
@@ -55,7 +55,8 @@ function Post({title, published_at, feature_image, html, backLink}) {
         }
 
         .blog-separator {
-          border-bottom: 2px solid #0053B3;
+          border-bottom: 1px solid #0053B3;
+          padding: .5em;
         }
 
         .blog-back-button {
@@ -69,6 +70,12 @@ function Post({title, published_at, feature_image, html, backLink}) {
 
         .blog figure.kg-card {
           text-align: center;
+        }
+
+        .infos-container {
+          display: flex;
+          justify-content: space-between;
+          border-bottom: 1px solid #0053B3;
         }
 
         .kg-bookmark-card {
@@ -155,6 +162,7 @@ Post.propTypes = {
   title: PropTypes.string.isRequired,
   published_at: PropTypes.string.isRequired,
   feature_image: PropTypes.string,
+  authors: PropTypes.array.isRequired,
   html: PropTypes.string.isRequired,
   backLink: PropTypes.string.isRequired
 }

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -23,7 +23,7 @@ export async function getPosts() {
 
 export async function getSinglePost(slug) {
   try {
-    const res = await fetch(`${URL}/ghost/api/v3/content/posts/slug/${slug}/?key=${KEY}`)
+    const res = await fetch(`${URL}/ghost/api/v3/content/posts/slug/${slug}/?key=${KEY}&include=authors`)
     if (res.ok) {
       const data = await res.json()
       return data.posts[0]

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -83,6 +83,7 @@ function BlogIndex({posts}) {
       </Section>
       <style jsx>{`
         .blog-section {
+          padding-top: 1em;
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
           grid-gap: 3em 5em;


### PR DESCRIPTION
**_Cette PR propose d’afficher le nom de l’auteur de l'article et quelques modifications visuelles._**

### Affichage du nom de l’auteur : 

Le nom de la personne ayant rédigé l'article est maintenant affiché sur la page `/blog` ainsi que sur la page affichant l’article.

### Modifications visuelles : 

- Le nom de l’auteur ainsi que la date de publication de l’article sont maintenant affichés en dessous de la `feature_image`
- La hauteur de la `feature_image` a été réduite pour plus de lisibilité de l’article
- La taille du titre a été réduite

### Captures : 

#### Avant : 

![image](https://user-images.githubusercontent.com/56537238/159923192-136f3cb8-1611-4dd0-ad27-89f4d0cddd55.png)

#### Après : 

![image](https://user-images.githubusercontent.com/56537238/159923269-378caf28-e044-4cb0-925b-48097acbb1b5.png)
