### PR TITLE
Ajout d'une ancre pour rediriger vers la newsletter

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -165,7 +165,7 @@ function Home({stats, posts}) {
         `}</style>
       </Section>
 
-      <Section title='Suivez et participez à l’actualité de la communauté adresse.data.gouv' background='grey'>
+      <Section id='newsletter' title='Suivez et participez à l’actualité de la communauté adresse.data.gouv' background='grey'>
         <SocialMedia />
       </Section>
     </Page>


### PR DESCRIPTION
Ajout d'une ancre vers la section sur la page d'accueil.
Sur la documentation [Services et outils à disposition](https://doc.adresse.data.gouv.fr/naviguer-sur-le-site/services-et-outils-a-disposition#suivre-lactualite-de-ladresse), l'utilisateur était seulement redirigé vers la page d'accueil au lieu d'être redirigé vers la section **Suivez et participez à l’actualité de la communauté adresse.data.gouv** en cliquant sur `Infolettre`

Close #1175