### PR TITLE
Utilisation de lien symbolique pour les guides

### DIFF
--- a/pages/ressources.js
+++ b/pages/ressources.js
@@ -65,7 +65,7 @@ function Guides() {
         <DocDownload
           id='guide-adressage'
           title='Le guide de Mes Adresses'
-          link='https://adresse.data.gouv.fr/data/docs/guide-mes-adresses-v6.0.pdf'
+          link='https://adresse.data.gouv.fr/data/docs/guide-mes-adresses.pdf'
           src='/images/previews/guide-mes-adresses-preview.png'
           alt='miniature du guide Mes Adresses'
           version='6 - 06/05/2022'
@@ -86,7 +86,7 @@ function Guides() {
           isReverse
           src='/images/previews/bonnes-pratiques-preview.png'
           alt='miniature du guide bonne pratique'
-          link='https://adresse.data.gouv.fr/data/docs/guide-bonnes-pratiques-v3.1.pdf'
+          link='https://adresse.data.gouv.fr/data/docs/guide-bonnes-pratiques.pdf'
           version='3.1 - 11/03/2022'
         >
           <SectionText>


### PR DESCRIPTION
## Contexte
Certains sites placent le lien vers les guides en PDF et ces liens changent à chaque nouvelle version.
Des sites de partenaires de la charte et autres institutions renvoient actuellement vers les versions obsolètes du Guide de l'éditeur et du Guide des bonnes pratiques.

Cette PR utilise les liens symboliques qui pointe vers la dernière version disponible des guides afin de pouvoir fournir aux ré-utilisateurs un URL pérenne.

Fix #1171