### PR TITLE
Modification wording du partenaire Pôle Marennes Oléron

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -892,7 +892,7 @@
       "name": "Pôle Marennes Oléron",
       "link": "https://www.marennes-oleron.com/adresse-accompagnement-des-communes/",
       "infos": "Le Pôle Marennes Oléron, à travers son Système d'Information Territoriale, accompagne les communes de son territoire à travailler sur l’adresse, en les formant à la thématique et en leur mettant en place des solutions à façon.",
-      "perimeter": "17 communes des communautés de communes de l’Île d’Oléron et du Bassin de Marennes",
+      "perimeter": "14 communes des communautés de communes de l’Île d’Oléron et du Bassin de Marennes",
       "codeDepartement": [
         "17"
       ],


### PR DESCRIPTION
`Communes concernées : 17 communes des communautés de communes de l’Île d’Oléron et du Bassin de Marennes (département 17, Charente maritime)` 
**devient** 
`Communes concernées : 14 communes des communautés de communes de l’Île d’Oléron et du Bassin de Marennes (département 17, Charente maritime)`
 ### **AVANT**
<img width="367" alt="Capture d’écran 2022-05-17 à 16 25 35" src="https://user-images.githubusercontent.com/66621960/168835717-ce8af080-8e9f-4478-bb5f-463d275211f2.png">

 ### **APRÈS**
<img width="427" alt="Capture d’écran 2022-05-17 à 16 25 20" src="https://user-images.githubusercontent.com/66621960/168835707-789c3a3a-89d5-4bd9-80b0-cb813d07ede9.png">


Close  #1143