### PR TITLE
Correction du bug choix de saison pour la bannière

### DIFF
--- a/components/frise.js
+++ b/components/frise.js
@@ -7,9 +7,7 @@ const getSeasonColors = () => {
   const year = now.getFullYear()
 
   const winter = new Date(`${year}-12-21`)
-  const newYear = new Date(`${year + 1}-01-01`)
   const spring = new Date(`${year}-03-20`)
-  const nextYearSpring = new Date(`${year + 1}-03-20`)
   const summer = new Date(`${year}-06-21`)
   const fall = new Date(`${year}-09-22`)
 
@@ -20,7 +18,7 @@ const getSeasonColors = () => {
 
   const isSpring = now >= spring && now < summer
   const isFall = now >= fall && now < winter
-  const isWinter = now >= winter && (now > newYear && now < nextYearSpring)
+  const isSummer = now >= summer && now < fall
 
   if (isSpring) {
     return springColors
@@ -30,11 +28,11 @@ const getSeasonColors = () => {
     return fallColors
   }
 
-  if (isWinter) {
-    return winterColors
+  if (isSummer) {
+    return summerColors
   }
 
-  return summerColors
+  return winterColors
 }
 
 function Frise() {

--- a/components/frise.js
+++ b/components/frise.js
@@ -7,7 +7,7 @@ const getSeasonColors = () => {
   const year = now.getFullYear()
 
   const winter = new Date(`${year}-12-21`)
-  const lastYearWinter = new Date(`${year - 1}-03-20`)
+  const newYear = new Date(`${year + 1}-01-01`)
   const spring = new Date(`${year}-03-20`)
   const nextYearSpring = new Date(`${year + 1}-03-20`)
   const summer = new Date(`${year}-06-21`)
@@ -18,15 +18,19 @@ const getSeasonColors = () => {
   const fallColors = ['#C20505', '#FCE563', '#FCBF63', '#FC6363', '#FFE23F', '#FFB700', '#F19800', '#EC8C24', '#9E3200', '#C37676', '#E9A64F', '#C37679', '#F3DA43', '#C94976', '#F3DA43', '#C3A476']
   const summerColors = []
 
-  if (now >= spring && now < summer) {
+  const isSpring = now >= spring && now < summer
+  const isFall = now >= fall && now < winter
+  const isWinter = now >= winter && (now > newYear && now < nextYearSpring)
+
+  if (isSpring) {
     return springColors
   }
 
-  if (now >= fall && now < winter) {
+  if (isFall) {
     return fallColors
   }
 
-  if ((now >= winter || now >= lastYearWinter) && (now < nextYearSpring || now < spring)) {
+  if (isWinter) {
     return winterColors
   }
 


### PR DESCRIPTION
Les couleurs étaient aux couleurs de l'hiver en plein été.
L'algorithme de détection de la saison actuelle a été modifié.

### **AVANT**
<img width="1440" alt="Capture d’écran 2022-06-21 à 21 21 46" src="https://user-images.githubusercontent.com/66621960/174881243-c1a37b1b-8ee8-4da9-a2d3-ee4951a775d1.png">

### **APRÈS**
<img width="1439" alt="Capture d’écran 2022-06-21 à 21 21 36" src="https://user-images.githubusercontent.com/66621960/174881291-9a61cdb4-5d87-447b-8f0a-c16e6673dda6.png">

