### PR TITLE
Encourager les communes à être référencée comme partenaire

### DIFF
--- a/components/bases-locales/charte/search-partners-results.js
+++ b/components/bases-locales/charte/search-partners-results.js
@@ -7,54 +7,45 @@ import Notification from '@/components/notification'
 function SearchPartnersResults({companies, organizations, communes}) {
   return (
     <div>
-      <div>
-        <div className='title'>Communes - échelon de compétence</div>
+      <div className='contact-container'>
+        <div className='subscription-indication'>Vous souhaitez être référencé comme Partenaire de la Charte de la Base Adresse Nationale, contactez nous.</div>
+        <Notification isFullWidth>
+          <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} />
+          Pour en faire partie, vous pouvez nous contacter à l’adresse suivante: <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr.</a>
+        </Notification>
+      </div>
+
+      <div className='partner-section'>
+        <div className={`title ${communes.length === 0 && 'disabled'}`}>Communes - échelon de compétence</div>
         {communes.length > 0 ? (
           <div className='partners-container'>
             {communes.map(partner => <Partner key={partner.name} partnerInfos={partner} isCommune />)}
           </div>
         ) : (
-          <div className='contact-container'>
-            <div className='no-found'>Votre commune n’est pas encore référencée comme Partenaire de la Charte de la Base Adresse Locale.</div>
-            <Notification isFullWidth>
-              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} />
-              Pour en faire partie, vous pouvez nous contacter à l’adresse suivante: <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr.</a>
-            </Notification>
-          </div>
+          <div className='no-found'>Votre commune n’est pas encore référencée comme Partenaire de la Charte de la Base Adresse Locale.</div>
         )}
       </div>
 
-      <div>
-        <div className='title'>Organismes</div>
+      <div className='partner-section'>
+        <div className={`title ${organizations.length === 0 && 'disabled'}`}>Organismes</div>
         {organizations.length > 0 ? (
           <div className='partners-container'>
             {organizations.map(partner => <Partner key={partner.name} partnerInfos={partner} />)}
           </div>
         ) : (
-          <div className='contact-container'>
-            <div className='no-found'>Aucun organisme de mutualisation n’est référencé comme Partenaire de la Charte de la Base Adresse Locale dans ce département.</div>
-            <Notification isFullWidth>
-              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} />
-              Pour en faire partie, vous pouvez nous contacter à l’adresse suivante: <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr.</a>
-            </Notification>
-          </div>
+          <div className='no-found'>Aucun organisme de mutualisation n’est référencé comme Partenaire de la Charte de la Base Adresse Locale dans ce département.</div>
+
         )}
       </div>
 
-      <div className='organizations-container'>
-        <div className='title'>Entreprises</div>
+      <div className='partner-section'>
+        <div className={`title ${companies.length === 0 && 'disabled'}`}>Entreprises</div>
         {companies.length > 0 ? (
           <div className='partners-container'>
             {companies.map(partner => <Partner key={partner.name} partnerInfos={partner} />)}
           </div>
         ) : (
-          <div className='contact-container'>
-            <div className='no-found'>Aucune entreprise n’est référencée comme Partenaire de la Charte de la Base Adresse Locale dans ce département.</div>
-            <Notification isFullWidth>
-              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} />
-              Pour en faire partie, vous pouvez nous contacter à l’adresse suivante: <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr.</a>
-            </Notification>
-          </div>
+          <div className='no-found'>Aucune entreprise n’est référencée comme Partenaire de la Charte de la Base Adresse Locale dans ce département.</div>
         )}
       </div>
 
@@ -68,14 +59,17 @@ function SearchPartnersResults({companies, organizations, communes}) {
           gap: 6em 5em;
         }
 
-        .organizations-container {
+        .partner-section {
           margin-top: 4em;
         }
 
-        .no-found {
-          text-align: center;
+        .no-found, .subscription-indication {
           margin: 1em 0;
           font-style: italic;
+        }
+
+        .subscription-indication {
+          text-align: center;
         }
 
         .title {
@@ -85,6 +79,10 @@ function SearchPartnersResults({companies, organizations, communes}) {
 
         .contact-container {
           margin: 2em 0 4em 0;
+        }
+
+        .disabled {
+          opacity: 60%;
         }
       `}</style>
     </div>


### PR DESCRIPTION
Close #1110

Le message invitant à se référencer en tant que partenaire de la Charte ne s'affichait que si aucun partenaire n'était trouvé dans sa catégorie (communes, organismes ou sociétés).
Cette section avec un bouton contact est à présent visible par défaut à l'affichage des résultats de la recherche.

### **AVANT**
![Capture d’écran 2022-04-13 à 15 43 37](https://user-images.githubusercontent.com/66621960/163199934-839fca4e-4f3c-478f-bef5-cf0a5aace357.png)

### **APRÈS**
![Capture d’écran 2022-04-13 à 15 54 57](https://user-images.githubusercontent.com/66621960/163199958-dfff7839-59a8-4e6c-b8ee-51d60fd6459e.png)
