### PR TITLE
Résolution problème affichage adresse des COM

### DIFF
--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -13,7 +13,7 @@ import Tabs from '@/components/base-adresse-nationale/commune/tabs'
 import Notification from '@/components/notification'
 import Voie from './voie'
 
-function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, nbNumeros, nbNumerosCertifies, nbLieuxDits, population, codesPostaux, typeComposition}) {
+function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, nbNumeros, nbNumerosCertifies, nbLieuxDits, population, codesPostaux, typeComposition, isCOM}) {
   const [activeTab, setActiveTab] = useState('VOIES')
 
   const isAllCertified = nbNumeros > 0 && nbNumeros === nbNumerosCertifies
@@ -30,7 +30,9 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
       <div className='heading'>
         <div>
           <h2><a href={`/commune/${codeCommune}`}>{nomCommune} - {codeCommune}</a></h2>
-          <div className='region'>{region.nom} - {departement.nom} ({departement.code})</div>
+          <div className='region'>
+            {isCOM ? `Collectivité d’outremer - ${region.nom} (${region.code})` : `${region.nom} - ${departement.nom} (${departement.code})`}
+          </div>
         </div>
         <div style={{padding: '1em'}}>
           <Certification
@@ -131,14 +133,16 @@ Commune.propTypes = {
   nbNumeros: PropTypes.number.isRequired,
   nbNumerosCertifies: PropTypes.number.isRequired,
   region: PropTypes.shape({
-    nom: PropTypes.string.isRequired
+    nom: PropTypes.string.isRequired,
+    code: PropTypes.string.isRequired
   }).isRequired,
   departement: PropTypes.shape({
     code: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired
   }).isRequired,
   population: PropTypes.number.isRequired,
-  codesPostaux: PropTypes.array.isRequired
+  codesPostaux: PropTypes.array.isRequired,
+  isCOM: PropTypes.bool
 }
 
 export default Commune

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -31,7 +31,6 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
         <div>
           <h2><a href={`/commune/${codeCommune}`}>{nomCommune} - {codeCommune}</a></h2>
           <RegionInfos
-            title={`${nomCommune} - ${codeCommune}`}
             codeCommune={codeCommune}
             region={region}
             departement={departement}

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -3,17 +3,17 @@ import PropTypes from 'prop-types'
 import {orderBy} from 'lodash'
 import {CheckCircle} from 'react-feather'
 
-import colors from '@/styles/colors'
 import theme from '@/styles/theme'
 
 import Certification from '../certification'
 import AddressesList from '../addresses-list'
+import RegionInfos from '../region-infos'
 import Details from '@/components/base-adresse-nationale/commune/details'
 import Tabs from '@/components/base-adresse-nationale/commune/tabs'
 import Notification from '@/components/notification'
 import Voie from './voie'
 
-function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, nbNumeros, nbNumerosCertifies, nbLieuxDits, population, codesPostaux, typeComposition, isCOM}) {
+function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, nbNumeros, nbNumerosCertifies, nbLieuxDits, population, codesPostaux, typeComposition}) {
   const [activeTab, setActiveTab] = useState('VOIES')
 
   const isAllCertified = nbNumeros > 0 && nbNumeros === nbNumerosCertifies
@@ -30,9 +30,12 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
       <div className='heading'>
         <div>
           <h2><a href={`/commune/${codeCommune}`}>{nomCommune} - {codeCommune}</a></h2>
-          <div className='region'>
-            {isCOM ? `Collectivité d’outremer - ${region.nom} (${region.code})` : `${region.nom} - ${departement.nom} (${departement.code})`}
-          </div>
+          <RegionInfos
+            title={`${nomCommune} - ${codeCommune}`}
+            codeCommune={codeCommune}
+            region={region}
+            departement={departement}
+          />
         </div>
         <div style={{padding: '1em'}}>
           <Certification
@@ -108,13 +111,6 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
           margin-bottom: 0.2em;
         }
 
-        .region {
-          margin-top: 0.5em;
-          font-style: italic;
-          font-size: 17px;
-          color: ${colors.almostBlack};
-        }
-
         .non-breaking {
           white-space: nowrap;
         }
