### PR TITLE
Corrige les erreurs 500 dans l’explorateur BAN

### DIFF
--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -24,7 +24,7 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
 
   const coordinates = {lat, lon}
   const copyUnvailableMessage = `Votre navigateur est incompatible avec la copie des coordonnées GPS : ${lat},${lon}`
-  const sanitizedType = positionType.charAt(0).toUpperCase() + positionType.slice(1)
+  const sanitizedType = positionType ? (positionType.charAt(0).toUpperCase() + positionType.slice(1)) : 'Inconnu'
 
   return (
     <>

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -142,7 +142,8 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
 }
 
 Numero.defaultProps = {
-  isMobile: false
+  isMobile: false,
+  positionType: null
 }
 
 Numero.propTypes = {
@@ -167,7 +168,7 @@ Numero.propTypes = {
   libelleAcheminement: PropTypes.string.isRequired,
   codePostal: PropTypes.string.isRequired,
   cleInterop: PropTypes.string.isRequired,
-  positionType: PropTypes.string.isRequired,
+  positionType: PropTypes.string,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,
   isMobile: PropTypes.bool


### PR DESCRIPTION
## Problème : 
Des utilisateurs ont découvert que lorsque l’on clique sur certains numéros dans [l’explorateur BAN](https://adresse.data.gouv.fr/base-adresse-nationale/05085_0160#16.51/44.9298/6.718), celui-ci renvoi une erreur 500.

Le problème vient de la propriété `positionType` qui est parfois `null`.

## Correction : 
Cette PR propose d’ajouter une condition qui vérifie si la propriété `positionType` existe.
Dans le cas où elle n’existe pas, cette propriété sera définie comme "(Type : ) Inconnu".
