### PR TITLE
Fix des duplicatas concernant les départements avec des partenaires

### DIFF
--- a/pages/bases-locales/charte/communes.js
+++ b/pages/bases-locales/charte/communes.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import Image from 'next/image'
-import {groupBy, sum} from 'lodash'
+import {groupBy, sum, uniq} from 'lodash'
 import {Award, Mail} from 'react-feather'
 
 import {getDepartementByCode, getRegions} from '@/lib/api-geo'
@@ -86,12 +86,13 @@ export async function getServerSideProps() {
   return {
     props: {
       regions: await Promise.all(regions.map(async region => {
-        const departementsCode = partners.communes.filter(({codeRegion}) => codeRegion === region.code).map(({codeDepartement}) => codeDepartement[0])
+        const departementsCode = uniq(partners.communes.filter(({codeRegion}) => codeRegion === region.code).map(({codeDepartement}) => codeDepartement[0]))
 
         return {
           ...region,
           departements: await Promise.all(departementsCode.map(async codeDepartement => {
             const departement = await getDepartementByCode(codeDepartement)
+
             return {
               ...departement,
               communes: communesByDepartement[codeDepartement]

--- a/partners.json
+++ b/partners.json
@@ -1221,7 +1221,7 @@
     {
       "name": "Commune de Castillon-Savès",
       "link": "https://castillon-saves.fr/au-quotidien/plan-de-la-commune",
-      "codeRegion": "",
+      "codeRegion": "76",
       "codeDepartement": [
         "32"
       ],


### PR DESCRIPTION
Suite au constat d'un oubli dans le json des partenaires (`codeRegion` dans la commune de Castillon-Savès), un bug a également été décelé.
À savoir que lorsqu'un département contient plus d'une commune partenaire, celui-ci s'affiche autant de fois qu'il a de communes.

Cette PR ajoute donc le codeRegion oublié et corrige dans la foulée le bug de duplicata de département.

### **Bug lors de l'ajout du codeRegion dans la commune de Castillon-Savès**
<img width="1154" alt="168612739-0836e776-9ba6-40aa-b27c-8d68d7728f6e" src="https://user-images.githubusercontent.com/66621960/168622657-df2725fa-b022-42a0-9e31-7db74c88b8d4.png">

### **Après résolution du bug**
<img width="1187" alt="Capture d’écran 2022-05-16 à 16 59 52" src="https://user-images.githubusercontent.com/66621960/168623062-84e53726-8410-47ac-ae2d-b25f17877447.png">


Close #1158