@@ -141,8 +137,7 @@ Commune.propTypes = {
     nom: PropTypes.string.isRequired
   }).isRequired,
   population: PropTypes.number.isRequired,
-  codesPostaux: PropTypes.array.isRequired,
-  isCOM: PropTypes.bool
+  codesPostaux: PropTypes.array.isRequired
 }
 
 export default Commune

--- a/components/base-adresse-nationale/explorer.js
+++ b/components/base-adresse-nationale/explorer.js
@@ -35,10 +35,15 @@ function Explorer({address, isMobile, isSafariBrowser}) {
   }
 
   const Address = ADDRESSTYPES[address.type] || Numero
+  const isCOM = address.commune ? (
+    address.commune.region.code === address.commune.departement.code
+  ) : (
+    address.region.code === address.departement.code
+  ) // Quick fix to check if the address is a COM or not. Will be change at this issue resolution => https://github.com/etalab/api-geo/issues/154
 
   return (
     <div className='explorer-container'>
-      <Address {...address} isMobile={isMobile} isSafariBrowser={isSafariBrowser} />
+      <Address {...address} isMobile={isMobile} isSafariBrowser={isSafariBrowser} isCOM={isCOM} />
 
       <style jsx>{`
         .explorer-container {
@@ -61,7 +66,10 @@ Explorer.propTypes = {
   address: PropTypes.shape({
     type: PropTypes.oneOf(['commune', 'voie', 'lieu-dit', 'numero']),
     voies: PropTypes.array,
-    nbVoies: PropTypes.number
+    nbVoies: PropTypes.number,
+    commune: PropTypes.object,
+    departement: PropTypes.object,
+    region: PropTypes.object
   }),
   isMobile: PropTypes.bool,
   isSafariBrowser: PropTypes.bool

--- a/components/base-adresse-nationale/explorer.js
+++ b/components/base-adresse-nationale/explorer.js
@@ -35,15 +35,10 @@ function Explorer({address, isMobile, isSafariBrowser}) {
   }
 
   const Address = ADDRESSTYPES[address.type] || Numero
-  const isCOM = address.commune ? (
-    address.commune.region.code === address.commune.departement.code
-  ) : (
-    address.region.code === address.departement.code
-  ) // Quick fix to check if the address is a COM or not. Will be change at this issue resolution => https://github.com/etalab/api-geo/issues/154
 
   return (
     <div className='explorer-container'>
-      <Address {...address} isMobile={isMobile} isSafariBrowser={isSafariBrowser} isCOM={isCOM} />
+      <Address {...address} isMobile={isMobile} isSafariBrowser={isSafariBrowser} />
 
       <style jsx>{`
         .explorer-container {
@@ -66,10 +61,7 @@ Explorer.propTypes = {
   address: PropTypes.shape({
     type: PropTypes.oneOf(['commune', 'voie', 'lieu-dit', 'numero']),
     voies: PropTypes.array,
-    nbVoies: PropTypes.number,
-    commune: PropTypes.object,
-    departement: PropTypes.object,
-    region: PropTypes.object
+    nbVoies: PropTypes.number
   }),
   isMobile: PropTypes.bool,
   isSafariBrowser: PropTypes.bool

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -148,11 +148,6 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
   )
 }
 
-Numero.defaultProps = {
-  isMobile: false,
-  positionType: null
-}
-
 Numero.propTypes = {
   numero: PropTypes.number.isRequired,
   suffixe: PropTypes.string,

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -16,7 +16,7 @@ import CoordinatesCopy from './coordinates-copy'
 
 import DeviceContext from '@/contexts/device'
 
-function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, positionType, sourcePosition, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile}) {
+function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, positionType, sourcePosition, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile, isCOM}) {
   const {isSafariBrowser} = useContext(DeviceContext)
   const [copyError, setCopyError] = useState(null)
   const [isCopyAvailable, setIsCopyAvailable] = useState(true)
@@ -25,7 +25,6 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
   const coordinates = {lat, lon}
   const copyUnvailableMessage = `Votre navigateur est incompatible avec la copie des coordonnées GPS : ${lat},${lon}`
   const sanitizedType = positionType ? (positionType.charAt(0).toUpperCase() + positionType.slice(1)) : 'Inconnu'
-  const isOverseasCollectivity = Object.keys(commune.region).length === 0 && Object.keys(commune.departement).length === 0
 
   return (
     <>
@@ -34,12 +33,9 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
           <h2>{getNumeroComplet({numero, suffixe})} <Link href={`/base-adresse-nationale?id=${voie.id}`} as={`/base-adresse-nationale/${voie.id}`}><a>{voie.nomVoie}</a></Link>,</h2>
           {commune && <h4><Link href={`/base-adresse-nationale?id=${commune.id}`} as={`/base-adresse-nationale/${commune.id}`}><a>{commune.nom} - {commune.code}</a></Link></h4>}
 
-          {!isOverseasCollectivity && (
-            <div className='region'>
-              {`${commune.region.nom} - ${commune.departement.nom} (${commune.departement.code})`}
-            </div>
-          )}
-
+          <div className='region'>
+            {isCOM ? `Collectivité d’outremer - ${commune.departement.nom} (${commune.departement.code})` : `${commune.region.nom} - ${commune.departement.nom} (${commune.departement.code})`}
+          </div>
         </div>
         <div style={{padding: '1em'}}>
           <Certification
@@ -173,7 +169,8 @@ Numero.propTypes = {
   positionType: PropTypes.string,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,
-  isMobile: PropTypes.bool
+  isMobile: PropTypes.bool,
+  isCOM: PropTypes.bool
 }
 
 Numero.defaultProps = {

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -25,6 +25,7 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
   const coordinates = {lat, lon}
   const copyUnvailableMessage = `Votre navigateur est incompatible avec la copie des coordonnées GPS : ${lat},${lon}`
   const sanitizedType = positionType ? (positionType.charAt(0).toUpperCase() + positionType.slice(1)) : 'Inconnu'
+  const isOverseasCollectivity = Object.keys(commune.region).length === 0 && Object.keys(commune.departement).length === 0
 
   return (
     <>
@@ -32,7 +33,13 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
         <div>
           <h2>{getNumeroComplet({numero, suffixe})} <Link href={`/base-adresse-nationale?id=${voie.id}`} as={`/base-adresse-nationale/${voie.id}`}><a>{voie.nomVoie}</a></Link>,</h2>
           {commune && <h4><Link href={`/base-adresse-nationale?id=${commune.id}`} as={`/base-adresse-nationale/${commune.id}`}><a>{commune.nom} - {commune.code}</a></Link></h4>}
-          <div className='region'>{commune.region.nom} - {commune.departement.nom} ({commune.departement.code})</div>
+
+          {!isOverseasCollectivity && (
+            <div className='region'>
+              {`${commune.region.nom} - ${commune.departement.nom} (${commune.departement.code})`}
+            </div>
+          )}
+
         </div>
         <div style={{padding: '1em'}}>
           <Certification
@@ -51,8 +58,8 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
         {lieuDitComplementNom && (
           <div>Lieu-dit : <b>{lieuDitComplementNom}</b></div>
         )}
-        <div>Code postal : <b>{codePostal}</b></div>
-        <div>Libellé d’acheminement : <b>{libelleAcheminement}</b></div>
+        {codePostal && <div>Code postal : <b>{codePostal}</b></div>}
+        {libelleAcheminement && <div>Libellé d’acheminement : <b>{libelleAcheminement}</b></div>}
         <div>Type de position : <b>{sanitizedType}</b></div>
         <div>Clé d’interopérabilité : <b>{cleInterop}</b></div>
         <div>Parcelles cadastrales : <ParcellesList parcelles={parcelles} /></div>
@@ -165,13 +172,18 @@ Numero.propTypes = {
     id: PropTypes.string.isRequired,
     nomVoie: PropTypes.string.isRequired
   }),
-  libelleAcheminement: PropTypes.string.isRequired,
-  codePostal: PropTypes.string.isRequired,
+  libelleAcheminement: PropTypes.string,
+  codePostal: PropTypes.string,
   cleInterop: PropTypes.string.isRequired,
   positionType: PropTypes.string,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,
   isMobile: PropTypes.bool
+}
+
+Numero.defaultProps = {
+  codePostal: null,
+  libelleAcheminement: null
 }
 
 export default Numero

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -165,8 +165,13 @@ Numero.propTypes = {
 }
 
 Numero.defaultProps = {
+  suffixe: null,
+  lieuDitComplementNom: null,
+  positions: [],
   codePostal: null,
-  libelleAcheminement: null
+  libelleAcheminement: null,
+  positionType: null,
+  isMobile: false
 }
 
 export default Numero

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -15,8 +15,9 @@ import PositionsTypes from '../positions-types'
 import CoordinatesCopy from './coordinates-copy'
 
 import DeviceContext from '@/contexts/device'
+import RegionInfos from '../region-infos'
 
-function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, positionType, sourcePosition, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile, isCOM}) {
+function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, positionType, sourcePosition, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile}) {
   const {isSafariBrowser} = useContext(DeviceContext)
   const [copyError, setCopyError] = useState(null)
   const [isCopyAvailable, setIsCopyAvailable] = useState(true)
@@ -32,10 +33,7 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
         <div>
           <h2>{getNumeroComplet({numero, suffixe})} <Link href={`/base-adresse-nationale?id=${voie.id}`} as={`/base-adresse-nationale/${voie.id}`}><a>{voie.nomVoie}</a></Link>,</h2>
           {commune && <h4><Link href={`/base-adresse-nationale?id=${commune.id}`} as={`/base-adresse-nationale/${commune.id}`}><a>{commune.nom} - {commune.code}</a></Link></h4>}
-
-          <div className='region'>
-            {isCOM ? `Collectivité d’outremer - ${commune.departement.nom} (${commune.departement.code})` : `${commune.region.nom} - ${commune.departement.nom} (${commune.departement.code})`}
-          </div>
+          <RegionInfos codeCommune={commune.code} region={commune.region} departement={commune.departement} />
         </div>
         <div style={{padding: '1em'}}>
           <Certification
@@ -105,6 +103,7 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
           onClose={() => setIsCopyAvailable(true)}
         />
       )}
