### PR TITLE
Affichage de la version du pdf 

### DIFF
--- a/components/doc-download.js
+++ b/components/doc-download.js
@@ -4,16 +4,19 @@ import {DownloadCloud} from 'react-feather'
 
 import theme from '@/styles/theme'
 
-function DocDownload({title, link, src, alt, isReverse, children}) {
+function DocDownload({title, link, src, alt, isReverse, version, children}) {
   return (
     <div className='doc-container'>
       <div className='text-container'>
         <h3>{title}</h3>
         {children}
       </div>
-      <div className='img-container'>
-        <div className='preview'>
-          <Image width={200} height={280} layout='fixed' src={src} alt={alt} />
+      <div className='doc-download-container'>
+        <div className='doc-infos-container'>
+          <div className='preview'>
+            <Image width={200} height={280} layout='fixed' src={src} alt={alt} />
+          </div>
+          {version && <div className='version'>Version {version}</div>}
         </div>
         <a href={link}>
           <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '5px'}} />
@@ -34,7 +37,7 @@ function DocDownload({title, link, src, alt, isReverse, children}) {
           min-width: 250px;
         }
 
-        .img-container {
+        .doc-download-container {
           flex: 1;
           display: flex;
           flex-direction: column;
@@ -43,9 +46,19 @@ function DocDownload({title, link, src, alt, isReverse, children}) {
 
         .preview {
           display: flex;
-          margin: 1em;
           border: 5px solid ${theme.colors.whiteBlue};
           border-radius: ${theme.borderRadius};
+        }
+
+        .doc-infos-container {
+          text-align: center;
+          margin: 1em;
+        }
+
+        .version {
+          font-style: italic;
+          font-weight: bold;
+          font-size: .9em;
         }
       `}</style>
     </div>
@@ -58,7 +71,8 @@ DocDownload.propTypes = {
   link: PropTypes.string,
   title: PropTypes.string,
   src: PropTypes.string,
-  alt: PropTypes.string
+  alt: PropTypes.string,
+  version: PropTypes.string
 }
 
 DocDownload.defaultProps = {
@@ -67,8 +81,8 @@ DocDownload.defaultProps = {
   link: null,
   title: null,
   src: null,
-  alt: null
+  alt: null,
+  version: null
 }
 
 export default DocDownload
-

--- a/pages/ressources.js
+++ b/pages/ressources.js
@@ -68,6 +68,7 @@ function Guides() {
           link='https://adresse.data.gouv.fr/data/docs/guide-mes-adresses-v6.0.pdf'
           src='/images/previews/guide-mes-adresses-preview.png'
           alt='miniature du guide Mes Adresses'
+          version='6 - 06/05/2022'
         >
           <SectionText>
             <p>&quot;Mes Adresses&quot; est un outil en ligne qui vous permet de gérer simplement vos adresses, de la constitution d’une Base Adresse Locale à sa mise à jour. Il est accessible sans compétences techniques et dispose d’un tutoriel embarqué.<br /> Le Guide de Mes Adresses est disponible dans un <a href='https://guide.mes-adresses.data.gouv.fr/'>format texte en ligne</a> ou en PDF.</p>
@@ -86,6 +87,7 @@ function Guides() {
           src='/images/previews/bonnes-pratiques-preview.png'
           alt='miniature du guide bonne pratique'
           link='https://adresse.data.gouv.fr/data/docs/guide-bonnes-pratiques-v3.1.pdf'
+          version='3.1 - 11/03/2022'
         >
           <SectionText>
             <p>
@@ -104,6 +106,7 @@ function Guides() {
           src='/images/previews/obligations-adresse-preview.png'
           alt='miniature du document obligations-adresse'
           link='https://adresse.data.gouv.fr/data/docs/communes-operateurs-obligations-adresse.pdf'
+          version=''
         >
           <h5>Communes et opérateurs, vous pouvez gagner du temps</h5>
           <SectionText>


### PR DESCRIPTION
Dans la page `/ressources`, le guides de mes adresses et le guide des bonnes pratiques de l'adressage disposent maintenant de la version et la date de mise à jour du document directement sous la preview du pdf.

<img width="1227" alt="Capture d’écran 2022-05-20 à 16 16 34" src="https://user-images.githubusercontent.com/66621960/169547317-01380cb6-a358-4948-8279-a7f17a3f6b08.png">
