### PR TITLE
Résolution problème d'affichage du partenaire Égliseneuve

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -1036,8 +1036,8 @@
         "partage d'expérience"
       ],
       "picture": "/images/logos/partners/communes/egliseneuve-des-liards.jpg",
-      "height": 115,
-      "width": 288,
+      "height": 93,
+      "width": 232,
       "alt": "Blason de la commune de Égliseneuve-des-Liards",
       "signatureDate": "2021-05-11"
     },


### PR DESCRIPTION
Cette PR corrige la taille du logo de la commune partenaire Égliseneuve afin d'éviter les problèmes d'affichage avant le wrap des cartes partenaires sur la page [/bases-locales](http://localhost:3000/bases-locales) 


### **AVANT**
<img width="1202" alt="Capture d’écran 2022-05-02 à 13 25 43" src="https://user-images.githubusercontent.com/66621960/166422832-6cdcbb38-b30f-431c-9f40-b1ae2bcbf6e5.png">


### **APRÈS**
<img width="1146" alt="Capture d’écran 2022-05-03 à 10 16 11" src="https://user-images.githubusercontent.com/66621960/166422772-9f4a6d80-bb8f-4855-b850-551272081f04.png">

Close #1138