### PR TITLE
Accessibilité non-visuelle des liens et éléments interactifs

### DIFF
--- a/components/api-doc/api-adresse/expandable-menu.js
+++ b/components/api-doc/api-adresse/expandable-menu.js
@@ -4,11 +4,15 @@ import {ChevronDown, ChevronUp} from 'react-feather'
 
 import theme from '../../../styles/theme'
 
-function ExpandableMenu({title, children}) {
+function ExpandableMenu({title, children, label}) {
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
-    <div className='expandable-menu-container' onClick={() => setIsExpanded(!isExpanded)}>
+    <button
+      type='button'
+      aria-label={`${isExpanded ? 'Masquer' : 'Afficher'} la documentation de ${label}`}
+      className='expandable-menu-container' onClick={() => setIsExpanded(!isExpanded)}
+    >
       <div className='head'>
         <div className='title'>{title}</div>
         <div style={{paddingLeft: '.5em'}}>
@@ -20,11 +24,14 @@ function ExpandableMenu({title, children}) {
 
       <style jsx>{`
         .expandable-menu-container {
+          width: 100%;
           margin: 0.5em 0;
           padding: 0.5em;
           background: ${theme.colors.white};
           border-radius: 3px;
           color: ${theme.darkText};
+          border: none;
+          text-align: left;
         }
 
         .expandable-menu-container:hover {
@@ -45,7 +52,7 @@ function ExpandableMenu({title, children}) {
           width: 100%;
         }
         `}</style>
-    </div>
+    </button>
   )
 }
 
@@ -54,6 +61,7 @@ ExpandableMenu.propTypes = {
     PropTypes.string,
     PropTypes.node
   ]).isRequired,
+  label: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired
 }
 

