### PR TITLE
Mise à jour de l'url vers le site du partenaire ATD24

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -2,7 +2,7 @@
   "epci": [
     {
       "name": "ATD24",
-      "link": "https://www.atd24.fr/gestion-des-territoires__trashed/cartographie-numerique/",
+      "link": "https://www.atd24.fr/gestion-des-territoires/cartographie-numerique/",
       "infos": "L’Agence Technique Départementale de la Dordogne a développé une Base Adresse Locale sur Périgéo, son SIG mutualisé, permettant aux communes de créer et gérer leurs adresses.",
       "perimeter": "Dordogne",
       "codeDepartement": [


### PR DESCRIPTION
Mise à jour de l'URL vers le site du partenaire ATD24.
`https://www.atd24.fr/gestion-des-territoires/cartographie-numerique/` est remplacé par `https://www.atd24.fr/gestion-des-territoires/cartographie-numerique/`

Close #1190