### PR TITLE
Mise à jour du fichier PDF en page d’accueil

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -106,7 +106,7 @@ function Home({stats, posts}) {
         <DocDownload
           src='/images/previews/obligations-adresse-preview.png'
           alt='miniature du document obligations-adresse'
-          link='https://adresse.data.gouv.fr/data/docs/communes-operateurs-obligations-adresse.pdf'
+          link='https://adresse.data.gouv.fr/data/docs/communes-operateurs-obligations-adresse-v2.0.pdf'
         >
           <SectionText>
             <p>


### PR DESCRIPTION
Cette PR propose de modifier le lien du fichier `commune-operateurs-obligations-adresse.pdf` vers sa version v2.0

Fix #1101
