### PR TITLE
Avertissement XO concernant les variables en camel case oubliées

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -25,7 +25,7 @@ SlugPage.propTypes = {
   post: PropTypes.shape({
     title: PropTypes.string.isRequired,
     excerpt: PropTypes.string.isRequired,
-    feature_image: PropTypes.string
+    feature_image: PropTypes.string /* eslint-disable-line camelcase */
   })
 }
 


### PR DESCRIPTION
Close #1097

La plupart des alertes pour les variables en camel case ont été traitées dans ce [commit ](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/pull/1087/commits/89a90b86bd65071cc6f13b19df3be4759fae9f94) fait par Guillaume sur cette [PR](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/pull/1087) (mergée à ce jour).

Or, un avertissement a été oublié et est donc corrigé ici