### PR TITLE
Référence de la page status.adresse.data.gouv.fr

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -20,6 +20,7 @@ function Footer() {
           <li><h2>adresse.data.gouv.fr</h2></li>
           <li><Link href='/cgu'><a>Mentions légales et CGU</a></Link></li>
           <li><a href='https://doc.adresse.data.gouv.fr/'>Documentation</a></li>
+          <li><a href='https://status.adresse.data.gouv.fr/'>Supervision BAN/BAL</a></li>
           <li><Link href='/nous-contacter'><a>Nous contacter</a></Link></li>
         </ul>
       </div>

--- a/pages/api-doc/index.js
+++ b/pages/api-doc/index.js
@@ -1,4 +1,4 @@
-import {Compass, Terminal, Map, Folder} from 'react-feather'
+import {Compass, Terminal, Map, Folder, Activity} from 'react-feather'
 
 import Page from '@/layouts/main'
 import Head from '@/components/head'
@@ -32,6 +32,12 @@ function ApiPage() {
       description: 'API permettant consulter la base FANTOIR de la DGFiP.',
       href: 'https://github.com/BaseAdresseNationale/api-fantoir/blob/master/README.md#api',
       icon: <Folder />
+    },
+    {
+      title: 'Supervision BAN/BAL',
+      description: 'Consultez la disponiblité des différents systèmes grâce à un outil de monitoring.',
+      href: 'https://status.adresse.data.gouv.fr/',
+      icon: <Activity />
     }
   ]
 


### PR DESCRIPTION
Suite à la mise en place de la page [status.adresse.data.gouv.fr](https://status.adresse.data.gouv.fr/), cette PR permet de référencer cette dernière sur la page `/api-doc` et d'ajouter un point d'entrée au niveau du `footer`.

<img width="1439" alt="Capture d’écran 2022-05-27 à 15 11 22" src="https://user-images.githubusercontent.com/66621960/170706893-76b6013a-a0f0-493e-9300-cca88da9bed3.png">
<img width="1120" alt="Capture d’écran 2022-05-27 à 15 11 34" src="https://user-images.githubusercontent.com/66621960/170706899-1e65e66e-d2f6-418c-938f-25f31f47a92a.png">

Close #1165