--- a/components/api-doc/api-adresse/technical-doc/attributs.js
+++ b/components/api-doc/api-adresse/technical-doc/attributs.js
@@ -7,7 +7,7 @@ import ParamsTable from './params-table'
 
 function Attributs({model, defaults, optionals}) {
   return (
-    <ExpandableMenu title='Attributs'>
+    <ExpandableMenu title='Attributs' label='Attributs'>
       <div>
         <ParamsTable label='Par défaut' params={defaults} />
         {optionals && (

--- a/components/api-doc/api-adresse/technical-doc/path.js
+++ b/components/api-doc/api-adresse/technical-doc/path.js
@@ -43,6 +43,7 @@ function Path({name, description, params, method, body}) {
         }
 
         .description {
+          font-size: 14px;
           width: 100%;
           display: flex;
           justify-content: space-between;
@@ -54,7 +55,7 @@ function Path({name, description, params, method, body}) {
   )
 
   return (
-    <ExpandableMenu title={title}>
+    <ExpandableMenu title={title} label={description}>
       <ParamsTable params={params} />
       {body && <ParamsTable label='body' params={[body]} />}
     </ExpandableMenu>

--- a/components/base-adresse-nationale/commune/tabs.js
+++ b/components/base-adresse-nationale/commune/tabs.js
@@ -5,20 +5,26 @@ import colors from '@/styles/colors'
 function Tabs({activeTab, setActiveTab}) {
   return (
     <div className='tab-container'>
-      <div className={`tab ${activeTab === 'VOIES' ? 'active' : 'inactive'}`}
+      <button
+        type='button'
+        aria-label='Afficher les voies'
+        className={`tab ${activeTab === 'VOIES' ? 'active' : 'inactive'}`}
         onClick={() => {
           setActiveTab('VOIES')
         }}
       >
         Voies
-      </div>
-      <div className={`tab ${activeTab === 'LIEUXDITS' ? 'active' : 'inactive'}`}
+      </button>
+      <button
+        type='button'
+        aria-label='Afficher les lieux-dits'
+        className={`tab ${activeTab === 'LIEUXDITS' ? 'active' : 'inactive'}`}
         onClick={() => {
           setActiveTab('LIEUXDITS')
         }}
       >
         Lieux-dits
-      </div>
+      </button>
 
       <style jsx>{`
         .tab-container {
@@ -32,7 +38,8 @@ function Tabs({activeTab, setActiveTab}) {
           flex: 1;
           text-align: center;
           padding: 0.5em;
-          background-color: ${colors.lighterGrey}
+          background-color: ${colors.lighterGrey};
+          border: none;
         }
 
         .tab:hover {

--- a/components/base-adresse-nationale/layout-selector.js
+++ b/components/base-adresse-nationale/layout-selector.js
@@ -4,7 +4,12 @@ import theme from '@/styles/theme'
 function LayoutSelector({name, value, icon, isSelected, handleClick}) {
   const Icon = icon
   return (
-    <div className={`layout ${isSelected ? 'selected' : ''}`} onClick={() => handleClick(value)}>
+    <button
+      type='button'
+      aria-label={`Séléctionner l'onglet ${name}`}
+      className={`layout ${isSelected ? 'selected' : ''}`}
+      onClick={() => handleClick(value)}
+    >
       <div><Icon /></div>
       <div>{name}</div>
 
@@ -15,6 +20,10 @@ function LayoutSelector({name, value, icon, isSelected, handleClick}) {
           justify-content: center;
           align-items: center;
           padding-top: 0.5em;
+          gap: 5px;
+          background: none;
+          border: none;
+          color: ${theme.darkText};
         }
 
         .layout.selected {
@@ -23,7 +32,7 @@ function LayoutSelector({name, value, icon, isSelected, handleClick}) {
           border-top: 4px solid ${theme.primary};
         }
         `}</style>
-    </div>
+    </button>
   )
 }
 

--- a/components/base-adresse-nationale/layout-selector.js
+++ b/components/base-adresse-nationale/layout-selector.js
@@ -6,7 +6,7 @@ function LayoutSelector({name, value, icon, isSelected, handleClick}) {
   return (
     <button
       type='button'
-      aria-label={`Séléctionner l'onglet ${name}`}
+      aria-label={`Sélectionner l'onglet ${name}`}
       className={`layout ${isSelected ? 'selected' : ''}`}
       onClick={() => handleClick(value)}
     >

--- a/components/base-adresse-nationale/postal-codes.js
+++ b/components/base-adresse-nationale/postal-codes.js
@@ -13,9 +13,14 @@ function PostalCodes({codes}) {
       ) : (
         <div className='postal-codes'>
           <div>
-            <div className='with-icon wrapper' onClick={() => setShowCodes(!showCodes)}>
+            <button
+              type='button'
+              aria-label={showCodes ? 'Masquer les codes postaux' : 'Afficher les codes postaux'}
+              className='with-icon wrapper'
+              onClick={() => setShowCodes(!showCodes)}
+            >
               <div>Codes postaux</div> {showCodes ? <ChevronUp /> : <ChevronDown />}
-            </div>
+            </button>
           </div>
           {showCodes && (
             <ul className='codes-list'>
@@ -41,8 +46,8 @@ function PostalCodes({codes}) {
         .wrapper {
           justify-content: space-between;
           background: whitesmoke;
-          padding: 0.2em 0.4em;
           border-radius: 4px;
+          border: none;
         }
 
         .with-icon > div {

--- a/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
+++ b/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
@@ -18,7 +18,7 @@ class BaseAdresseLocale extends React.Component {
       <div className='bal-container'>
         <div className='link-title'>
           <Link href={`/bases-locales/jeux-de-donnees/${dataset.id}`} passHref>
-            <a>{dataset.title}</a>
+            <a aria-label={`Consulter le jeux de données ${dataset.title}`}>{dataset.title}</a>
           </Link>
         </div>
 

--- a/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
+++ b/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
@@ -18,7 +18,7 @@ class BaseAdresseLocale extends React.Component {
       <div className='bal-container'>
         <div className='link-title'>
           <Link href={`/bases-locales/jeux-de-donnees/${dataset.id}`} passHref>
-            <a aria-label={`Consulter le jeux de données ${dataset.title}`}>{dataset.title}</a>
+            <a aria-label={`Consulter le jeu de données ${dataset.title}`}>{dataset.title}</a>
           </Link>
         </div>
 

--- a/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
+++ b/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
@@ -17,7 +17,7 @@ class BaseAdresseLocale extends React.Component {
     return (
       <div className='bal-container'>
         <div className='link-title'>
-          <Link href={`/bases-locales/jeux-de-donnees/${dataset.id}`} passHref>
+          <Link href={`/bases-locales/jeux-de-donnees/${dataset.id}`}>
             <a aria-label={`Consulter le jeu de données ${dataset.title}`}>{dataset.title}</a>
           </Link>
         </div>

--- a/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
+++ b/components/bases-locales/bases-adresse-locales/base-adresse-locale.js
@@ -17,7 +17,7 @@ class BaseAdresseLocale extends React.Component {
     return (
       <div className='bal-container'>
         <div className='link-title'>
-          <Link href={`/bases-locales/jeux-de-donnees/${dataset.id}`}>
+          <Link href={`/bases-locales/jeux-de-donnees/${dataset.id}`} passHref>
             <a>{dataset.title}</a>
           </Link>
         </div>

--- a/components/bases-locales/bases-adresse-locales/dataset/index.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/index.js
@@ -38,6 +38,10 @@ function Dataset({dataset}) {
     )
   }
 
+  const handleLabel = item => {
+    return `Consulter les adresses de la commune ${item} dans la Base Adresse Nationale`
+  }
+
   return (
     <div>
       <Section>
@@ -57,6 +61,7 @@ function Dataset({dataset}) {
             title={dataset.communes.length === 1 ? 'Commune' : 'Communes'}
             subtitle={dataset.communes.length === 1 ? '1 commune répertoriée' : `${dataset.communes.length} communes répertoriées`}
             list={dataset.communes}
+            handleLabel={handleLabel}
             textFilter={item => item.nom}
             cols={cols}
             handleSelect={selectCommune} />

--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -15,7 +15,7 @@ class Summary extends React.Component {
 
   render() {
     const {dataset} = this.props
-    const {id, organization, url, model, dateMAJ, rowsCount, communes} = dataset
+    const {id, organization, url, model, dateMAJ, rowsCount, communes, title} = dataset
     const infos = [
       {
         title: 'Format',
@@ -43,11 +43,11 @@ class Summary extends React.Component {
           </div>
 
           <div className='links'>
-            <ButtonLink href={`/bases-locales/jeux-de-donnees/${id}`}>
+            <ButtonLink href={`/bases-locales/jeux-de-donnees/${id}`} label={`Consulter la Base Adresse Locale ${dataset.title}`}>
               Consulter la Base Adresse Locale
             </ButtonLink>
             {url &&
-              <a href={url}>
+              <a href={url} aria-label={`Télécharger les ${title}`}>
                 <DownloadCloud size={18} style={{verticalAlign: 'middle', marginRight: '5px'}} />
                 Télécharger la Base Adresse Locale
               </a>}

--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -43,7 +43,7 @@ class Summary extends React.Component {
           </div>
 
           <div className='links'>
-            <ButtonLink href={`/bases-locales/jeux-de-donnees/${id}`} label={`Consulter la Base Adresse Locale ${dataset.title}`}>
+            <ButtonLink href={`/bases-locales/jeux-de-donnees/${id}`} label={`Consulter la Base Adresse Locale ${title}`}>
               Consulter la Base Adresse Locale
             </ButtonLink>
             {url &&

--- a/components/bases-locales/charte/commune.js
+++ b/components/bases-locales/charte/commune.js
@@ -13,11 +13,11 @@ function Commune({name, codeCommune, picture, height, width, alt, signatureDate,
     <div className='commune-container' onClick={event => event.stopPropagation()}>
       <div className='commune-infos'>
         <Image src={picture} height={height / 2} width={width / 2} alt={alt} />
-        <Link href={`/commune/${codeCommune}`}>{`${name} - ${codeCommune}`}</Link>
+        <Link href={`/commune/${codeCommune}`} aria-label={`Aller sur la page commune de ${name}`}>{`${name} - ${codeCommune}`}</Link>
       </div>
       <div className='signature-date'>Partenaire depuis le <b>{date}</b></div>
       {charteURL && (
-        <ButtonLink href={charteURL} isExternal target='_blank'>
+        <ButtonLink href={charteURL} isExternal target='_blank' label={`Voir la charte de ${name}`}>
           Voir la charte <ExternalLink size={20} style={{verticalAlign: 'sub'}} />
         </ButtonLink>
       )}

--- a/components/bases-locales/charte/dropdown.js
+++ b/components/bases-locales/charte/dropdown.js
@@ -26,7 +26,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
     >
       <div className='visible-container'>
         <div className='dropdown-infos-container'>
-          <div className='name' aria-label={`Commune ${nom}, code postal ${code}`}>{nom} - {code}</div>
+          <div className='name' aria-label={`Commune ${nom}, code INSEE ${code}`}>{nom} - {code}</div>
           <div className='communes-length'>
             {isDisabled ? 'Aucune commune partenaire' : (
               <div aria-label={`${communesCount} communes partenaires`} className='commune-count'><b>{communesCount}</b> {communesCount <= 1 ? 'commune partenaire' : 'communes partenaires'}</div>

--- a/components/bases-locales/charte/dropdown.js
+++ b/components/bases-locales/charte/dropdown.js
@@ -15,7 +15,8 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
   }
 
   return (
-    <div
+    <button
+      type='button'
       className={`
         dropdown-container
         ${isDisabled ? 'disabled' : ''}
@@ -28,7 +29,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
           <div className='name' aria-label={`Commune ${nom}, code postal ${code}`}>{nom} - {code}</div>
           <div className='communes-length'>
             {isDisabled ? 'Aucune commune partenaire' : (
-              <div aria-label={`${communesCount} communes partenaires`}><b>{communesCount}</b> {communesCount <= 1 ? 'commune partenaire' : 'communes partenaires'}</div>
+              <div aria-label={`${communesCount} communes partenaires`} className='commune-count'><b>{communesCount}</b> {communesCount <= 1 ? 'commune partenaire' : 'communes partenaires'}</div>
             )}
           </div>
         </div>
@@ -52,10 +53,15 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
           margin: 1em 0;
           opacity: 100%;
           pointer-events: auto;
+          border: none;
         }
 
         .dropdown-container:hover {
           background: ${color === 'primary' ? theme.colors.lightGrey : theme.primaryDark};
+        }
+
+        .commune-count {
+          width: fit-content;
         }
 
         .alt {
@@ -85,7 +91,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
           font-style: italic;
         }
       `}</style>
-    </div>
+    </button>
   )
 }
 
@@ -105,4 +111,3 @@ Dropdown.defaultProps = {
 }
 
 export default React.memo(Dropdown)
-

--- a/components/bases-locales/charte/dropdown.js
+++ b/components/bases-locales/charte/dropdown.js
@@ -25,10 +25,10 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
     >
       <div className='visible-container'>
         <div className='dropdown-infos-container'>
-          <div className='name'>{nom} - {code}</div>
+          <div className='name' aria-label={`Commune ${nom}, code postal ${code}`}>{nom} - {code}</div>
           <div className='communes-length'>
             {isDisabled ? 'Aucune commune partenaire' : (
-              <><b>{communesCount}</b> {communesCount <= 1 ? 'commune partenaire' : 'communes partenaires'}</>
+              <div aria-label={`${communesCount} communes partenaires`}><b>{communesCount}</b> {communesCount <= 1 ? 'commune partenaire' : 'communes partenaires'}</div>
             )}
           </div>
         </div>

--- a/components/bases-locales/charte/tags.js
+++ b/components/bases-locales/charte/tags.js
@@ -33,14 +33,13 @@ function Tags({onSelectTags, selectedTags, filteredPartners, allPartners}) {
   return (
     <div className='labels-container'>
       {handleListOfTags(allPartners).map(tag => {
-        const isActive = handleTagClassname(tag) === 'label label-active'
-        const isDisable = handleTagClassname(tag) === 'label label-inactive'
+        const isActive = handleTagClassname(tag).includes('active')
 
         return (
           <button
             type='button'
             aria-label={`${isActive ? 'Désélectionner' : 'Sélectionner'} le tag ${tag}`}
-            aria-disabled={isDisable}
+            aria-disabled={!isActive}
             onClick={() => {
               onSelectTags(tag)
             }}

--- a/components/bases-locales/charte/tags.js
+++ b/components/bases-locales/charte/tags.js
@@ -33,8 +33,14 @@ function Tags({onSelectTags, selectedTags, filteredPartners, allPartners}) {
   return (
     <div className='labels-container'>
       {handleListOfTags(allPartners).map(tag => {
+        const isActive = handleTagClassname(tag) === 'label label-active'
+        const isDisable = handleTagClassname(tag) === 'label label-inactive'
+
         return (
-          <div
+          <button
+            type='button'
+            aria-label={`${isActive ? 'Désélectionner' : 'Sélectionner'} le tag ${tag}`}
+            aria-disabled={isDisable}
             onClick={() => {
               onSelectTags(tag)
             }}
@@ -42,7 +48,7 @@ function Tags({onSelectTags, selectedTags, filteredPartners, allPartners}) {
             className={handleTagClassname(tag)}
           >
             {formatTag(tag)}
-          </div>
+          </button>
         )
       })}
 
@@ -52,8 +58,12 @@ function Tags({onSelectTags, selectedTags, filteredPartners, allPartners}) {
             grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
           }
 
+        .labels-container button {
+          border: none;
+        }
+
         .label {
-          font-size: 1.1em;
+          font-size: .9em;
           background-color: ${theme.colors.lightGrey};
           color: ${theme.colors.black};
           border-radius: 4px;

--- a/components/bases-locales/publication/authentification.js
+++ b/components/bases-locales/publication/authentification.js
@@ -33,7 +33,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
           <div className='content'>
             <div className='authentification-choice'>
               <h4>M’authentifier comme élu de la commune</h4>
-              <a href={fcButtonUrl}>
+              <a href={fcButtonUrl} aria-label='S’authentifier sur FranceConnect'>
                 <Image width={280} height={82} layout='fixed' src='/images/FCboutons-10.svg' alt='bouton FranceConnect' />
               </a>
               <p className='alert-personal-data'>

--- a/components/bases-locales/publication/authentification.js
+++ b/components/bases-locales/publication/authentification.js
@@ -19,13 +19,15 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
   return (
     <div className='auth-container'>
       <div className='dropdown-container'>
-        <div
+        <button
+          type='button'
+          aria-label={`${isHabilitedOpen ? 'Masquer' : 'Afficher'} la marche à suivre lorsque vous êtes habilité`}
           className='dropdown-title'
           onClick={() => setIsHabilitedOpen(!isHabilitedOpen)}
         >
           <h3>Vous êtes habilité(e)</h3>
           {isHabilitedOpen ? <ChevronDown color={theme.primary} size={35} /> : <ChevronRight color={theme.primary} size={35} />}
-        </div>
+        </button>
 
         {isHabilitedOpen && (
           <div className='content'>
@@ -69,13 +71,15 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
       </div>
 
       <div className='dropdown-container'>
-        <div
+        <button
+          type='button'
+          aria-label={`${isHabilitedOpen ? 'Masquer' : 'Afficher'} la marche à suivre lorsque vous n'êtes pas habilité`}
           className='dropdown-title'
           onClick={() => setIsNonHabilitedOpen(!isNonHabilitedOpen)}
         >
           <h3>Vous n’êtes pas habilité(e)</h3>
           {isNonHabilitedOpen ? <ChevronDown color={theme.primary} size={35} /> : <ChevronRight color={theme.primary} size={35} />}
-        </div>
+        </button>
 
         {isNonHabilitedOpen && (
           <div className='content'>
@@ -130,6 +134,10 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
           display: flex;
           justify-content: space-between;
           align-items: center;
+          width: 100%;
+          border: none;
+          background: none;
+          color: ${theme.darkText};
         }
 
         h4 {

--- a/components/bases-locales/publication/authentification.js
+++ b/components/bases-locales/publication/authentification.js
@@ -33,7 +33,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
           <div className='content'>
             <div className='authentification-choice'>
               <h4>M’authentifier comme élu de la commune</h4>
-              <a href={fcButtonUrl} aria-label='S’authentifier sur FranceConnect'>
+              <a href={fcButtonUrl} aria-label='S’authentifier avec FranceConnect'>
                 <Image width={280} height={82} layout='fixed' src='/images/FCboutons-10.svg' alt='bouton FranceConnect' />
               </a>
               <p className='alert-personal-data'>

--- a/components/bases-locales/publication/code-authentification.js
+++ b/components/bases-locales/publication/code-authentification.js
@@ -75,7 +75,12 @@ function CodeAuthentification({habilitationId, email, handleValidCode, sendBackC
               placeholder='Entrez votre code ici'
               onChange={handleInput}
             />
-            <button type='submit' disabled={code.length !== 6} onClick={submitCode}>
+            <button
+              type='submit'
+              aria-label='Soumettre le code d’authentification'
+              disabled={code.length !== 6}
+              onClick={submitCode}
+            >
               <Check />
             </button>
           </div>
@@ -83,7 +88,7 @@ function CodeAuthentification({habilitationId, email, handleValidCode, sendBackC
 
           <div>
             <div>Vous n’avez pas reçu votre code ?</div>
-            <div onClick={sendBackCode}><a>Renvoyer un code à l’adresse {email}</a></div>
+            <button type='button' onClick={sendBackCode}><a>Renvoyer un code à l’adresse {email}</a></button>
           </div>
         </div>
       </div>
@@ -134,6 +139,11 @@ function CodeAuthentification({habilitationId, email, handleValidCode, sendBackC
           font-weight: bold;
           font-size: 30px;
           caret-color: transparent;
+        }
+
+        button {
+          border: none;
+          background: none;
         }
 
         /* Chrome, Safari, Edge, Opera */

--- a/components/bases-locales/validator/report/summary/issue-dialog.js
+++ b/components/bases-locales/validator/report/summary/issue-dialog.js
@@ -20,7 +20,7 @@ function IssueDialog({issue, unknowFields, handleClose}) {
             <h3>Ligne{issue.rows.length > 1 ? 's' : ''} avec l’alerte :</h3>
             <h4>{getLabel(issue.code)}</h4>
           </div>
-          <button type='button' onClick={handleClose} aria-label='Fermer la modale indiquant les lignes avec alertes'>
+          <button type='button' onClick={handleClose} aria-label='Fermer la fenêtre indiquant les lignes avec alertes'>
             <X size={40} style={{cursor: 'pointer'}} />
           </button>
         </div>

--- a/components/bases-locales/validator/report/summary/issue-dialog.js
+++ b/components/bases-locales/validator/report/summary/issue-dialog.js
@@ -20,7 +20,9 @@ function IssueDialog({issue, unknowFields, handleClose}) {
             <h3>Ligne{issue.rows.length > 1 ? 's' : ''} avec l’alerte :</h3>
             <h4>{getLabel(issue.code)}</h4>
           </div>
-          <X size={40} style={{cursor: 'pointer'}} onClick={handleClose} />
+          <button type='button' onClick={handleClose} aria-label='Fermer la modale indiquant les lignes avec alertes'>
+            <X size={40} style={{cursor: 'pointer'}} />
+          </button>
         </div>
         <div className='scroll'>
 
@@ -50,6 +52,13 @@ function IssueDialog({issue, unknowFields, handleClose}) {
           left: 0;
           right: 0;
           z-index: 999;
+        }
+
+        button {
+          border: none;
+          background: none;
+          height: fit-content;
+          width: fit-content;
         }
 
         .dialog {

--- a/components/bases-locales/validator/report/summary/issue-rows.js
+++ b/components/bases-locales/validator/report/summary/issue-rows.js
@@ -10,8 +10,10 @@ function IssueRows({issue, rows, isOnAllLines, onClick, type}) {
     return null
   }
 
+  const buttonLabel = `Afficher ${isOnAllLines ? 'toutes les lignes comportant l’alerte' : (rowsCount === 1 ? 'l’alerte' : `les ${rowsCount} alertes`)} ${getLabel(issue)}`
+
   return (
-    <div className='issue' onClick={onClick}>
+    <button type='button' aria-label={buttonLabel} className='issue' onClick={onClick}>
       <div>
         <b>{
           isOnAllLines ?
@@ -31,6 +33,9 @@ function IssueRows({issue, rows, isOnAllLines, onClick, type}) {
           padding: 0.4em 0;
           display: flex;
           justify-content: space-between;
+          width: 100%;
+          border: none;
+          background: none;
         }
 
         .colored {
@@ -42,7 +47,7 @@ function IssueRows({issue, rows, isOnAllLines, onClick, type}) {
           background-color: #f8f8f8;
         }
         `}</style>
-    </div>
+    </button>
   )
 }
 

--- a/components/bases-locales/validator/report/summary/row.js
+++ b/components/bases-locales/validator/report/summary/row.js
@@ -21,7 +21,12 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
 
   return (
     <div>
-      <div className='line' onClick={handleError}>
+      <button
+        type='button'
+        className='line'
+        aria-label={`${showIssues ? 'Masquer' : 'Afficher'} la ligne ${row.line}`}
+        onClick={handleError}
+      >
         <div>
           <div className='col'>
             <b>Ligne {row.line}</b>
@@ -44,7 +49,7 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
         ) : (
           <ChevronDown style={{verticalAlign: 'middle', color: '#222'}} />
         )}
-      </div>
+      </button>
 
       {showIssues &&
         <div className='issue'>
@@ -66,6 +71,9 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
         }
 
         .line {
+          width: 100%;
+          border: none;
+          background: none;
           display: flex;
           justify-content: space-between;
           align-items: center;
@@ -80,6 +88,7 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
 
         .col {
           margin: 0.5em 1em 0.5em 0;
+          font-size: 16px;
         }
 
         .error {

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -23,7 +23,7 @@ function BlogCard({post, onClick}) {
       {onClick && post.tags && (
         <div className='blog-tags-container'>
           {post.tags.map(tag => (
-            <button type='button' aria-label={`Séléctionner le tag ${tag.name}`} key={tag.id} onClick={() => onClick(tag)}>
+            <button type='button' aria-label={`Sélectionner le tag ${tag.name}`} key={tag.id} onClick={() => onClick(tag)}>
               {tag.name}
             </button>
           ))}

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -23,7 +23,9 @@ function BlogCard({post, onClick}) {
       {onClick && post.tags && (
         <div className='blog-tags-container'>
           {post.tags.map(tag => (
-            <span key={tag.id} onClick={() => onClick(tag)}>{tag.name}</span>
+            <button type='button' aria-label={`Séléctionner le tag ${tag.name}`} key={tag.id} onClick={() => onClick(tag)}>
+              {tag.name}
+            </button>
           ))}
         </div>
       )}
@@ -32,6 +34,7 @@ function BlogCard({post, onClick}) {
           <a aria-label={`Lire l’article ${post.title}`}>Lire l’article</a>
         </Link>
       </div>
+
       <style jsx>{`
         .blog-container {
           display: flex;
@@ -59,14 +62,15 @@ function BlogCard({post, onClick}) {
           margin: .5em 0;
         }
 
-        .blog-tags-container span {
+        .blog-tags-container button {
           background-color: ${colors.lighterBlue};
           text-decoration: underline;
           cursor: pointer;
+          border: none;
           border-radius: 15px;
-          padding: 0px 8px;
+          padding: 5px 8px;
           font-size: .8em;
-          font-style: italic;
+          font-style: oblique;
         }
 
         .infos-container {

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -30,7 +30,7 @@ function BlogCard({post, onClick}) {
         </div>
       )}
       <div className='blog-link-container'>
-        <Link href={link} passHref>
+        <Link href={link}>
           <a aria-label={`Lire l’article ${post.title}`}>Lire l’article</a>
         </Link>
       </div>

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -28,7 +28,9 @@ function BlogCard({post, onClick}) {
         </div>
       )}
       <div className='blog-link-container'>
-        <Link href={link}><a>Lire l’article</a></Link>
+        <Link href={link} passHref>
+          <a>Lire l’article</a>
+        </Link>
       </div>
       <style jsx>{`
         .blog-container {

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -29,7 +29,7 @@ function BlogCard({post, onClick}) {
       )}
       <div className='blog-link-container'>
         <Link href={link} passHref>
-          <a>Lire l’article</a>
+          <a aria-label={`Lire l’article ${post.title}`}>Lire l’article</a>
         </Link>
       </div>
       <style jsx>{`

--- a/components/blog-pagination.js
+++ b/components/blog-pagination.js
@@ -13,7 +13,7 @@ function BlogPagination({page, pages, prev, next}) {
 
   return (
     <>
-      <div className='blog-pagination'>
+      <div className='blog-pagination' role='navigation'>
         {prev && (
           <Link href={`${href}${prev}${tags}`} passHref>
             <a className='page'><ArrowLeftCircle aria-label='Aller à la page précédente' style={{verticalAlign: 'middle'}} /></a>

--- a/components/blog-pagination.js
+++ b/components/blog-pagination.js
@@ -15,12 +15,12 @@ function BlogPagination({page, pages, prev, next}) {
     <>
       <div className='blog-pagination' role='navigation'>
         {prev && (
-          <Link href={`${href}${prev}${tags}`} passHref>
+          <Link href={`${href}${prev}${tags}`}>
             <a className='page'><ArrowLeftCircle aria-label='Aller à la page précédente' style={{verticalAlign: 'middle'}} /></a>
           </Link>
         )}
         {pageNumbers.map(n => (
-          <Link key={n} href={`${href}${n}${tags}`} passHref>
+          <Link key={n} href={`${href}${n}${tags}`}>
             <a
               className={page === n ? 'actual-page page' : 'page'}
               aria-label={`${page === n ? `Vous êtes sur la page ${n}` : `Aller à la page ${n}`}`}
@@ -30,7 +30,7 @@ function BlogPagination({page, pages, prev, next}) {
           </Link>
         ))}
         {next && (
-          <Link href={`${href}${next}${tags}`} passHref>
+          <Link href={`${href}${next}${tags}`}>
             <a className='page' aria-label='Aller à la page suivante'><ArrowRightCircle style={{verticalAlign: 'middle'}} /></a>
           </Link>
         )}

--- a/components/blog-pagination.js
+++ b/components/blog-pagination.js
@@ -16,16 +16,22 @@ function BlogPagination({page, pages, prev, next}) {
       <div className='blog-pagination'>
         {prev && (
           <Link href={`${href}${prev}${tags}`} passHref>
-            <a className='page'><ArrowLeftCircle style={{verticalAlign: 'middle'}} /></a>
+            <a className='page'><ArrowLeftCircle aria-label='Aller à la page précédente' style={{verticalAlign: 'middle'}} /></a>
           </Link>
         )}
         {pageNumbers.map(n => (
           <Link key={n} href={`${href}${n}${tags}`} passHref>
+            <a
+              className={page === n ? 'actual-page page' : 'page'}
+              aria-label={`${page === n ? `Vous êtes sur la page ${n}` : `Aller à la page ${n}`}`}
+            >
+              {n}
+            </a>
           </Link>
         ))}
         {next && (
           <Link href={`${href}${next}${tags}`} passHref>
-            <a className='page'><ArrowRightCircle style={{verticalAlign: 'middle'}} /></a>
+            <a className='page' aria-label='Aller à la page suivante'><ArrowRightCircle style={{verticalAlign: 'middle'}} /></a>
           </Link>
         )}
       </div>

--- a/components/blog-pagination.js
+++ b/components/blog-pagination.js
@@ -15,17 +15,16 @@ function BlogPagination({page, pages, prev, next}) {
     <>
       <div className='blog-pagination'>
         {prev && (
-          <Link href={`${href}${prev}${tags}`}>
+          <Link href={`${href}${prev}${tags}`} passHref>
             <a className='page'><ArrowLeftCircle style={{verticalAlign: 'middle'}} /></a>
           </Link>
         )}
         {pageNumbers.map(n => (
-          <Link key={n} href={`${href}${n}${tags}`}>
-            <a className={page === n ? 'actual-page page' : 'page'}>{n}</a>
+          <Link key={n} href={`${href}${n}${tags}`} passHref>
           </Link>
         ))}
         {next && (
-          <Link href={`${href}${next}${tags}`}>
+          <Link href={`${href}${next}${tags}`} passHref>
             <a className='page'><ArrowRightCircle style={{verticalAlign: 'middle'}} /></a>
           </Link>
         )}

--- a/components/button-link.js
+++ b/components/button-link.js
@@ -4,11 +4,11 @@ import Link from 'next/link'
 
 import colors from '@/styles/colors'
 
-function ButtonLink({size, color, href, isDisabled, isOutlined, isExternal, children, ...props}) {
+function ButtonLink({size, color, href, label, isDisabled, isOutlined, isExternal, children, ...props}) {
   if (isDisabled) {
     return (
       <>
-        <a alt='nopnop' className={`button ${size} secondary`} {...props}>
+        <a aria-label={label} className={`button ${size} secondary`} {...props}>
           {children}
         </a>
         <div className='unavailable'>(Temporairement indisponible)</div>
@@ -29,12 +29,12 @@ function ButtonLink({size, color, href, isDisabled, isOutlined, isExternal, chil
 
   return (
     isExternal ? (
-      <a href={href} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
+      <a href={href} aria-label={label} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
         {children}
       </a>
     ) : (
       <Link href={href} passHref>
-        <a className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props} >
+        <a aria-label={label} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props} >
           {children}
         </a>
       </Link>
@@ -55,6 +55,7 @@ ButtonLink.propTypes = {
     'white'
   ]),
   href: PropTypes.string.isRequired,
+  label: PropTypes.string,
   isOutlined: PropTypes.bool,
   isExternal: PropTypes.bool,
   isDisabled: PropTypes.bool,
@@ -64,6 +65,7 @@ ButtonLink.propTypes = {
 ButtonLink.defaultProps = {
   size: null,
   color: 'primary',
+  label: null,
   isOutlined: false,
   isExternal: false,
   isDisabled: false,

--- a/components/button-link.js
+++ b/components/button-link.js
@@ -33,7 +33,7 @@ function ButtonLink({size, color, href, label, isDisabled, isOutlined, isExterna
         {children}
       </a>
     ) : (
-      <Link href={href} passHref>
+      <Link href={href}>
         <a aria-label={label} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props} >
           {children}
         </a>

--- a/components/button-link.js
+++ b/components/button-link.js
@@ -33,7 +33,7 @@ function ButtonLink({size, color, href, isDisabled, isOutlined, isExternal, chil
         {children}
       </a>
     ) : (
-      <Link href={href}>
+      <Link href={href} passHref>
         <a className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props} >
           {children}
         </a>

--- a/components/card.js
+++ b/components/card.js
@@ -21,7 +21,7 @@ function Card({title, link, action, links, list, children, color}) {
 
             {links && (
               <div className='card-links'>
-                { links.map(({title, href}) => <a key={title} href={href}>{title}</a>)}
+                {links.map(({title, href}) => <a key={title} href={href} aria-label={`Accéder au contenu ${title}`}>{title}</a>)}
               </div>
             )}
           </div>

--- a/components/circle-link.js
+++ b/components/circle-link.js
@@ -7,7 +7,7 @@ function CircleLink({size, href, isExternal, icon, label, fontSize, isImportant,
   return (
     <>
       {isExternal ? (
-        <a href={href} className={isDisable ? 'disable' : ''} aria-label={label ? label : children}>
+        <a href={href} className={isDisable ? 'disable' : ''} aria-label={label || children}>
           <div className='circle'>
             {icon}
           </div>
@@ -15,7 +15,7 @@ function CircleLink({size, href, isExternal, icon, label, fontSize, isImportant,
         </a>
       ) : (
         <Link href={href}>
-          <a className={isDisable ? 'disable' : ''} aria-label={label ? label : children}>
+          <a className={isDisable ? 'disable' : ''} aria-label={label || children}>
             <div className='circle'>
               {icon}
             </div>

--- a/components/circle-link.js
+++ b/components/circle-link.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types'
 
 import theme from '@/styles/theme'
 
-function CircleLink({size, href, isExternal, icon, fontSize, isImportant, isDisable, children}) {
+function CircleLink({size, href, isExternal, icon, label, fontSize, isImportant, isDisable, children}) {
   return (
     <>
       {isExternal ? (
-        <a href={href} className={isDisable ? 'disable' : ''}>
+        <a href={href} className={isDisable ? 'disable' : ''} aria-label={label ? label : children}>
           <div className='circle'>
             {icon}
           </div>
@@ -15,7 +15,7 @@ function CircleLink({size, href, isExternal, icon, fontSize, isImportant, isDisa
         </a>
       ) : (
         <Link href={href}>
-          <a className={isDisable ? 'disable' : ''}>
+          <a className={isDisable ? 'disable' : ''} aria-label={label ? label : children}>
             <div className='circle'>
               {icon}
             </div>
@@ -71,6 +71,7 @@ CircleLink.propTypes = {
   size: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
   icon: PropTypes.object.isRequired,
+  label: PropTypes.string,
   fontSize: PropTypes.string,
   children: PropTypes.node,
   isExternal: PropTypes.bool,
@@ -84,6 +85,7 @@ CircleLink.defaultProps = {
   isExternal: false,
   isDisable: false,
   isImportant: false,
+  label: null
 }
 
 export default CircleLink

--- a/components/commune/contact-modal.js
+++ b/components/commune/contact-modal.js
@@ -11,7 +11,14 @@ function ContactModal({mairieInfos, onModalClose}) {
   return (
     <div className='modal-wrapper'>
       <div className='contacts-container'>
-        <button className='close-modal' type='button' onClick={onModalClose}><XSquare /></button>
+        <button
+          className='close-modal'
+          type='button'
+          aria-label='Fermer la fenêtre de contact'
+          onClick={onModalClose}
+        >
+          <XSquare />
+        </button>
         <MairieCard nom={nom} horaires={horaires} email={email} telephone={telephone} />
       </div>
 

--- a/components/commune/historique-item.js
+++ b/components/commune/historique-item.js
@@ -8,8 +8,11 @@ function HistoriqueItem({balData, communeName}) {
   const {updatedAt, client, current, _id} = balData
 
   const balURL = getBalUrl(_id)
+
   const date = new Date(updatedAt)
   const completUpdateTime = `le ${date.toLocaleDateString('fr-FR')} à ${date.getHours()}h${date.getMinutes().toString().padStart(2, '0')}`
+  const accessibleDateOptions = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+  const accessibleUpdateTime = `le ${date.toLocaleDateString('fr-FR', accessibleDateOptions)} à ${date.getHours()} heures ${date.getMinutes().toString().padStart(2, '0')}`
 
   const userName = balData.context?.organisation || `la mairie de ${communeName}`
 
@@ -23,7 +26,7 @@ function HistoriqueItem({balData, communeName}) {
       <div className='user-infos'>
         <div>Par <b>{userName}</b></div>
         <div>Via <b>{client.nom}</b></div>
-        <a href={balURL}><Download /></a>
+        <a href={balURL} aria-label={`Télécharger la version du ${accessibleUpdateTime}`}><Download /></a>
       </div>
 
       <style jsx>{`

--- a/components/commune/historique-item.js
+++ b/components/commune/historique-item.js
@@ -3,30 +3,25 @@ import PropTypes from 'prop-types'
 import {Circle, Download} from 'react-feather'
 
 import {getBalUrl} from '@/lib/api-depot'
+import {sanitizedDateTime, accessibleDateTime} from '@/lib/date'
 
 function HistoriqueItem({balData, communeName}) {
   const {updatedAt, client, current, _id} = balData
 
   const balURL = getBalUrl(_id)
-
-  const date = new Date(updatedAt)
-  const completUpdateTime = `le ${date.toLocaleDateString('fr-FR')} à ${date.getHours()}h${date.getMinutes().toString().padStart(2, '0')}`
-  const accessibleDateOptions = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
-  const accessibleUpdateTime = `le ${date.toLocaleDateString('fr-FR', accessibleDateOptions)} à ${date.getHours()} heures ${date.getMinutes().toString().padStart(2, '0')}`
-
   const userName = balData.context?.organisation || `la mairie de ${communeName}`
 
   return (
     <div className='item-container'>
       <div className='update-infos'>
         <div className='status'><Circle color={current ? theme.successBorder : theme.colors.darkGrey} /></div>
-        <div className='date'>{completUpdateTime}</div>
+        <div className='date'>{sanitizedDateTime(updatedAt)}</div>
       </div>
 
       <div className='user-infos'>
         <div>Par <b>{userName}</b></div>
         <div>Via <b>{client.nom}</b></div>
-        <a href={balURL} aria-label={`Télécharger la version du ${accessibleUpdateTime}`}><Download /></a>
+        <a href={balURL} aria-label={`Télécharger la version du ${accessibleDateTime(updatedAt)}`}><Download /></a>
       </div>
 
       <style jsx>{`

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -43,7 +43,14 @@ function EventBanner() {
 
           return (
             <li className={idx === index ? 'slide' : 'hidden'} key={`${event.title}-${sanitizedDate}`}>
-              <div className='event-link' onClick={() => setSelectedEvent(event)}>{event.title}</div>
+              <button
+                type='button'
+                className='event-link'
+                aria-label={`Afficher l’évènement ${event.title}`}
+                onClick={() => setSelectedEvent(event)}
+              >
+                {event.title}
+              </button>
               {event.subtitle && <div>{event.subtitle}</div>}
               <div className='date'>le {sanitizedDate}</div>
             </li>
@@ -54,7 +61,9 @@ function EventBanner() {
 
       <div className='slideshow-dots'>
         {events.map((event, idx) => (
-          <div
+          <button
+            aria-label={`${index === idx ? 'Vous être sur la slide' : 'Allez à la slide'} de l’évènement ${event.title}`}
+            type='button'
             key={`${event.title}-${event.date}`}
             className={`slideshow-dot ${index === idx ? 'active' : ''}`}
             onClick={() => setIndex(idx)}
@@ -108,6 +117,8 @@ function EventBanner() {
           font-size: 16px;
           font-weight: bold;
           text-align: center;
+          border: none;
+          background: none;
         }
 
         .date {
@@ -133,6 +144,8 @@ function EventBanner() {
           margin: 15px 7px 0px;
           background-color: ${theme.colors.white};
           opacity: 50%;
+          padding: 0;
+          border: none;
         }
 
         .active {

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -62,7 +62,7 @@ function EventBanner() {
       <div className='slideshow-dots'>
         {events.map((event, idx) => (
           <button
-            aria-label={`${index === idx ? 'Vous être sur la slide' : 'Allez à la slide'} de l’évènement ${event.title}`}
+            aria-label={`${index === idx ? 'Vous êtes sur la fiche de' : 'Allez à la fiche de'} l’évènement ${event.title} du ${accessibleDate}`}
             type='button'
             key={`${event.title}-${event.date}`}
             className={`slideshow-dot ${index === idx ? 'active' : ''}`}

--- a/components/evenement/event-banner.js
+++ b/components/evenement/event-banner.js
@@ -14,6 +14,10 @@ function EventBanner() {
   const [index, setIndex] = useState(0)
   const [selectedEvent, setSelectedEvent] = useState(null)
 
+  const sanitizedDate = selectedEvent && new Date(selectedEvent.date).toLocaleDateString('fr-FR')
+  const options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+  const accessibleDate = selectedEvent && new Date(selectedEvent.date).toLocaleDateString('fr-FR', options)
+
   useEffect(() => {
     if (!selectedEvent) {
       const slideInterval = setTimeout(() => {
@@ -61,7 +65,8 @@ function EventBanner() {
       {selectedEvent && (
         <EventModal
           event={selectedEvent}
-          date={new Date(selectedEvent.date).toLocaleDateString('fr-FR')}
+          sanitizedDate={sanitizedDate}
+          accessibleDate={accessibleDate}
           onClose={() => setSelectedEvent(null)}
         />
       )}

--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -11,7 +11,7 @@ import ButtonLink from '../button-link'
 import SectionText from '../section-text'
 import Notification from '../notification'
 
-function EventModal({event, date, isPassed, onClose}) {
+function EventModal({event, sanitizedDate, accessibleDate, isPassed, onClose}) {
   const modalRef = useRef(null)
 
   const {title, subtitle, address, description, href, isSubscriptionClosed, tags, type, startHour, endHour, target, isOnlineOnly, instructions} = event
@@ -44,7 +44,7 @@ function EventModal({event, date, isPassed, onClose}) {
             <div className='date-hours-container'>
               <div className='date-container'>
                 L’évènement {isPassed ? 'a eu' : 'aura'} lieu le
-                <div className='date'>{date}</div>
+                <div className='date' aria-label={accessibleDate}>{sanitizedDate}</div>
               </div>
               <div className='date-container'>
                 De
@@ -239,7 +239,8 @@ EventModal.propTypes = {
     isOnlineOnly: PropTypes.bool.isRequired,
     instructions: PropTypes.string,
   }).isRequired,
-  date: PropTypes.string.isRequired,
+  sanitizedDate: PropTypes.string.isRequired,
+  accessibleDate: PropTypes.string.isRequired,
   isPassed: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired
 }

--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -6,15 +6,16 @@ import {XSquare, MapPin} from 'react-feather'
 import theme from '@/styles/theme'
 
 import {formatTag} from '@/lib/tag'
+import {sanitizedDate, accessibleDate} from '@/lib/date'
 
 import ButtonLink from '../button-link'
 import SectionText from '../section-text'
 import Notification from '../notification'
 
-function EventModal({event, sanitizedDate, accessibleDate, isPassed, onClose}) {
+function EventModal({event, isPassed, onClose}) {
   const modalRef = useRef(null)
 
-  const {title, subtitle, address, description, href, isSubscriptionClosed, tags, type, startHour, endHour, target, isOnlineOnly, instructions} = event
+  const {title, subtitle, address, description, href, date, isSubscriptionClosed, tags, type, startHour, endHour, target, isOnlineOnly, instructions} = event
   const {nom, numero, voie, codePostal, commune} = address
 
   useEffect(() => {
@@ -44,7 +45,7 @@ function EventModal({event, sanitizedDate, accessibleDate, isPassed, onClose}) {
             <div className='date-hours-container'>
               <div className='date-container'>
                 L’évènement {isPassed ? 'a eu' : 'aura'} lieu le
-                <div className='date' aria-label={accessibleDate}>{sanitizedDate}</div>
+                <div className='date' aria-label={accessibleDate(date)}>{sanitizedDate(date)}</div>
               </div>
               <div className='date-container'>
                 De
@@ -234,13 +235,12 @@ EventModal.propTypes = {
     tags: PropTypes.array.isRequired,
     type: PropTypes.string.isRequired,
     startHour: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
     endHour: PropTypes.string.isRequired,
     target: PropTypes.string.isRequired,
     isOnlineOnly: PropTypes.bool.isRequired,
     instructions: PropTypes.string,
   }).isRequired,
-  sanitizedDate: PropTypes.string.isRequired,
-  accessibleDate: PropTypes.string.isRequired,
   isPassed: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired
 }

--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -34,7 +34,7 @@ function EventModal({event, sanitizedDate, accessibleDate, isPassed, onClose}) {
     <div className='modal-wrapper'>
       <div className='modal-container' ref={modalRef}>
         <div className='close-container'>
-          <button type='button' onClick={onClose} className='close-button'>
+          <button type='button' onClick={onClose} aria-label='Fermer la fenêtre' className='close-button'>
             <XSquare />
           </button>
         </div>

--- a/components/evenement/event.js
+++ b/components/evenement/event.js
@@ -13,6 +13,8 @@ function Event({event, background, isPassed, id}) {
   const {nom, numero, voie, codePostal, commune} = address
 
   const sanitizedDate = new Date(date).toLocaleDateString('fr-FR')
+  const options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+  const accessibleDate = new Date(date).toLocaleDateString('fr-FR', options)
 
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -27,7 +29,7 @@ function Event({event, background, isPassed, id}) {
           <div>{subtitle}</div>
         </div>
         <div className='date-container'>
-          <div className='date'>{`le ${sanitizedDate}, de ${startHour} à ${endHour}`}</div>
+          <div className='date' aria-label={`le ${accessibleDate}, de ${startHour} à ${endHour}`}>{`le ${sanitizedDate}, de ${startHour} à ${endHour}`}</div>
         </div>
 
         {isOnlineOnly ? (
@@ -40,7 +42,7 @@ function Event({event, background, isPassed, id}) {
         </div>
       </div>
 
-      {isModalOpen && <EventModal event={event} date={sanitizedDate} isPassed={isPassed} onClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && <EventModal event={event} sanitizedDate={sanitizedDate} accessibleDate={accessibleDate} isPassed={isPassed} onClose={() => setIsModalOpen(false)} />}
 
       <style jsx>{`
         {/* Avoid opacity heritance on modal */}

--- a/components/fantoir/body-list-fantoir.js
+++ b/components/fantoir/body-list-fantoir.js
@@ -6,14 +6,22 @@ import theme from '@/styles/theme'
 function BodyListFantoir({contents, onSelect, isCanceled}) {
   return (
     <div>
-      <div onClick={onSelect}>
+      <button type='button' aria-label={`Accéder aux données de ${contents[0]}`} onClick={onSelect}>
         <div className={isCanceled ? 'line canceled' : 'line'}>
           {contents.map(item => (
             <div key={uniqueId('_infos')} className='infos'>{item}</div>
           ))}
         </div>
-      </div>
+      </button>
+
       <style jsx>{`
+        button {
+          width: 100%;
+          border: none;
+          background: none;
+          font-size: 14px;
+        }
+
         .line {
           display: flex;
           padding: .5em;

--- a/components/fantoir/voie-information.js
+++ b/components/fantoir/voie-information.js
@@ -9,14 +9,19 @@ function VoieInformation({voie}) {
 
   return (
     <div className='line-container'>
-      <div className={voie?.dateAnnulation ? 'line title canceled' : 'line title'} onClick={() => setIsOpen(!isOpen)}>
+      <button
+        type='button'
+        aria-label={`${isOpen ? 'Masquer' : 'Afficher'} les informations concernant la voie ${voie.libelleVoieComplet}`}
+        className={voie?.dateAnnulation ? 'line title canceled' : 'line title'}
+        onClick={() => setIsOpen(!isOpen)}
+      >
         <div className='infos'>{voie.libelleVoieComplet}</div>
         <div className='infos'>{voie.typeVoie}</div>
         <div className='infos'>{voie.codeRivoli}</div>
         <div>
           {isOpen ? <ChevronUp size={35} /> : <ChevronDown size={35} />}
         </div>
-      </div>
+      </button>
       {isOpen && (
         <div className='voie-tags'>
           <div>Code Rivoli : <span>{voie.codeRivoli}</span></div>
@@ -37,6 +42,12 @@ function VoieInformation({voie}) {
           background-color: ${isOpen ? theme.primary : ''};
           display: flex;
           padding: .5em;
+        }
+
+        button {
+          width: 100%;
+          border: none;
+          background: none;
         }
 
         .line {

--- a/components/footer.js
+++ b/components/footer.js
@@ -10,8 +10,8 @@ function Footer() {
         <div className='footer__logo'>
           <Image width={160} height={46} src='/images/logos/etalab.svg' alt='Etalab' />
           <ul className='footer__social'>
-            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Visiter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='Twitter' /></a></li>
-            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Visiter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='Github' /></a></li>
+            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Consulter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='Twitter' /></a></li>
+            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Consulter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='Github' /></a></li>
             <li>
               <Link href='/blog'>
                 <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a>

--- a/components/footer.js
+++ b/components/footer.js
@@ -10,20 +10,25 @@ function Footer() {
         <div className='footer__logo'>
           <Image width={160} height={46} src='/images/logos/etalab.svg' alt='Etalab' />
           <ul className='footer__social'>
+            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Visiter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='Twitter' /></a></li>
+            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Visiter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='Github' /></a></li>
             <li>
               <Link href='/blog' passHref>
-                <a><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a>
+                <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a>
               </Link>
             </li>
             <li>
               <Link href='/nous-contacter' passHref>
-                <a><Image width={25} height={25} src='/images/medias/envelop.svg' alt='Nous contacter' /></a>
+                <a aria-label='Contacter l’équipe'><Image width={25} height={25} src='/images/medias/envelop.svg' alt='Nous contacter' /></a>
               </Link>
             </li>
           </ul>
         </div>
         <ul className='footer__links'>
           <li><h2>adresse.data.gouv.fr</h2></li>
+          <li><Link href='/cgu' passHref><a aria-label='Accéder aux mentions légales et conditions générales d’utilisation'>Mentions légales et CGU</a></Link></li>
+          <li><a href='https://doc.adresse.data.gouv.fr/' aria-label='Consulter la documentation'>Documentation</a></li>
+          <li><a href='https://status.adresse.data.gouv.fr/' aria-label='Consulter la supervision de la Base Adresse Nationale et Base Adresse Locale'>Supervision BAN/BAL</a></li>
           <li><Link href='/nous-contacter' passHref><a>Nous contacter</a></Link></li>
         </ul>
       </div>

--- a/components/footer.js
+++ b/components/footer.js
@@ -13,12 +13,12 @@ function Footer() {
             <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Visiter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='Twitter' /></a></li>
             <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Visiter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='Github' /></a></li>
             <li>
-              <Link href='/blog' passHref>
+              <Link href='/blog'>
                 <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a>
               </Link>
             </li>
             <li>
-              <Link href='/nous-contacter' passHref>
+              <Link href='/nous-contacter'>
                 <a aria-label='Contacter l’équipe'><Image width={25} height={25} src='/images/medias/envelop.svg' alt='Nous contacter' /></a>
               </Link>
             </li>
@@ -26,10 +26,10 @@ function Footer() {
         </div>
         <ul className='footer__links'>
           <li><h2>adresse.data.gouv.fr</h2></li>
-          <li><Link href='/cgu' passHref><a aria-label='Accéder aux mentions légales et conditions générales d’utilisation'>Mentions légales et CGU</a></Link></li>
+          <li><Link href='/cgu'><a aria-label='Accéder aux mentions légales et conditions générales d’utilisation'>Mentions légales et CGU</a></Link></li>
           <li><a href='https://doc.adresse.data.gouv.fr/' aria-label='Consulter la documentation'>Documentation</a></li>
           <li><a href='https://status.adresse.data.gouv.fr/' aria-label='Consulter la supervision de la Base Adresse Nationale et Base Adresse Locale'>Supervision BAN/BAL</a></li>
-          <li><Link href='/nous-contacter' passHref><a>Nous contacter</a></Link></li>
+          <li><Link href='/nous-contacter'><a>Nous contacter</a></Link></li>
         </ul>
       </div>
       <style jsx>{`

--- a/components/footer.js
+++ b/components/footer.js
@@ -10,19 +10,21 @@ function Footer() {
         <div className='footer__logo'>
           <Image width={160} height={46} src='/images/logos/etalab.svg' alt='Etalab' />
           <ul className='footer__social'>
-            <li><a href='https://twitter.com/AdresseDataGouv'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='Twitter' /></a></li>
-            <li><a href='https://github.com/etalab/adresse.data.gouv.fr'><Image width={25} height={25} src='/images/medias/github.svg' alt='Github' /></a></li>
-            <li><Link href='/blog'><a><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a></Link></li>
-            <li><Link href='/nous-contacter'><a><Image width={25} height={25} src='/images/medias/envelop.svg' alt='Nous contacter' /></a></Link></li>
+            <li>
+              <Link href='/blog' passHref>
+                <a><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a>
+              </Link>
+            </li>
+            <li>
+              <Link href='/nous-contacter' passHref>
+                <a><Image width={25} height={25} src='/images/medias/envelop.svg' alt='Nous contacter' /></a>
+              </Link>
+            </li>
           </ul>
         </div>
         <ul className='footer__links'>
           <li><h2>adresse.data.gouv.fr</h2></li>
-          <li><Link href='/cgu'><a>Mentions légales et CGU</a></Link></li>
-          <li><a href='https://doc.adresse.data.gouv.fr/'>Documentation</a></li>
-          <li><a href='https://status.adresse.data.gouv.fr/'>Supervision BAN/BAL</a></li>
-          <li><Link href='/nous-contacter'><a>Nous contacter</a></Link></li>
-          <li><Link href='/accessibilite'><a>Accessibilité : non conforme</a></Link></li>
+          <li><Link href='/nous-contacter' passHref><a>Nous contacter</a></Link></li>
         </ul>
       </div>
       <style jsx>{`

--- a/components/hamburger-menu.js
+++ b/components/hamburger-menu.js
@@ -39,8 +39,8 @@ class HamburgerMenu extends React.Component {
         {visible && (
           <div className='content'>
             {links.map(link => (
-              <Link key={link.text} href={link.href}>
-                <a>{link.text}</a>
+              <Link key={link.text} href={link.href} passHref>
+                <a aria-label={`Visiter la page ${link.text}`}>{link.text}</a>
               </Link>
             ))}
           </div>

--- a/components/hamburger-menu.js
+++ b/components/hamburger-menu.js
@@ -40,7 +40,7 @@ class HamburgerMenu extends React.Component {
           <div className='content'>
             {links.map(link => (
               <Link key={link.text} href={link.href}>
-                <a aria-label={`Visiter la page ${link.text}`}>{link.text}</a>
+                <a aria-label={`Consulter la page ${link.text}`}>{link.text}</a>
               </Link>
             ))}
           </div>

--- a/components/hamburger-menu.js
+++ b/components/hamburger-menu.js
@@ -32,9 +32,9 @@ class HamburgerMenu extends React.Component {
 
     return (
       <div className='dropdown'>
-        <div onClick={this.handleMenu}>
+        <button type='button' aria-label={`${visible ? 'Fermer' : 'Ouvrir'} le menu de navigation`} onClick={this.handleMenu}>
           {visible ? <X size={22} /> : <Menu size={22} />}
-        </div>
+        </button>
 
         {visible && (
           <div className='content'>
@@ -51,6 +51,11 @@ class HamburgerMenu extends React.Component {
             position: relative;
             display: inline-block;
             cursor: pointer;
+          }
+
+          .dropdown button {
+            border: none;
+            background: none;
           }
 
           a {

--- a/components/hamburger-menu.js
+++ b/components/hamburger-menu.js
@@ -39,7 +39,7 @@ class HamburgerMenu extends React.Component {
         {visible && (
           <div className='content'>
             {links.map(link => (
-              <Link key={link.text} href={link.href} passHref>
+              <Link key={link.text} href={link.href}>
                 <a aria-label={`Visiter la page ${link.text}`}>{link.text}</a>
               </Link>
             ))}

--- a/components/hero.js
+++ b/components/hero.js
@@ -43,6 +43,7 @@ function Hero({title, tagline}) {
               href='/bases-locales'
               icon={<Database size={48} color={theme.colors.white} />}
               isImportant
+              label='Découvrir la Base Adresse Locale'
               size='80'
             >
               Bases Adresses Locales

--- a/components/mairie/mairie-schedules.js
+++ b/components/mairie/mairie-schedules.js
@@ -17,13 +17,19 @@ function CommuneSchedules({scheldules}) {
 
   return (
     <div className='schedules'>
-      <div className='scheldule-dropdown' onClick={toggleSchedules}>Horaires d’ouverture
+      <button
+        type='button'
+        aria-label={`${isDisplayed ? 'Masquer' : 'Afficher'} les horaires de la mairie`}
+        className='scheldule-dropdown'
+        onClick={toggleSchedules}
+      >
+        Horaires d’ouverture
         {isDisplayed ? (
           <ChevronDown style={{marginTop: '2px'}} />
         ) : (
           <ChevronRight style={{marginTop: '2px'}} />
         )}
-      </div>
+      </button>
 
       <div>
         {scheldules ? (
@@ -35,8 +41,8 @@ function CommuneSchedules({scheldules}) {
                 </div>
                 <ul>
                   {scheldule.heures.map(heure => (
-                    <li key={`${scheldule.du}-${scheldule.au}&${heure.de}-${heure.a}`}>
-                      De <b>{getHours(heure.de)}h</b> à <b>{getHours(heure.a)}h</b>
+                    <li key={`${scheldule.du}-${scheldule.au}&${heure.de}-${heure.a}`} aria-label={`${getHours(heure.de)} heures à ${getHours(heure.a)} heures`}>
+                      <div aria-hidden>De <b>{getHours(heure.de)}h</b> à <b>{getHours(heure.a)}h</b></div>
                     </li>
                   ))}
                 </ul>
@@ -64,6 +70,8 @@ function CommuneSchedules({scheldules}) {
           gap: 5px;
           cursor: pointer;
           text-decoration: underline;
+          border: none;
+          background: none;
         }
 
         .schedules > div {

--- a/components/map-bal-section.js
+++ b/components/map-bal-section.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import Link from 'next/link'
 import Image from 'next/image'
 
 import {numFormater} from '@/lib/format-numbers'
@@ -15,11 +14,9 @@ function MapBalSection({stats}) {
   return (
     <div className='deployement-container'>
       <div className='map-illustration'>
-        <Link href='/deploiement-bal'>
-          <a>
-            <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} />
-          </a>
-        </Link>
+        <div className='map-illustration'>
+          <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} />
+        </div>
       </div>
       <div className='metrics-container'>
         <Metric metric={stats.bal.nbCommunesCouvertes}> communes couvertes</Metric>

--- a/components/maplibre/select-paint-layer.js
+++ b/components/maplibre/select-paint-layer.js
@@ -13,7 +13,7 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
     >
       <div className='select-wrap'>
         <select
-          aria-label='Séléctionner le layer'
+          aria-label='Modifier l’affichage des adresses sur la carte'
           value={selected}
           name='paint-layer'
           id='paint-layer'

--- a/components/maplibre/select-paint-layer.js
+++ b/components/maplibre/select-paint-layer.js
@@ -13,6 +13,7 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
     >
       <div className='select-wrap'>
         <select
+          aria-label='Séléctionner le layer'
           value={selected}
           name='paint-layer'
           id='paint-layer'
@@ -25,9 +26,14 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
         </select>
 
         {isMobile && !isWrap && (
-          <div className='close-icon' onClick={() => setIsWrap(true)}>
+          <button
+            type='button'
+            aria-label='Fermer la séléction'
+            className='close-icon'
+            onClick={() => setIsWrap(true)}
+          >
             <X />
-          </div>
+          </button>
         )}
       </div>
 
@@ -79,6 +85,9 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
           margin-right: 1em;
           margin-left: 1em;
           cursor: pointer;
+          border: none;
+          background: none;
+          height: fit-content;
         }
 
         .content {

--- a/components/maplibre/select-paint-layer.js
+++ b/components/maplibre/select-paint-layer.js
@@ -13,7 +13,7 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
     >
       <div className='select-wrap'>
         <select
-          aria-label='Modifier l’affichage des adresses sur la carte'
+          aria-label='Sélectionner le fond de carte'
           value={selected}
           name='paint-layer'
           id='paint-layer'

--- a/components/maplibre/switch-map-style.js
+++ b/components/maplibre/switch-map-style.js
@@ -38,6 +38,12 @@ class SwitchMapStyle extends React.Component {
             box-shadow: 0 1px 4px 0 ${theme.boxShadow};
           }
 
+          button {
+            border: none;
+            background: none;
+            padding: 0;
+          }
+
           .switch-style:hover {
             cursor: pointer;
           }

--- a/components/maplibre/switch-map-style.js
+++ b/components/maplibre/switch-map-style.js
@@ -17,13 +17,18 @@ class SwitchMapStyle extends React.Component {
 
     return (
       <div className='switch-style'>
-        <Image
-          width={80}
-          height={80}
-          alt={style}
-          src={src}
+        <button
+          type='button'
+          aria-label={isVector ? 'Passer en vue satellite' : 'Passer en vue vectoriel'}
           onClick={handleChange}
-        />
+        >
+          <Image
+            width={80}
+            height={80}
+            alt={style}
+            src={src}
+          />
+        </button>
         <div className='text'>{style}</div>
         <style jsx>{`
           .switch-style {

--- a/components/question.js
+++ b/components/question.js
@@ -39,7 +39,7 @@ class Question extends React.Component {
       <div id={slug}>
         <button
           type='button'
-          aria-label={`Nous contacter pour la raison suivante : ${question}`}
+          aria-label={`Afficher la réponse à la question : ${question}`}
           className={`question-container ${open ? 'is-open' : ''}`}
           onClick={this.toggle}
         >

--- a/components/question.js
+++ b/components/question.js
@@ -37,18 +37,24 @@ class Question extends React.Component {
 
     return (
       <div id={slug}>
-        <div
+        <button
+          type='button'
+          aria-label={`Nous contacter pour la raison suivante : ${question}`}
           className={`question-container ${open ? 'is-open' : ''}`}
           onClick={this.toggle}
         >
           <div className='question'>{question}</div>
           <div>{open ? <ChevronUp style={{verticalAlign: 'middle'}} /> : <ChevronDown style={{verticalAlign: 'middle'}} />}</div>
-        </div>
+        </button>
         {open && (
           <div className='answer'>{children}</div>
         )}
+
         <style jsx>{`
           .question-container {
+            color: ${theme.darkText};
+            width: 100%;
+            background: none;
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -71,11 +77,13 @@ class Question extends React.Component {
           }
 
           .question {
-            font-size: ${isBold ? '20px' : 'large'};
-            font-weight: ${isBold ? '600' : 'initial'};
+            text-align: left;
+            font-size: ${isBold ? '18px' : 'large'};
+            font-weight: ${isBold ? '800' : 'initial'};
           }
 
           .answer {
+            width: 100%;
             padding: 1em;
             border: 1px solid ${theme.primary};
             border-top: none;

--- a/components/selectable-item-list.js
+++ b/components/selectable-item-list.js
@@ -24,7 +24,7 @@ class SelectableItemList extends React.Component {
           {list.map(item => (
             <button
               type='button'
-              aria-label={buttonIcon === '+' ? `Séléctionner ${item.value}` : `Désélectionner ${item.value}`}
+              aria-label={buttonIcon === '+' ? `Sélectionner ${item.value}` : `Désélectionner ${item.value}`}
               key={item.key}
               className='item'
               onClick={() => action(item)}

--- a/components/selectable-item-list.js
+++ b/components/selectable-item-list.js
@@ -11,7 +11,7 @@ class SelectableItemList extends React.Component {
         value: PropTypes.string.isRequired
       })
     ).isRequired,
-    buttonIcon: PropTypes.string.isRequired,
+    buttonIcon: PropTypes.oneOf(['+', '-']).isRequired,
     action: PropTypes.func.isRequired
   }
 

--- a/components/selectable-item-list.js
+++ b/components/selectable-item-list.js
@@ -22,10 +22,16 @@ class SelectableItemList extends React.Component {
       <div>
         <div className={`${list.length > 0 && 'list selection'}`}>
           {list.map(item => (
-            <div key={item.key} className='item' onClick={() => action(item)}>
+            <button
+              type='button'
+              aria-label={buttonIcon === '+' ? `Séléctionner ${item.value}` : `Désélectionner ${item.value}`}
+              key={item.key}
+              className='item'
+              onClick={() => action(item)}
+            >
               <div className='text'>{item.value}</div>
               <div className='button'>{buttonIcon}</div>
-            </div>
+            </button>
           ))}
         </div>
         <style jsx>{`

--- a/components/social-media.js
+++ b/components/social-media.js
@@ -21,7 +21,7 @@ function SocialMedia() {
           </a>
         </Link>
 
-        <a href='https://twitter.com/adressedatagouv?lang=fr' aria-label='Visiter notre compte Twitter'>
+        <a href='https://twitter.com/adressedatagouv?lang=fr' aria-label='Consulter notre compte Twitter'>
           <Image src='/images/logos/twitter.svg' height={88} width={88} alt='Twitter' />
           <div>Sur notre fil Twitter</div>
         </a>

--- a/components/social-media.js
+++ b/components/social-media.js
@@ -15,24 +15,29 @@ function SocialMedia() {
     <>
       <div className='socials'>
         <Link href='/blog' passHref>
-          <a>
+          <a aria-label='Consulter notre blog'>
             <Image src='/images/logos/blog.svg' height={88} width={88} alt='Blog' />
             <div>En lisant notre blog</div>
           </a>
         </Link>
 
-        <a href='https://twitter.com/adressedatagouv?lang=fr'>
+        <a href='https://twitter.com/adressedatagouv?lang=fr' aria-label='Visiter notre compte Twitter'>
           <Image src='/images/logos/twitter.svg' height={88} width={88} alt='Twitter' />
           <div>Sur notre fil Twitter</div>
         </a>
 
-        <div onClick={handleNewsletter} className='newsletter'>
+        <button
+          onClick={handleNewsletter}
+          className='newsletter'
+          aria-label='S’inscrire à l’infolettre'
+          type='button'
+        >
           <Image src='/images/logos/newsletter.svg' height={88} width={88} alt='Newsletter' />
           <div className='dropdown'>
             {isShown ? <ChevronDown /> : <ChevronRight />}
             En s’inscrivant à l’infolettre
           </div>
-        </div>
+        </button>
       </div>
 
       {isShown && (
@@ -48,6 +53,11 @@ function SocialMedia() {
             justify-content: space-around;
             flex-wrap: wrap;
             gap: 2em;
+          }
+
+          .newsletter {
+            border: none;
+            background: none;
           }
 
           a, .newsletter {

--- a/components/social-media.js
+++ b/components/social-media.js
@@ -14,7 +14,7 @@ function SocialMedia() {
   return (
     <>
       <div className='socials'>
-        <Link href='/blog'>
+        <Link href='/blog' passHref>
           <a>
             <Image src='/images/logos/blog.svg' height={88} width={88} alt='Blog' />
             <div>En lisant notre blog</div>

--- a/components/social-media.js
+++ b/components/social-media.js
@@ -14,7 +14,7 @@ function SocialMedia() {
   return (
     <>
       <div className='socials'>
-        <Link href='/blog' passHref>
+        <Link href='/blog'>
           <a aria-label='Consulter notre blog'>
             <Image src='/images/logos/blog.svg' height={88} width={88} alt='Blog' />
             <div>En lisant notre blog</div>

--- a/components/table-list/index.js
+++ b/components/table-list/index.js
@@ -20,7 +20,7 @@ const getPropsToFilter = (list, filters) => {
   })
 }
 
-function TableList({title, subtitle, list, textFilter, filters, cols, checkIsSelected, handleSelect}) {
+function TableList({title, subtitle, list, textFilter, filters, cols, checkIsSelected, handleSelect, handleLabel}) {
   const [text, setText] = useState('')
   const [propsFilter, setPropsFilter] = useState()
   const [selectedPropsFilter, setSelectedPropsFilter] = useState({})
@@ -91,6 +91,7 @@ function TableList({title, subtitle, list, textFilter, filters, cols, checkIsSel
           cols={cols}
           checkIsSelected={checkIsSelected}
           handleSelect={handleSelect}
+          handleLabel={handleLabel}
         />
       )}
 
@@ -111,6 +112,7 @@ TableList.propTypes = {
   textFilter: PropTypes.func,
   filters: PropTypes.object,
   cols: PropTypes.object.isRequired,
+  handleLabel: PropTypes.func.isRequired,
   checkIsSelected: PropTypes.func,
   handleSelect: PropTypes.func
 }

--- a/components/table-list/table-control.js
+++ b/components/table-list/table-control.js
@@ -9,7 +9,7 @@ import Body from './table/body'
 
 const LIST_LIMIT = 10
 
-function TableControl({list, cols, checkIsSelected, handleSelect}) {
+function TableControl({list, cols, checkIsSelected, handleSelect, handleLabel}) {
   const [orderedList, setOrderedList] = useState(list)
   const [order, setOrder] = useState('desc')
   const [sortedColumn, setSortedColumn] = useState()
@@ -58,6 +58,7 @@ function TableControl({list, cols, checkIsSelected, handleSelect}) {
         <Body
           list={isWrap ? orderedList.slice(0, LIST_LIMIT) : orderedList}
           cols={cols}
+          handleLabel={handleLabel}
           checkIsSelected={checkIsSelected}
           handleSelect={handleSelect}
         />
@@ -69,6 +70,7 @@ function TableControl({list, cols, checkIsSelected, handleSelect}) {
 TableControl.propTypes = {
   list: PropTypes.array.isRequired,
   cols: PropTypes.object.isRequired,
+  handleLabel: PropTypes.func.isRequired,
   checkIsSelected: PropTypes.func,
   handleSelect: PropTypes.func
 }

--- a/components/table-list/table/body.js
+++ b/components/table-list/table/body.js
@@ -2,14 +2,14 @@ import PropTypes from 'prop-types'
 
 import theme from '@/styles/theme'
 
-function Body({list, cols, checkIsSelected, handleSelect}) {
+function Body({list, cols, checkIsSelected, handleLabel, handleSelect}) {
   return (
     <tbody>
       {list.map((item, idx) => (
         <tr
           role='button'
           tabIndex='0'
-          aria-label={`Accéder à la commune ${item.nom} dans l’explorateur`}
+          aria-label={() => handleLabel(item.nom)}
           key={`tr-${idx}`} // eslint-disable-line react/no-array-index-key
           className={`${checkIsSelected && checkIsSelected(item) ? 'selected' : null}`}
           onClick={handleSelect ? () => handleSelect(item) : null}
@@ -57,6 +57,7 @@ function Body({list, cols, checkIsSelected, handleSelect}) {
 Body.propTypes = {
   list: PropTypes.array.isRequired,
   cols: PropTypes.object.isRequired,
+  handleLabel: PropTypes.func.isRequired,
   handleSelect: PropTypes.func,
   checkIsSelected: PropTypes.func
 }

--- a/components/table-list/table/body.js
+++ b/components/table-list/table/body.js
@@ -7,6 +7,9 @@ function Body({list, cols, checkIsSelected, handleSelect}) {
     <tbody>
       {list.map((item, idx) => (
         <tr
+          role='button'
+          tabIndex='0'
+          aria-label={`Accéder à la commune ${item.nom} dans l’explorateur`}
           key={`tr-${idx}`} // eslint-disable-line react/no-array-index-key
           className={`${checkIsSelected && checkIsSelected(item) ? 'selected' : null}`}
           onClick={handleSelect ? () => handleSelect(item) : null}

--- a/components/table-list/table/head.js
+++ b/components/table-list/table/head.js
@@ -5,22 +5,31 @@ import Header from './header'
 const order = (a, b, direction) => (
   <button
     type='button'
-    style={{display: 'inline-flex', border: 'none', background: 'none', color: 'white'}}
     aria-label={`Trier par ordre ${direction === 'asc' ? 'croissant' : 'décroissant'}`}
   >
     <ArrowDown />
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      fontSize: '14px',
-      lineHeight: '14px',
-      marginLeft: '3px',
-      marginTop: '-2px'
-    }}
-    >
+    <div>
       <div>{a}</div>
       <div>{b}</div>
     </div>
+
+    <style jsx>{`
+      button {
+        display: inline-flex;
+        border: none;
+        background: none;
+        color: white;
+      }
+
+      .order-instruction {
+        display: flex;
+        flex-direction: column;
+        font-size: 14px;
+        line-height: 14px;
+        margin-left: 3px;
+        margin-top: -2px
+      }
+    `}</style>
   </button>
 )
 

--- a/components/table-list/table/head.js
+++ b/components/table-list/table/head.js
@@ -2,8 +2,12 @@ import PropTypes from 'prop-types'
 import {ArrowDown} from 'react-feather'
 import Header from './header'
 
-const order = (a, b) => (
-  <div style={{display: 'inline-flex'}}>
+const order = (a, b, direction, type) => (
+  <button
+    type='button'
+    style={{display: 'inline-flex', border: 'none', background: 'none', color: 'white'}}
+    aria-label={`Trier ${type === 'alpha' ? 'les communes par nom et' : 'par nombre d’adresses et'} par ordre ${direction === 'asc' ? 'croissant' : 'décroissant'}`}
+  >
     <ArrowDown />
     <div style={{
       display: 'flex',
@@ -17,17 +21,17 @@ const order = (a, b) => (
       <div>{a}</div>
       <div>{b}</div>
     </div>
-  </div>
+  </button>
 )
 
 const alphabetical = {
-  asc: order('Z', 'A'),
-  desc: order('A', 'Z')
+  asc: order('Z', 'A', 'asc', 'alpha'),
+  desc: order('A', 'Z', 'desc', 'alpha')
 }
 
 const numeric = {
-  asc: order('9', '1'),
-  desc: order('1', '9')
+  asc: order('9', '1', 'asc', 'num'),
+  desc: order('1', '9', 'desc', 'num')
 }
 
 const sortTypes = {alphabetical, numeric}

--- a/components/table-list/table/head.js
+++ b/components/table-list/table/head.js
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types'
 import {ArrowDown} from 'react-feather'
 import Header from './header'
 
-const order = (a, b, direction, type) => (
+const order = (a, b, direction) => (
   <button
     type='button'
     style={{display: 'inline-flex', border: 'none', background: 'none', color: 'white'}}
-    aria-label={`Trier ${type === 'alpha' ? 'les communes par nom et' : 'par nombre d’adresses et'} par ordre ${direction === 'asc' ? 'croissant' : 'décroissant'}`}
+    aria-label={`Trier par ordre ${direction === 'asc' ? 'croissant' : 'décroissant'}`}
   >
     <ArrowDown />
     <div style={{
@@ -25,13 +25,13 @@ const order = (a, b, direction, type) => (
 )
 
 const alphabetical = {
-  asc: order('Z', 'A', 'asc', 'alpha'),
-  desc: order('A', 'Z', 'desc', 'alpha')
+  asc: order('Z', 'A', 'asc'),
+  desc: order('A', 'Z', 'desc')
 }
 
 const numeric = {
-  asc: order('9', '1', 'asc', 'num'),
-  desc: order('1', '9', 'desc', 'num')
+  asc: order('9', '1', 'asc'),
+  desc: order('1', '9', 'desc')
 }
 
 const sortTypes = {alphabetical, numeric}

--- a/components/table-list/table/index.js
+++ b/components/table-list/table/index.js
@@ -25,9 +25,9 @@ class Table extends React.Component {
         </table>
 
         {!hasDisabledWrap &&
-          <div className='wrap' onClick={onWrap}>
-            {isWrap ? 'Tout afficher' : 'Réduire'}
-          </div>}
+          <button type='button' className='wrap' onClick={onWrap}>
+            {isWrap ? 'Afficher tout la liste' : 'Réduire l’affichage de la liste'}
+          </button>}
 
         <style jsx>{`
           .table-container {
@@ -44,6 +44,8 @@ class Table extends React.Component {
             text-align: center;
             margin-top: 1em;
             text-decoration: underline;
+            border: none;
+            background: none;
           }
 
           .wrap:hover {

--- a/lib/date.js
+++ b/lib/date.js
@@ -7,3 +7,26 @@ export function sortEventsByDate(events, order) {
     },
   ], [order])
 }
+
+export function sanitizedDate(date) {
+  return new Date(date).toLocaleDateString('fr-FR')
+}
+
+export function accessibleDate(date) {
+  const options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+
+  return new Date(date).toLocaleDateString('fr-FR', options)
+}
+
+export function sanitizedDateTime(date) {
+  const newDate = new Date(date)
+
+  return `le ${newDate.toLocaleDateString('fr-FR')} à ${newDate.getHours()}h${newDate.getMinutes().toString().padStart(2, '0')}`
+}
+
+export function accessibleDateTime(date) {
+  const newDate = new Date(date)
+  const options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+
+  return `le ${newDate.toLocaleDateString('fr-FR', options)} à ${newDate.getHours()} heures ${newDate.getMinutes().toString().padStart(2, '0')}`
+}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -50,9 +50,14 @@ function BlogIndex({posts, pagination, tags, tagsList}) {
                   <div className='tags-container'>
                     <div className='tags-list'>
                       {tags.map(tag => (
-                        <div key={tag} className='tag' onClick={() => removeTag(tag)}>
+                        <button
+                          type='button'
+                          aria-label={`Supprimer le tag ${getTagName(tag)}`}
+                          key={tag} className='tag'
+                          onClick={() => removeTag(tag)}
+                        >
                           {getTagName(tag)} <X size='15' style={{verticalAlign: 'middle'}} />
-                        </div>
+                        </button>
                       ))}
                     </div>
                     <Button onClick={resetTags} size='small' style={{float: 'right'}}>Voir tous les articles</Button>
@@ -107,9 +112,11 @@ function BlogIndex({posts, pagination, tags, tagsList}) {
         .tag {
           background-color: ${colors.lighterBlue};
           border-radius: 15px;
-          padding: 2px 10px;
+          border: none;
+          padding: 5px 10px;
           margin: 3px;
           font-size: .8em;
+          font-weight: bold;
           font-style: italic;
           text-decoration: underline;
           color: ${colors.blue}


### PR DESCRIPTION
Cette PR fait suite à [**Modification du wording des liens et boutons par soucis d'accessibilité**](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/pull/1197).

Testé sous le lecteur d'écran VoiceOver (Mac)

Elle se concentre sur 

- l'ajout d'attributs tels que `aria-label` pour outrepasser l'`innerText` par les lecteurs d'écran et rajouter du contexte à l'action.

- L'ajout de l'attribut `passHref` aux composants `Link` de Nextjs, parents de balises `<a>` (joue sur l'accessibilité et le SEO)

- L'ajout de rôles et types pertinents à des éléments interactifs afin de faciliter leur compréhension par les utilisateurs du lecteur d'écran