+
       <style jsx>{`
         .heading {
           display: grid;
@@ -117,13 +116,6 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, positions, pos
 
         .heading h2 {
           margin-bottom: 0.2em;
-        }
-
-        .region {
-          margin: 2em 0 0.7em 0;
-          font-style: italic;
-          font-size: 17px;
-          color: ${colors.almostBlack};
         }
 
         .numero-details {
@@ -169,8 +161,7 @@ Numero.propTypes = {
   positionType: PropTypes.string,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,
-  isMobile: PropTypes.bool,
-  isCOM: PropTypes.bool
+  isMobile: PropTypes.bool
 }
 
 Numero.defaultProps = {

--- a/components/base-adresse-nationale/region-infos.js
+++ b/components/base-adresse-nationale/region-infos.js
@@ -1,0 +1,43 @@
+import {useMemo} from 'react'
+import PropTypes from 'prop-types'
+
+import colors from '@/styles/colors'
+
+import {isCOM} from '@/lib/ban'
+
+function RegionInfos({codeCommune, region, departement}) {
+  const sortInfoToDisplay = useMemo(() => {
+    if (isCOM(codeCommune)) {
+      return `Collectivité d’outremer - ${departement.nom} (${departement.code})`
+    }
+
+    if (region.nom === departement.nom) {
+      return `${departement.nom} (${departement.code})`
+    }
+
+    return `${region.nom} - ${departement.nom} (${departement.code})`
+  }, [codeCommune, region, departement])
+
+  return (
+    <div className='region'>
+      {sortInfoToDisplay}
+
+      <style jsx>{`
+        .region {
+          margin: 2em 0 0.7em 0;
+          font-style: italic;
+          font-size: 17px;
+          color: ${colors.almostBlack};
+        }
+      `}</style>
+    </div>
+  )
+}
+
+RegionInfos.propTypes = {
+  codeCommune: PropTypes.string.isRequired,
+  region: PropTypes.object.isRequired,
+  departement: PropTypes.object.isRequired
+}
+
+export default RegionInfos

--- a/components/base-adresse-nationale/voie/index.js
+++ b/components/base-adresse-nationale/voie/index.js
@@ -10,8 +10,9 @@ import AddressesList from '../addresses-list'
 import ParcellesList from '../parcelles-list'
 import Numero from './numero'
 import Notification from '@/components/notification'
+import RegionInfos from '../region-infos'
 
-function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumeros, isCOM}) {
+function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumeros}) {
   const isToponyme = type === 'lieu-dit'
   const {region, departement} = commune
 
@@ -21,9 +22,7 @@ function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumero
         <h2>{nomVoie}</h2>
         {commune && <h4><Link href={`/base-adresse-nationale?id=${commune.id}`} as={`/base-adresse-nationale/${commune.id}`}><a>{commune.nom} - {commune.code}</a></Link></h4>}
         {region && departement && (
-          <div className='region'>
-            {isCOM ? `Collectivité d’outremer - ${commune.departement.nom} (${commune.departement.code})` : `${commune.region.nom} - ${commune.departement.nom} (${commune.departement.code})`}
-          </div>
+          <RegionInfos codeCommune={commune.code} region={region} departement={departement} />
         )}
         <div className='number-of-numeros'>{nbNumeros > 0 ? (nbNumeros > 1 ? `${nbNumeros} numéros répertoriés` : '1 numéro répertorié') : 'Aucun numéros répertorié'}</div>
       </div>
@@ -63,13 +62,6 @@ function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumero
           margin-bottom: 0.2em;
         }
 
-        .region {
-          margin-top: 0.5em;
-          font-style: italic;
-          font-size: 17px;
-          color: ${colors.almostBlack};
-        }
-
         .number-of-numeros {
           font-weight: bolder;
           margin: 2em 0 0.7em 0;
@@ -100,8 +92,7 @@ Voie.propTypes = {
   displayBBox: PropTypes.array,
   nbNumeros: PropTypes.number,
   numeros: PropTypes.array,
-  parcelles: PropTypes.array,
-  isCOM: PropTypes.bool
+  parcelles: PropTypes.array
 }
 
 export default Voie

--- a/components/base-adresse-nationale/voie/index.js
+++ b/components/base-adresse-nationale/voie/index.js
@@ -11,7 +11,7 @@ import ParcellesList from '../parcelles-list'
 import Numero from './numero'
 import Notification from '@/components/notification'
 
-function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumeros}) {
+function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumeros, isCOM}) {
   const isToponyme = type === 'lieu-dit'
   const {region, departement} = commune
 
@@ -21,7 +21,9 @@ function Voie({type, nomVoie, commune, numeros, parcelles, displayBBox, nbNumero
         <h2>{nomVoie}</h2>
         {commune && <h4><Link href={`/base-adresse-nationale?id=${commune.id}`} as={`/base-adresse-nationale/${commune.id}`}><a>{commune.nom} - {commune.code}</a></Link></h4>}
         {region && departement && (
-          <div className='region'>{region.nom} - {departement.nom} ({departement.code})</div>
+          <div className='region'>
+            {isCOM ? `Collectivité d’outremer - ${commune.departement.nom} (${commune.departement.code})` : `${commune.region.nom} - ${commune.departement.nom} (${commune.departement.code})`}
+          </div>
         )}
         <div className='number-of-numeros'>{nbNumeros > 0 ? (nbNumeros > 1 ? `${nbNumeros} numéros répertoriés` : '1 numéro répertorié') : 'Aucun numéros répertorié'}</div>
       </div>
@@ -98,7 +100,8 @@ Voie.propTypes = {
   displayBBox: PropTypes.array,
   nbNumeros: PropTypes.number,
   numeros: PropTypes.array,
-  parcelles: PropTypes.array
+  parcelles: PropTypes.array,
+  isCOM: PropTypes.bool
 }
 
 export default Voie

--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -96,7 +96,7 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
           La commune est l’échelon de compétence pour mettre à jour les adresses. En cas de problème d’adresse sur la commune, voici comment la contacter. Vous pouvez également lui indiquer notre contact (<a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr</a>) au besoin.
 
         </SectionText>
-        <Button color='white' isOutlined onClick={handleModalOpen}>Contactez la mairie</Button>
+        <Button color='white' isOutlined disabled={!mairieInfos} onClick={handleModalOpen}>Contactez la mairie</Button>
         {isContactModalOpen && <ContactModal mairieInfos={mairieInfos} onModalClose={handleModalOpen} />}
       </div>
 
@@ -139,14 +139,15 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
 
 BALState.propTypes = {
   communeInfos: PropTypes.object.isRequired,
-  mairieInfos: PropTypes.object.isRequired,
+  mairieInfos: PropTypes.object,
   typeComposition: PropTypes.string.isRequired,
   hasMigratedBAL: PropTypes.bool.isRequired,
   revision: PropTypes.object
 }
 
 BALState.defaultType = {
-  revision: null
+  revision: null,
+  mairieInfos: null
 }
 
 export default BALState

--- a/lib/api-etablissements-public.js
+++ b/lib/api-etablissements-public.js
@@ -22,7 +22,10 @@ export async function _fetch(url) {
   throw new Error('Une erreur est survenue')
 }
 
-export function getMairie(codeCommune) {
-  const url = `${API_ETABLISSEMENTS_PUBLIC}/communes/${codeCommune}/mairie`
+export function getMairie(codeCommune, type) {
+  let url = `${API_ETABLISSEMENTS_PUBLIC}/communes/${codeCommune}`
+
+  url += type ? `/${type}` : '/mairie'
+
   return _fetch(url)
 }

--- a/lib/api-etablissements-public.js
+++ b/lib/api-etablissements-public.js
@@ -1,4 +1,5 @@
 import HttpError from './http-error'
+import {isCOM} from '@/lib/ban'
 
 const API_ETABLISSEMENTS_PUBLIC = process.env.NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC || 'https://etablissements-publics.api.gouv.fr/v3'
 
@@ -22,10 +23,9 @@ export async function _fetch(url) {
   throw new Error('Une erreur est survenue')
 }
 
-export function getMairie(codeCommune, type) {
-  let url = `${API_ETABLISSEMENTS_PUBLIC}/communes/${codeCommune}`
-
-  url += type ? `/${type}` : '/mairie'
+export function getMairie(codeCommune) {
+  const type = isCOM(codeCommune) && 'mairie_com'
+  const url = `${API_ETABLISSEMENTS_PUBLIC}/communes/${codeCommune}/${type ? type : 'mairie'}`
 
   return _fetch(url)
 }

--- a/lib/ban.js
+++ b/lib/ban.js
@@ -1,3 +1,10 @@
 export function getNumeroComplet({numero, suffixe}) {
   return `${numero}${suffixe || ''}`
 }
+
+export function isCOM(codeCommune) {
+  const prefix2 = codeCommune.slice(0, 2)
+  const prefix3 = codeCommune.slice(0, 3)
+
+  return prefix2 > '97' || (prefix2 === '97' && !['971', '972', '973', '974', '976'].includes(prefix3))
+} // Quick fix to check if the address is a COM or not. Will be change at this issue resolution => https://github.com/etalab/api-geo/issues/154

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -6,7 +6,6 @@ import {getCommune} from '@/lib/api-ban'
 import {getRevisions} from '@/lib/api-depot'
 import {getMairie} from '@/lib/api-etablissements-public'
 import withErrors from '@/components/hoc/with-errors'
-import {isCOM} from '@/lib/ban'
 
 import Page from '@/layouts/main'
 import Head from '@/components/head'
@@ -52,9 +51,8 @@ Commune.getInitialProps = async ({query}) => {
   const {codeCommune} = query
 
   const commune = await getCommune(codeCommune)
-  const isCommuneCOM = isCOM(codeCommune)
 
-  const mairie = isCommuneCOM ? await getMairie(codeCommune, 'mairie_com') : await getMairie(codeCommune)
+  const mairie = await getMairie(codeCommune)
 
   const revisions = await getRevisions(codeCommune)
 

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -60,7 +60,7 @@ Commune.getInitialProps = async ({query}) => {
   return {
     codeCommune,
     communeInfos: commune,
-    mairieInfos: mairie.features[0].properties,
+    mairieInfos: mairie.features[0]?.properties,
     revisions,
     currentRevision,
     typeCompositionAdresses
@@ -69,7 +69,7 @@ Commune.getInitialProps = async ({query}) => {
 
 Commune.propTypes = {
   communeInfos: PropTypes.object.isRequired,
-  mairieInfos: PropTypes.object.isRequired,
+  mairieInfos: PropTypes.object,
   codeCommune: PropTypes.string.isRequired,
   typeCompositionAdresses: PropTypes.string.isRequired,
   currentRevision: PropTypes.object,
@@ -78,7 +78,8 @@ Commune.propTypes = {
 
 Commune.defaultType = {
   revision: [],
-  currentRevision: null
+  currentRevision: null,
+  mairieInfos: null
 }
 
 export default withErrors(Commune)

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -6,6 +6,7 @@ import {getCommune} from '@/lib/api-ban'
 import {getRevisions} from '@/lib/api-depot'
 import {getMairie} from '@/lib/api-etablissements-public'
 import withErrors from '@/components/hoc/with-errors'
+import {isCOM} from '@/lib/ban'
 
 import Page from '@/layouts/main'
 import Head from '@/components/head'
@@ -51,7 +52,10 @@ Commune.getInitialProps = async ({query}) => {
   const {codeCommune} = query
 
   const commune = await getCommune(codeCommune)
-  const mairie = await getMairie(codeCommune)
+  const isCommuneCOM = isCOM(codeCommune)
+
+  const mairie = isCommuneCOM ? await getMairie(codeCommune, 'mairie_com') : await getMairie(codeCommune)
+
   const revisions = await getRevisions(codeCommune)
 
   const currentRevision = revisions.find(revision => revision.current)


### PR DESCRIPTION
Cette PR propose un fix à l'issue #1163

**Les problèmes** : 

- L'accès à la page `/commune/<codecommune>` d'une commune des COM mène à une erreur `500`.
- Une erreur d'affichage de l'adresse se produit également sur l'explorateur.

Ces erreurs sont dûes à certaines informations manquantes chez les COM (infos de la mairie, nom/code region/departement) qui mènent soit à une erreur au chargement de la page faute d'existence des données, soit à un souci d'affichage.

**Résolution** :

- Retourner `null` si les informations ne sont pas présentes dans un `getInitialProps` afin d'éviter l'erreur `500` au retour des props.
- Conditionner l'affichage suivant si l'adresse est une COM ou non

### **AVANT**
### Page `/commune/97501`
<img width="632" alt="168839070-34771d16-b2f8-4eed-83e1-f3bb0ef4019c" src="https://user-images.githubusercontent.com/66621960/169072725-d6fc74f1-5752-4392-b76b-95d9150d4d46.png">

### Explorateur
<img width="705" alt="168838961-30c17213-e688-4848-ac45-71d6ddfb64e7" src="https://user-images.githubusercontent.com/66621960/169072937-8ee0f66b-36ea-47c5-9301-9fb7da8df25f.png">

### **APRÈS**
<img width="1440" alt="Capture d’écran 2022-05-18 à 17 01 24" src="https://user-images.githubusercontent.com/66621960/169073456-e4c44183-b887-448f-9403-04434d8e72e0.png">
<img width="460" alt="Capture d’écran 2022-05-19 à 12 37 43" src="https://user-images.githubusercontent.com/66621960/169276087-1b88034b-5fa2-4ea0-a950-f1e9d4e69817.png">


Close #1163
