### PR TITLE
Déréférence CRIGE PACA comme partenaire de la Charte 

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -1,31 +1,6 @@
 {
   "epci": [
     {
-      "name": "CRIGE PACA",
-      "link": "https://www.crige-paca.org/projets/adresse/",
-      "infos": "Le Centre de Ressources en Information Géographique en Provence-Alpes-Côte d’Azur est le centre de ressources en géomatique au service des organismes publics de la région.",
-      "perimeter": "Région PACA",
-      "codeDepartement": [
-        "04",
-        "05",
-        "06",
-        "13",
-        "83",
-        "84"
-      ],
-      "echelon": 3,
-      "isPerimeterFrance": false,
-      "isCompany": false,
-      "services": [
-        "formation",
-        "accompagnement technique"
-      ],
-      "picture": "/images/logos/partners/epci/crige.jpg",
-      "height": 124,
-      "width": 299,
-      "alt": "Logo du Centre de Ressources en Information Géographique en Provence-Alpes-Côte d’Azur"
-    },
-    {
       "name": "ATD24",
       "link": "https://www.atd24.fr/gestion-des-territoires__trashed/cartographie-numerique/",
       "infos": "L’Agence Technique Départementale de la Dordogne a développé une Base Adresse Locale sur Périgéo, son SIG mutualisé, permettant aux communes de créer et gérer leurs adresses.",


### PR DESCRIPTION
## Contexte
CRIGE PACA n'accompagnant pas les communes, il a été décidé de le déréférencer des partenaires de la Charte.

Fix #1187