### PR TITLE
Utilisation d'attributs alt pertinents pour les images

### DIFF
--- a/components/api-doc/api-adresse/expandable-menu.js
+++ b/components/api-doc/api-adresse/expandable-menu.js
@@ -17,9 +17,9 @@ function ExpandableMenu({title, children, label}) {
         <div className='title'>{title}</div>
         <div style={{paddingLeft: '.5em'}}>
           {isExpanded ? (
-            <ChevronUp style={{verticalAlign: 'middle'}} size={38} alt='' />
+            <ChevronUp style={{verticalAlign: 'middle'}} size={38} alt />
           ) : (
-            <ChevronDown style={{verticalAlign: 'middle'}} size={38} alt='' />
+            <ChevronDown style={{verticalAlign: 'middle'}} size={38} alt />
           )}
         </div>
       </div>

--- a/components/api-doc/api-adresse/expandable-menu.js
+++ b/components/api-doc/api-adresse/expandable-menu.js
@@ -16,7 +16,11 @@ function ExpandableMenu({title, children, label}) {
       <div className='head'>
         <div className='title'>{title}</div>
         <div style={{paddingLeft: '.5em'}}>
-          {isExpanded ? <ChevronUp style={{verticalAlign: 'middle'}} size={38} /> : <ChevronDown style={{verticalAlign: 'middle'}} size={38} />}
+          {isExpanded ? (
+            <ChevronUp style={{verticalAlign: 'middle'}} size={38} alt='' />
+          ) : (
+            <ChevronDown style={{verticalAlign: 'middle'}} size={38} alt='' />
+          )}
         </div>
       </div>
 

--- a/components/api-doc/api-adresse/notification-api.js
+++ b/components/api-doc/api-adresse/notification-api.js
@@ -5,10 +5,10 @@ import {HelpCircle, AlertTriangle, Check, X} from 'react-feather'
 import theme from '../../../styles/theme'
 
 const types = {
-  info: {icon: <HelpCircle alt='' />, title: 'Bon à savoir'},
-  success: {icon: <Check alt='' />, title: 'Réussi'},
-  warning: {icon: <AlertTriangle alt='' />, title: 'Attention'},
-  error: {icon: <X alt='' />, title: 'Erreur'}
+  info: {icon: <HelpCircle alt />, title: 'Bon à savoir'},
+  success: {icon: <Check alt />, title: 'Réussi'},
+  warning: {icon: <AlertTriangle alt />, title: 'Attention'},
+  error: {icon: <X alt />, title: 'Erreur'}
 }
 
 function NotificationApi({message, type}) {

--- a/components/api-doc/api-adresse/notification-api.js
+++ b/components/api-doc/api-adresse/notification-api.js
@@ -5,10 +5,10 @@ import {HelpCircle, AlertTriangle, Check, X} from 'react-feather'
 import theme from '../../../styles/theme'
 
 const types = {
-  info: {icon: <HelpCircle />, title: 'Bon à savoir'},
-  success: {icon: <Check />, title: 'Réussi'},
-  warning: {icon: <AlertTriangle />, title: 'Attention'},
-  error: {icon: <X />, title: 'Erreur'}
+  info: {icon: <HelpCircle alt='' />, title: 'Bon à savoir'},
+  success: {icon: <Check alt='' />, title: 'Réussi'},
+  warning: {icon: <AlertTriangle alt='' />, title: 'Attention'},
+  error: {icon: <X alt='' />, title: 'Erreur'}
 }
 
 function NotificationApi({message, type}) {

--- a/components/api-doc/api-adresse/technical-doc/index.js
+++ b/components/api-doc/api-adresse/technical-doc/index.js
@@ -11,7 +11,7 @@ function TechnicalDoc({paths, defaultModel, defaultAttributs, optionAttributs}) 
     <Section background='color'>
 
       <div className='title'>
-        <div className='feather-icon'><Book alt='' /></div>
+        <div className='feather-icon'><Book alt /></div>
         <h2 className='h2'>Documentation technique</h2>
       </div>
 

--- a/components/api-doc/api-adresse/technical-doc/index.js
+++ b/components/api-doc/api-adresse/technical-doc/index.js
@@ -11,7 +11,7 @@ function TechnicalDoc({paths, defaultModel, defaultAttributs, optionAttributs}) 
     <Section background='color'>
 
       <div className='title'>
-        <div className='feather-icon'><Book /></div>
+        <div className='feather-icon'><Book alt='' /></div>
         <h2 className='h2'>Documentation technique</h2>
       </div>
 

--- a/components/base-adresse-nationale/addresses-list.js
+++ b/components/base-adresse-nationale/addresses-list.js
@@ -33,7 +33,7 @@ function AddressesList({title, placeholder, addresses, getLabel, addressComponen
         </div>
         {addresses.length > 0 ? (
           <div className='search-input'>
-            <div className='search-icon'><Search size={18} alt='' /></div>
+            <div className='search-icon'><Search size={18} alt /></div>
             <input
               type='text'
               placeholder={placeholder || 'Recherche'}

--- a/components/base-adresse-nationale/addresses-list.js
+++ b/components/base-adresse-nationale/addresses-list.js
@@ -33,7 +33,7 @@ function AddressesList({title, placeholder, addresses, getLabel, addressComponen
         </div>
         {addresses.length > 0 ? (
           <div className='search-input'>
-            <div className='search-icon'><Search size={18} /></div>
+            <div className='search-icon'><Search size={18} alt='' /></div>
             <input
               type='text'
               placeholder={placeholder || 'Recherche'}

--- a/components/base-adresse-nationale/certification.js
+++ b/components/base-adresse-nationale/certification.js
@@ -10,13 +10,13 @@ function Certification({isCertified, certifiedMessage, notCertifiedMessage, icon
     <div>
       {isCertified && (
         <Tooltip message={certifiedMessage} direction={tooltipDirection}>
-          <CheckCircle style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={validIconColor} size={iconSize} alt='' />
+          <CheckCircle style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={validIconColor} size={iconSize} alt />
         </Tooltip>
       )}
 
       {!isCertified && notCertifiedMessage && (
         <Tooltip message={notCertifiedMessage} direction={tooltipDirection}>
-          <XOctagon style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={theme.warningBorder} size={iconSize} alt='' />
+          <XOctagon style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={theme.warningBorder} size={iconSize} alt />
         </Tooltip>
       )}
     </div>

--- a/components/base-adresse-nationale/certification.js
+++ b/components/base-adresse-nationale/certification.js
@@ -10,13 +10,13 @@ function Certification({isCertified, certifiedMessage, notCertifiedMessage, icon
     <div>
       {isCertified && (
         <Tooltip message={certifiedMessage} direction={tooltipDirection}>
-          <CheckCircle style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={validIconColor} size={iconSize} />
+          <CheckCircle style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={validIconColor} size={iconSize} alt='' />
         </Tooltip>
       )}
 
       {!isCertified && notCertifiedMessage && (
         <Tooltip message={notCertifiedMessage} direction={tooltipDirection}>
-          <XOctagon style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={theme.warningBorder} size={iconSize} />
+          <XOctagon style={{marginLeft: '.5em', verticalAlign: 'sub'}} color={theme.warningBorder} size={iconSize} alt='' />
         </Tooltip>
       )}
     </div>

--- a/components/base-adresse-nationale/commune/details.js
+++ b/components/base-adresse-nationale/commune/details.js
@@ -11,7 +11,7 @@ function Details({certificationPercentage, nbVoies, nbLieuxDits, nbNumeros, code
       <div className='commune-general'>
         <PostalCodes codes={codesPostaux} />
         <div className='with-icon'>
-          <Users alt='' /> <div><b>{population}</b> habitants</div>
+          <Users alt /> <div><b>{population}</b> habitants</div>
         </div>
       </div>
       <div className='number-of-wrapper'>

--- a/components/base-adresse-nationale/commune/details.js
+++ b/components/base-adresse-nationale/commune/details.js
@@ -11,7 +11,7 @@ function Details({certificationPercentage, nbVoies, nbLieuxDits, nbNumeros, code
       <div className='commune-general'>
         <PostalCodes codes={codesPostaux} />
         <div className='with-icon'>
-          <Users /> <div><b>{population}</b> habitants</div>
+          <Users alt='' /> <div><b>{population}</b> habitants</div>
         </div>
       </div>
       <div className='number-of-wrapper'>

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -65,7 +65,7 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
       {certificationInProgress && nbNumeros > 0 && (
         <Notification style={{marginTop: '1em'}} type='info'>
           Les adresses sont en <b>cours de certification</b> par la commune.<br />{}
-          Actuellement, <span className='non-breaking'><b>{nbNumerosCertifies} / {nbNumeros} adresses ({certificationPercentage}%) sont certifiées</b> <CheckCircle style={{verticalAlign: 'middle'}} color={theme.successBorder} size={26} alt='' /></span>.
+          Actuellement, <span className='non-breaking'><b>{nbNumerosCertifies} / {nbNumeros} adresses ({certificationPercentage}%) sont certifiées</b> <CheckCircle style={{verticalAlign: 'middle'}} color={theme.successBorder} size={26} alt /></span>.
         </Notification>
       )}
 

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -65,7 +65,7 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
       {certificationInProgress && nbNumeros > 0 && (
         <Notification style={{marginTop: '1em'}} type='info'>
           Les adresses sont en <b>cours de certification</b> par la commune.<br />{}
-          Actuellement, <span className='non-breaking'><b>{nbNumerosCertifies} / {nbNumeros} adresses ({certificationPercentage}%) sont certifiées</b> <CheckCircle style={{verticalAlign: 'middle'}} color={theme.successBorder} size={26} /></span>.
+          Actuellement, <span className='non-breaking'><b>{nbNumerosCertifies} / {nbNumeros} adresses ({certificationPercentage}%) sont certifiées</b> <CheckCircle style={{verticalAlign: 'middle'}} color={theme.successBorder} size={26} alt='' /></span>.
         </Notification>
       )}
 

--- a/components/base-adresse-nationale/explorer.js
+++ b/components/base-adresse-nationale/explorer.js
@@ -14,7 +14,7 @@ const ADDRESSTYPES = {
 function SearchMessage() {
   return (
     <div className='search-message'>
-      <ArrowUp />
+      <ArrowUp alt='' />
       <h4>Rechercher une adresse</h4>
       <style jsx>{`
         .search-message {

--- a/components/base-adresse-nationale/explorer.js
+++ b/components/base-adresse-nationale/explorer.js
@@ -14,7 +14,7 @@ const ADDRESSTYPES = {
 function SearchMessage() {
   return (
     <div className='search-message'>
-      <ArrowUp alt='' />
+      <ArrowUp alt />
       <h4>Rechercher une adresse</h4>
       <style jsx>{`
         .search-message {

--- a/components/base-adresse-nationale/layout-selector.js
+++ b/components/base-adresse-nationale/layout-selector.js
@@ -10,7 +10,7 @@ function LayoutSelector({name, value, icon, isSelected, handleClick}) {
       className={`layout ${isSelected ? 'selected' : ''}`}
       onClick={() => handleClick(value)}
     >
-      <div><Icon /></div>
+      <div alt=''><Icon /></div>
       <div>{name}</div>
 
       <style jsx>{`

--- a/components/base-adresse-nationale/layout-selector.js
+++ b/components/base-adresse-nationale/layout-selector.js
@@ -10,7 +10,7 @@ function LayoutSelector({name, value, icon, isSelected, handleClick}) {
       className={`layout ${isSelected ? 'selected' : ''}`}
       onClick={() => handleClick(value)}
     >
-      <div alt=''><Icon /></div>
+      <div alt><Icon /></div>
       <div>{name}</div>
 
       <style jsx>{`

--- a/components/base-adresse-nationale/numero/coordinates-copy.js
+++ b/components/base-adresse-nationale/numero/coordinates-copy.js
@@ -50,7 +50,7 @@ function CoordinatesCopy({coordinates, setCopyError, setIsCopySucceded, setIsCop
           onClick={handleClick}
         >
           Copier la position GPS
-          <Clipboard style={{marginLeft: '1em', verticalAlign: 'middle'}} alt='' />
+          <Clipboard style={{marginLeft: '1em', verticalAlign: 'middle'}} alt />
         </Button>
       )}
       <style jsx>{`

--- a/components/base-adresse-nationale/numero/coordinates-copy.js
+++ b/components/base-adresse-nationale/numero/coordinates-copy.js
@@ -38,8 +38,9 @@ function CoordinatesCopy({coordinates, setCopyError, setIsCopySucceded, setIsCop
             size='small'
             style={{borderRadius: '0 3px 3px 0'}}
             onClick={handleClick}
+            label='Copier les coordonnées'
           >
-            <Clipboard alt='Copier les coordonnées' />
+            <Clipboard alt />
           </Button>
         </div>
       ) : (

--- a/components/base-adresse-nationale/numero/coordinates-copy.js
+++ b/components/base-adresse-nationale/numero/coordinates-copy.js
@@ -39,7 +39,7 @@ function CoordinatesCopy({coordinates, setCopyError, setIsCopySucceded, setIsCop
             style={{borderRadius: '0 3px 3px 0'}}
             onClick={handleClick}
           >
-            <Clipboard />
+            <Clipboard alt='Copier les coordonnées' />
           </Button>
         </div>
       ) : (
@@ -50,7 +50,7 @@ function CoordinatesCopy({coordinates, setCopyError, setIsCopySucceded, setIsCop
           onClick={handleClick}
         >
           Copier la position GPS
-          <Clipboard style={{marginLeft: '1em', verticalAlign: 'middle'}} />
+          <Clipboard style={{marginLeft: '1em', verticalAlign: 'middle'}} alt='' />
         </Button>
       )}
       <style jsx>{`

--- a/components/base-adresse-nationale/postal-codes.js
+++ b/components/base-adresse-nationale/postal-codes.js
@@ -19,7 +19,7 @@ function PostalCodes({codes}) {
               className='with-icon wrapper'
               onClick={() => setShowCodes(!showCodes)}
             >
-              <div>Codes postaux</div> {showCodes ? <ChevronUp alt='' /> : <ChevronDown alt='' />}
+              <div>Codes postaux</div> {showCodes ? <ChevronUp alt /> : <ChevronDown alt />}
             </button>
           </div>
           {showCodes && (

--- a/components/base-adresse-nationale/postal-codes.js
+++ b/components/base-adresse-nationale/postal-codes.js
@@ -19,7 +19,7 @@ function PostalCodes({codes}) {
               className='with-icon wrapper'
               onClick={() => setShowCodes(!showCodes)}
             >
-              <div>Codes postaux</div> {showCodes ? <ChevronUp /> : <ChevronDown />}
+              <div>Codes postaux</div> {showCodes ? <ChevronUp alt='' /> : <ChevronDown alt='' />}
             </button>
           </div>
           {showCodes && (

--- a/components/bases-locales/bal-cover-map.js
+++ b/components/bases-locales/bal-cover-map.js
@@ -183,7 +183,7 @@ class BalCoverMap extends React.Component {
       <div>
         {this.state.warningZoom && (
           <div className='warning'>
-            <AlertTriangle color='orange' />
+            <AlertTriangle color='orange' alt='Annonce d’alerte' />
             <div className='warning-text'>
               Double-cliquez sur la carte pour activer le zoom
             </div>

--- a/components/bases-locales/bal-cover-map.js
+++ b/components/bases-locales/bal-cover-map.js
@@ -183,7 +183,7 @@ class BalCoverMap extends React.Component {
       <div>
         {this.state.warningZoom && (
           <div className='warning'>
-            <AlertTriangle color='orange' alt='Annonce d’alerte' />
+            <AlertTriangle color='orange' alt='Avertissement' />
             <div className='warning-text'>
               Double-cliquez sur la carte pour activer le zoom
             </div>

--- a/components/bases-locales/bases-adresse-locales/dataset/description.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/description.js
@@ -21,7 +21,7 @@ class Description extends React.Component {
       <div>
         <Markdown markdown={description} />
         {page &&
-          <a className='dgv-link' href={page}><ArrowRight style={{marginRight: '5px', verticalAlign: 'middle'}} /> Consulter ce jeu de données sur data.gouv.fr</a>}
+          <a className='dgv-link' href={page}><ArrowRight style={{marginRight: '5px', verticalAlign: 'middle'}} alt='' /> Consulter ce jeu de données sur data.gouv.fr</a>}
       </div>
     )
   }

--- a/components/bases-locales/bases-adresse-locales/dataset/description.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/description.js
@@ -21,7 +21,7 @@ class Description extends React.Component {
       <div>
         <Markdown markdown={description} />
         {page &&
-          <a className='dgv-link' href={page}><ArrowRight style={{marginRight: '5px', verticalAlign: 'middle'}} alt='' /> Consulter ce jeu de données sur data.gouv.fr</a>}
+          <a className='dgv-link' href={page}><ArrowRight style={{marginRight: '5px', verticalAlign: 'middle'}} alt /> Consulter ce jeu de données sur data.gouv.fr</a>}
       </div>
     )
   }

--- a/components/bases-locales/bases-adresse-locales/dataset/header.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/header.js
@@ -38,7 +38,7 @@ class Header extends React.Component {
             </Info>
           )}
         </div>
-        {logo && <Image objectFit='contain' width={240} height={140} src={logo} alt='' />}
+        {logo && <Image objectFit='contain' width={240} height={140} src={logo} alt />}
 
         <style jsx>{`
           .head {

--- a/components/bases-locales/bases-adresse-locales/dataset/header.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/header.js
@@ -38,7 +38,7 @@ class Header extends React.Component {
             </Info>
           )}
         </div>
-        {logo && <Image objectFit='contain' width={240} height={140} src={logo} alt={`${name}-logo`} />}
+        {logo && <Image objectFit='contain' width={240} height={140} src={logo} alt='' />}
 
         <style jsx>{`
           .head {

--- a/components/bases-locales/bases-adresse-locales/dataset/index.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/index.js
@@ -50,7 +50,7 @@ function Dataset({dataset}) {
 
         {url && <div className='links'>
           <ButtonLink isExternal href={url} size='large' >
-            Télécharger le jeu de données<Download style={{verticalAlign: 'middle', marginLeft: '3px'}} alt='' />
+            Télécharger le jeu de données<Download style={{verticalAlign: 'middle', marginLeft: '3px'}} alt />
           </ButtonLink>
         </div>}
 

--- a/components/bases-locales/bases-adresse-locales/dataset/index.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/index.js
@@ -50,7 +50,7 @@ function Dataset({dataset}) {
 
         {url && <div className='links'>
           <ButtonLink isExternal href={url} size='large' >
-            Télécharger le jeu de données<Download style={{verticalAlign: 'middle', marginLeft: '3px'}} />
+            Télécharger le jeu de données<Download style={{verticalAlign: 'middle', marginLeft: '3px'}} alt='' />
           </ButtonLink>
         </div>}
 

--- a/components/bases-locales/bases-adresse-locales/info-report.js
+++ b/components/bases-locales/bases-adresse-locales/info-report.js
@@ -15,12 +15,13 @@ class InfoReport extends React.Component {
 
     return (
       <Info title='Conformité' type={isValid ? 'valid' : 'not-valid'}>
-        {isValid ? <Check size={14} /> : <X size={14} />}
+        {isValid ? <Check size={14} alt='Conforme' /> : <X size={14} alt='Non-conforme' />}
 
         <div className='info-report'>
           <Link href={`/bases-locales/jeux-de-donnees/${id}/rapport`}>
             <a>Consulter le rapport</a>
           </Link>
+
           <style jsx>{`
             .info-report {
               margin-left: 0.2em;

--- a/components/bases-locales/bases-adresse-locales/organization.js
+++ b/components/bases-locales/bases-adresse-locales/organization.js
@@ -17,7 +17,7 @@ class Organization extends React.Component {
     const {logo, name} = this.props
     return (
       <div className='organization'>
-        <Image width={100} height={100} objectFit='contain' src={logo} alt={name} />
+        <Image width={100} height={100} objectFit='contain' src={logo} alt='' />
         <div className='name'>{name}</div>
 
         <style jsx>{`

--- a/components/bases-locales/bases-adresse-locales/organization.js
+++ b/components/bases-locales/bases-adresse-locales/organization.js
@@ -17,7 +17,7 @@ class Organization extends React.Component {
     const {logo, name} = this.props
     return (
       <div className='organization'>
-        <Image width={100} height={100} objectFit='contain' src={logo} alt='' />
+        <Image width={100} height={100} objectFit='contain' src={logo} alt />
         <div className='name'>{name}</div>
 
         <style jsx>{`

--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -48,7 +48,7 @@ class Summary extends React.Component {
             </ButtonLink>
             {url &&
               <a href={url} aria-label={`Télécharger les ${title}`}>
-                <DownloadCloud size={18} style={{verticalAlign: 'middle', marginRight: '5px'}} />
+                <DownloadCloud size={18} style={{verticalAlign: 'middle', marginRight: '5px'}} alt='' />
                 Télécharger la Base Adresse Locale
               </a>}
           </div>

--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -48,7 +48,7 @@ class Summary extends React.Component {
             </ButtonLink>
             {url &&
               <a href={url} aria-label={`Télécharger les ${title}`}>
-                <DownloadCloud size={18} style={{verticalAlign: 'middle', marginRight: '5px'}} alt='' />
+                <DownloadCloud size={18} style={{verticalAlign: 'middle', marginRight: '5px'}} alt />
                 Télécharger la Base Adresse Locale
               </a>}
           </div>

--- a/components/bases-locales/charte/commune.js
+++ b/components/bases-locales/charte/commune.js
@@ -12,7 +12,7 @@ function Commune({name, codeCommune, picture, height, width, signatureDate, char
   return (
     <div className='commune-container' onClick={event => event.stopPropagation()}>
       <div className='commune-infos'>
-        <Image src={picture} height={height / 2} width={width / 2} alt='' />
+        <Image src={picture} height={height / 2} width={width / 2} alt />
         <Link href={`/commune/${codeCommune}`} aria-label={`Aller sur la page commune de ${name}`}>{`${name} - ${codeCommune}`}</Link>
       </div>
       <div className='signature-date'>Partenaire depuis le <b>{date}</b></div>

--- a/components/bases-locales/charte/commune.js
+++ b/components/bases-locales/charte/commune.js
@@ -6,19 +6,19 @@ import {ExternalLink} from 'react-feather'
 import theme from '@/styles/theme'
 import ButtonLink from '@/components/button-link'
 
-function Commune({name, codeCommune, picture, height, width, alt, signatureDate, charteURL}) {
+function Commune({name, codeCommune, picture, height, width, signatureDate, charteURL}) {
   const date = new Date(signatureDate).toLocaleDateString('fr-FR', {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'})
 
   return (
     <div className='commune-container' onClick={event => event.stopPropagation()}>
       <div className='commune-infos'>
-        <Image src={picture} height={height / 2} width={width / 2} alt={alt} />
+        <Image src={picture} height={height / 2} width={width / 2} alt='' />
         <Link href={`/commune/${codeCommune}`} aria-label={`Aller sur la page commune de ${name}`}>{`${name} - ${codeCommune}`}</Link>
       </div>
       <div className='signature-date'>Partenaire depuis le <b>{date}</b></div>
       {charteURL && (
         <ButtonLink href={charteURL} isExternal target='_blank' label={`Voir la charte de ${name}`}>
-          Voir la charte <ExternalLink size={20} style={{verticalAlign: 'sub'}} />
+          Voir la charte <ExternalLink size={20} style={{verticalAlign: 'sub'}} alt='Lien externe' />
         </ButtonLink>
       )}
 
@@ -63,7 +63,6 @@ Commune.propTypes = {
   picture: PropTypes.string.isRequired,
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
-  alt: PropTypes.string.isRequired,
   signatureDate: PropTypes.string.isRequired,
   charteURL: PropTypes.string
 }

--- a/components/bases-locales/charte/dropdown.js
+++ b/components/bases-locales/charte/dropdown.js
@@ -37,6 +37,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
         <Chevron
           style={{cursor: 'pointer'}}
           color={color === 'primary' ? theme.primary : theme.colors.white}
+          alt=''
         />
       </div>
 

--- a/components/bases-locales/charte/dropdown.js
+++ b/components/bases-locales/charte/dropdown.js
@@ -37,7 +37,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
         <Chevron
           style={{cursor: 'pointer'}}
           color={color === 'primary' ? theme.primary : theme.colors.white}
-          alt=''
+          alt
         />
       </div>
 

--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -48,14 +48,14 @@ function Partner({partnerInfos, isCommune}) {
             height={height}
             width={width}
             layout='fixed'
-            alt=''
+            alt
           />
         </div>
 
         <button type='button' onClick={() => setIsDisplay(!isDisplay)} className='button-container'>
           <p>{isDisplay ? 'Masquer' : 'Afficher'} les informations</p>
           <div className='chevron'>
-            <Chevron size={18} color={`${theme.colors.lightBlue}`} alt='' />
+            <Chevron size={18} color={`${theme.colors.lightBlue}`} alt />
           </div>
         </button>
       </div>

--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -14,7 +14,7 @@ function Partner({partnerInfos, isCommune}) {
   const [isDisplay, setIsDisplay] = useState(false)
   const [mairieContact, setMairieContact] = useState(null)
 
-  const {name, link, alt, infos, perimeter, codeCommune, services, picture, height, width, isCompany} = partnerInfos
+  const {name, link, infos, perimeter, codeCommune, services, picture, height, width, isCompany} = partnerInfos
   const Chevron = isDisplay ? ChevronUp : ChevronDown
 
   const getMairieInfos = useCallback(async () => {
@@ -45,17 +45,17 @@ function Partner({partnerInfos, isCommune}) {
         <div className='logo'>
           <Image
             src={picture}
-            alt={alt}
             height={height}
             width={width}
             layout='fixed'
+            alt=''
           />
         </div>
 
         <button type='button' onClick={() => setIsDisplay(!isDisplay)} className='button-container'>
           <p>{isDisplay ? 'Masquer' : 'Afficher'} les informations</p>
           <div className='chevron'>
-            <Chevron size={18} color={`${theme.colors.lightBlue}`} />
+            <Chevron size={18} color={`${theme.colors.lightBlue}`} alt='' />
           </div>
         </button>
       </div>
@@ -222,7 +222,6 @@ Partner.propTypes = {
     picture: PropTypes.string.isRequired,
     height: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
-    alt: PropTypes.string.isRequired,
     isCompany: PropTypes.bool.isRequired
   }).isRequired,
   isCommune: PropTypes.bool

--- a/components/bases-locales/charte/search-partners-results.js
+++ b/components/bases-locales/charte/search-partners-results.js
@@ -10,7 +10,7 @@ function SearchPartnersResults({companies, organizations, communes}) {
       <div className='contact-container'>
         <div className='subscription-indication'>Vous souhaitez être référencé comme Partenaire de la Charte de la Base Adresse Nationale, contactez nous.</div>
         <Notification isFullWidth>
-          <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} alt='Notification informative' />
+          <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} alt />
           Pour en faire partie, vous pouvez nous contacter à l’adresse suivante: <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr.</a>
         </Notification>
       </div>

--- a/components/bases-locales/charte/search-partners-results.js
+++ b/components/bases-locales/charte/search-partners-results.js
@@ -10,7 +10,7 @@ function SearchPartnersResults({companies, organizations, communes}) {
       <div className='contact-container'>
         <div className='subscription-indication'>Vous souhaitez être référencé comme Partenaire de la Charte de la Base Adresse Nationale, contactez nous.</div>
         <Notification isFullWidth>
-          <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} />
+          <HelpCircle style={{verticalAlign: 'bottom', marginRight: '5px'}} alt='Notification informative' />
           Pour en faire partie, vous pouvez nous contacter à l’adresse suivante: <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr.</a>
         </Notification>
       </div>

--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -46,12 +46,12 @@ const BasesLocales = React.memo(({datasets, stats}) => {
 
           <div className='parters'>
             <div className='partner'>
-              <div><Image src='/images/logos/logo_ANCT.svg' alt='' width={190} height={80} layout='fixed' /></div>
+              <div><Image src='/images/logos/logo_ANCT.svg' alt width={190} height={80} layout='fixed' /></div>
               <div><b>Le Programme Bases Adresses Locales de l’Agence Nationale pour la Cohésion des Territoires (ANCT)</b> est en place pour faciliter leur déploiement.</div>
             </div>
 
             <div className='partner'>
-              <div><Image src='/images/logos/logo-AMF.jpg' alt='' width={201} height={106} layout='fixed' /></div>
+              <div><Image src='/images/logos/logo-AMF.jpg' alt width={201} height={106} layout='fixed' /></div>
               <div><b>L’Association des Maires de France soutient la démarche.</b></div>
             </div>
           </div>
@@ -60,7 +60,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
         <Notification style={{margin: '2em 0 -1em 0'}}>
           <div className='notification-content'>
             <div>
-              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '4px'}} alt='' />
+              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '4px'}} alt />
               Vous êtes une commune et souhaitez mettre en place une Base Adresse Locale à l’aide d’outils existants ?
             </div>
             <ButtonLink href='/gerer-mes-adresses'>
@@ -82,7 +82,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
             isOutlined
             color='white'
           >
-            Valider vos données au format BAL <CheckSquare style={{verticalAlign: 'middle', marginLeft: '3px'}} alt='' />
+            Valider vos données au format BAL <CheckSquare style={{verticalAlign: 'middle', marginLeft: '3px'}} alt />
           </ButtonLink>
         </div>
       </Section>

--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -46,12 +46,12 @@ const BasesLocales = React.memo(({datasets, stats}) => {
 
           <div className='parters'>
             <div className='partner'>
-              <div><Image src='/images/logos/logo_ANCT.svg' alt='logo ANCT' width={190} height={80} layout='fixed' /></div>
+              <div><Image src='/images/logos/logo_ANCT.svg' alt='' width={190} height={80} layout='fixed' /></div>
               <div><b>Le Programme Bases Adresses Locales de l’Agence Nationale pour la Cohésion des Territoires (ANCT)</b> est en place pour faciliter leur déploiement.</div>
             </div>
 
             <div className='partner'>
-              <div><Image src='/images/logos/logo-AMF.jpg' alt='Logo de l’Association des Maires' width={201} height={106} layout='fixed' /></div>
+              <div><Image src='/images/logos/logo-AMF.jpg' alt='' width={201} height={106} layout='fixed' /></div>
               <div><b>L’Association des Maires de France soutient la démarche.</b></div>
             </div>
           </div>
@@ -60,7 +60,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
         <Notification style={{margin: '2em 0 -1em 0'}}>
           <div className='notification-content'>
             <div>
-              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '4px'}} />
+              <HelpCircle style={{verticalAlign: 'bottom', marginRight: '4px'}} alt='' />
               Vous êtes une commune et souhaitez mettre en place une Base Adresse Locale à l’aide d’outils existants ?
             </div>
             <ButtonLink href='/gerer-mes-adresses'>
@@ -82,7 +82,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
             isOutlined
             color='white'
           >
-            Valider vos données au format BAL <CheckSquare style={{verticalAlign: 'middle', marginLeft: '3px'}} />
+            Valider vos données au format BAL <CheckSquare style={{verticalAlign: 'middle', marginLeft: '3px'}} alt='' />
           </ButtonLink>
         </div>
       </Section>

--- a/components/bases-locales/publication/authentification.js
+++ b/components/bases-locales/publication/authentification.js
@@ -45,7 +45,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
               <h4>Authentifier la mairie de la commune</h4>
               <Button size='large' disabled={!communeEmail} onClick={handleCodeAuthentification}>
                 <div className='mail-button'>
-                  <Mail size={40} alt='Envoie par e-mail' /> Recevoir un code d’authentification
+                  <Mail size={40} alt='Envoi par e-mail' /> Recevoir un code d’authentification
                 </div>
               </Button>
               <p className='email-info'>

--- a/components/bases-locales/publication/authentification.js
+++ b/components/bases-locales/publication/authentification.js
@@ -26,7 +26,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
           onClick={() => setIsHabilitedOpen(!isHabilitedOpen)}
         >
           <h3>Vous êtes habilité(e)</h3>
-          {isHabilitedOpen ? <ChevronDown color={theme.primary} size={35} alt='' /> : <ChevronRight color={theme.primary} size={35} alt='' />}
+          {isHabilitedOpen ? <ChevronDown color={theme.primary} size={35} alt /> : <ChevronRight color={theme.primary} size={35} alt />}
         </button>
 
         {isHabilitedOpen && (
@@ -34,7 +34,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
             <div className='authentification-choice'>
               <h4>M’authentifier comme élu de la commune</h4>
               <a href={fcButtonUrl} aria-label='S’authentifier avec FranceConnect'>
-                <Image width={280} height={82} layout='fixed' src='/images/FCboutons-10.svg' alt='' />
+                <Image width={280} height={82} layout='fixed' src='/images/FCboutons-10.svg' alt />
               </a>
               <p className='alert-personal-data'>
                 Aucune donnée personnelle ne nous sera transmise durant ce processus d’authentification
@@ -64,9 +64,9 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
         <div>Comprendre l’habilitation en quelques points</div>
         <p className='intro'>Afin de pouvoir publier vos adresses dans la <b>Base Adresse Nationale</b>, votre <b>Base Adresse Locale</b> doit obtenir une <b>habilitation</b>.</p>
         <ul>
-          <li><Users size={15} alt='' /> <p>Permet à <b>toute personne aillant accès à l’édition</b> de cette Base Adresse Locale de <b>mettre à jour</b> les adresses de sa commune.</p></li>
-          <li><Clock size={15} alt='' /> <p>Elle est valable <b>6 mois</b>.</p></li>
-          <li><LogIn size={15} alt='' /> <p>Pour l’obtenir, <b>un(e) élu(e)</b> de la commune ou <b>un(e) employé(e)</b> de la mairie doit <b>s’authentifier</b>.</p></li>
+          <li><Users size={15} alt /> <p>Permet à <b>toute personne aillant accès à l’édition</b> de cette Base Adresse Locale de <b>mettre à jour</b> les adresses de sa commune.</p></li>
+          <li><Clock size={15} alt /> <p>Elle est valable <b>6 mois</b>.</p></li>
+          <li><LogIn size={15} alt /> <p>Pour l’obtenir, <b>un(e) élu(e)</b> de la commune ou <b>un(e) employé(e)</b> de la mairie doit <b>s’authentifier</b>.</p></li>
         </ul>
       </div>
 
@@ -84,7 +84,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
         {isNonHabilitedOpen && (
           <div className='content'>
             <div className='infos-habilitation'>
-              <h4><Info alt='' /><b>Prestataires et délégataires</b></h4>
+              <h4><Info alt /><b>Prestataires et délégataires</b></h4>
               <p>Contactez la mairie pour qu’elle puisse <b>authentifier </b>les adresses selon les modalités définies ci-dessus. Pour rappel, la commune <b>reste responsable de ses adresses</b>, même en cas de délégation de la <b>réalisation technique de l’adressage</b>.</p>
             </div>
           </div>

--- a/components/bases-locales/publication/authentification.js
+++ b/components/bases-locales/publication/authentification.js
@@ -26,7 +26,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
           onClick={() => setIsHabilitedOpen(!isHabilitedOpen)}
         >
           <h3>Vous êtes habilité(e)</h3>
-          {isHabilitedOpen ? <ChevronDown color={theme.primary} size={35} /> : <ChevronRight color={theme.primary} size={35} />}
+          {isHabilitedOpen ? <ChevronDown color={theme.primary} size={35} alt='' /> : <ChevronRight color={theme.primary} size={35} alt='' />}
         </button>
 
         {isHabilitedOpen && (
@@ -34,7 +34,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
             <div className='authentification-choice'>
               <h4>M’authentifier comme élu de la commune</h4>
               <a href={fcButtonUrl} aria-label='S’authentifier avec FranceConnect'>
-                <Image width={280} height={82} layout='fixed' src='/images/FCboutons-10.svg' alt='bouton FranceConnect' />
+                <Image width={280} height={82} layout='fixed' src='/images/FCboutons-10.svg' alt='' />
               </a>
               <p className='alert-personal-data'>
                 Aucune donnée personnelle ne nous sera transmise durant ce processus d’authentification
@@ -45,7 +45,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
               <h4>Authentifier la mairie de la commune</h4>
               <Button size='large' disabled={!communeEmail} onClick={handleCodeAuthentification}>
                 <div className='mail-button'>
-                  <Mail size={40} /> Recevoir un code d’authentification
+                  <Mail size={40} alt='Envoie par e-mail' /> Recevoir un code d’authentification
                 </div>
               </Button>
               <p className='email-info'>
@@ -64,9 +64,9 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
         <div>Comprendre l’habilitation en quelques points</div>
         <p className='intro'>Afin de pouvoir publier vos adresses dans la <b>Base Adresse Nationale</b>, votre <b>Base Adresse Locale</b> doit obtenir une <b>habilitation</b>.</p>
         <ul>
-          <li><Users size={15} /> <p>Permet à <b>toute personne aillant accès à l’édition</b> de cette Base Adresse Locale de <b>mettre à jour</b> les adresses de sa commune.</p></li>
-          <li><Clock size={15} /> <p>Elle est valable <b>6 mois</b>.</p></li>
-          <li><LogIn size={15} /> <p>Pour l’obtenir, <b>un(e) élu(e)</b> de la commune ou <b>un(e) employé(e)</b> de la mairie doit <b>s’authentifier</b>.</p></li>
+          <li><Users size={15} alt='' /> <p>Permet à <b>toute personne aillant accès à l’édition</b> de cette Base Adresse Locale de <b>mettre à jour</b> les adresses de sa commune.</p></li>
+          <li><Clock size={15} alt='' /> <p>Elle est valable <b>6 mois</b>.</p></li>
+          <li><LogIn size={15} alt='' /> <p>Pour l’obtenir, <b>un(e) élu(e)</b> de la commune ou <b>un(e) employé(e)</b> de la mairie doit <b>s’authentifier</b>.</p></li>
         </ul>
       </div>
 
@@ -84,7 +84,7 @@ function Authentification({communeEmail, revisionId, habilitationId, authenticat
         {isNonHabilitedOpen && (
           <div className='content'>
             <div className='infos-habilitation'>
-              <h4><Info /><b>Prestataires et délégataires</b></h4>
+              <h4><Info alt='' /><b>Prestataires et délégataires</b></h4>
               <p>Contactez la mairie pour qu’elle puisse <b>authentifier </b>les adresses selon les modalités définies ci-dessus. Pour rappel, la commune <b>reste responsable de ses adresses</b>, même en cas de délégation de la <b>réalisation technique de l’adressage</b>.</p>
             </div>
           </div>

--- a/components/bases-locales/publication/published.js
+++ b/components/bases-locales/publication/published.js
@@ -9,7 +9,7 @@ function Published({codeCommune}) {
     <div>
       <div className='published'>
         <div className='header'>
-          <div className='valid'><Check size={45} /></div>
+          <div className='valid'><Check size={45} alt='' /></div>
           <h1>Votre Base Adresse Locale a bien été publiée !</h1>
         </div>
 
@@ -65,7 +65,7 @@ function Published({codeCommune}) {
       </div>
 
       <ButtonLink style={{marginTop: '1em'}} href='/bases-locales/publication'>
-        <ArrowLeft style={{verticalAlign: 'top'}} /> Publier une autre Base Adresse Locale
+        <ArrowLeft style={{verticalAlign: 'top'}} alt='' /> Publier une autre Base Adresse Locale
       </ButtonLink>
 
       <style jsx>{`

--- a/components/bases-locales/publication/published.js
+++ b/components/bases-locales/publication/published.js
@@ -9,7 +9,7 @@ function Published({codeCommune}) {
     <div>
       <div className='published'>
         <div className='header'>
-          <div className='valid'><Check size={45} alt='' /></div>
+          <div className='valid'><Check size={45} alt /></div>
           <h1>Votre Base Adresse Locale a bien été publiée !</h1>
         </div>
 
@@ -65,7 +65,7 @@ function Published({codeCommune}) {
       </div>
 
       <ButtonLink style={{marginTop: '1em'}} href='/bases-locales/publication'>
-        <ArrowLeft style={{verticalAlign: 'top'}} alt='' /> Publier une autre Base Adresse Locale
+        <ArrowLeft style={{verticalAlign: 'top'}} alt /> Publier une autre Base Adresse Locale
       </ButtonLink>
 
       <style jsx>{`

--- a/components/bases-locales/publication/publishing.js
+++ b/components/bases-locales/publication/publishing.js
@@ -22,7 +22,7 @@ function Publishing({user, commune, hasConflit, publication}) {
         {hasConflit && (
           <Notification type='warning'>
             <div className='alert-content'>
-              <h4><AlertOctagon alt='' /> Une autre Base Adresses Locale est déjà synchronisée avec la Base Adresses Nationale.</h4>
+              <h4><AlertOctagon alt /> Une autre Base Adresses Locale est déjà synchronisée avec la Base Adresses Nationale.</h4>
               <p>En choisissant de publier, votre Base Adresse Locale <b>remplacera celle actuellement en place</b>.</p>
             </div>
           </Notification>
@@ -37,7 +37,7 @@ function Publishing({user, commune, hasConflit, publication}) {
           )}
 
           <Button size='large' disabled={hasConflit && !isConfirmed} onClick={publication}>
-            <div className='publish-button-content'><ArrowUpCircle size={25} alt='' /> Publier</div>
+            <div className='publish-button-content'><ArrowUpCircle size={25} alt /> Publier</div>
           </Button>
         </div>
       </div>

--- a/components/bases-locales/publication/publishing.js
+++ b/components/bases-locales/publication/publishing.js
@@ -22,7 +22,7 @@ function Publishing({user, commune, hasConflit, publication}) {
         {hasConflit && (
           <Notification type='warning'>
             <div className='alert-content'>
-              <h4><AlertOctagon /> Une autre Base Adresses Locale est déjà synchronisée avec la Base Adresses Nationale.</h4>
+              <h4><AlertOctagon alt='' /> Une autre Base Adresses Locale est déjà synchronisée avec la Base Adresses Nationale.</h4>
               <p>En choisissant de publier, votre Base Adresse Locale <b>remplacera celle actuellement en place</b>.</p>
             </div>
           </Notification>
@@ -37,7 +37,7 @@ function Publishing({user, commune, hasConflit, publication}) {
           )}
 
           <Button size='large' disabled={hasConflit && !isConfirmed} onClick={publication}>
-            <div className='publish-button-content'><ArrowUpCircle size={25} /> Publier</div>
+            <div className='publish-button-content'><ArrowUpCircle size={25} alt='' /> Publier</div>
           </Button>
         </div>
       </div>

--- a/components/bases-locales/publication/user.js
+++ b/components/bases-locales/publication/user.js
@@ -8,7 +8,7 @@ function User({user, commune}) {
   return (
     <div className='user'>
       <div className='avatar'>
-        <Image width={60} height={60} src={`/images/icons/${user ? 'elu' : 'commune'}.svg`} alt='elu' />
+        <Image width={60} height={60} src={`/images/icons/${user ? 'elu' : 'commune'}.svg`} alt='' />
       </div>
       {user ? (
         <div className='user-infos'>{prenom} {nomMarital || nomNaissance}</div>

--- a/components/bases-locales/publication/user.js
+++ b/components/bases-locales/publication/user.js
@@ -8,7 +8,7 @@ function User({user, commune}) {
   return (
     <div className='user'>
       <div className='avatar'>
-        <Image width={60} height={60} src={`/images/icons/${user ? 'elu' : 'commune'}.svg`} alt='' />
+        <Image width={60} height={60} src={`/images/icons/${user ? 'elu' : 'commune'}.svg`} alt />
       </div>
       {user ? (
         <div className='user-infos'>{prenom} {nomMarital || nomNaissance}</div>

--- a/components/bases-locales/validator/report/csv-meta.js
+++ b/components/bases-locales/validator/report/csv-meta.js
@@ -8,9 +8,10 @@ function CsvMeta({name, value, isValid}) {
     <div>
       <div className='item'>
         <div><b>{name}</b></div>
-        {isValid ? <div className='check'><Check /></div> : <div className='error'><X /></div>}
+        {isValid ? <div className='check'><Check alt='Valide' /></div> : <div className='error'><X alt='Invalide' /></div>}
       </div>
       <div className='item-value'>{value}</div>
+
       <style jsx>{`
         .item {
           display: flex;

--- a/components/bases-locales/validator/report/summary/index.js
+++ b/components/bases-locales/validator/report/summary/index.js
@@ -56,7 +56,7 @@ function Summary({rows, fields}) {
   return (
     <div>
       {rowsWithIssuesCount === 0 ? (
-        <h4>Aucune ligne comprenant des alertes n’a été trouvée <span className='valid'><Check alt='' /></span></h4>
+        <h4>Aucune ligne comprenant des alertes n’a été trouvée <span className='valid'><Check alt /></span></h4>
       ) : (
         <div>
           {rowsWithIssuesCount > 1 ? (

--- a/components/bases-locales/validator/report/summary/index.js
+++ b/components/bases-locales/validator/report/summary/index.js
@@ -56,7 +56,7 @@ function Summary({rows, fields}) {
   return (
     <div>
       {rowsWithIssuesCount === 0 ? (
-        <h4>Aucune ligne comprenant des alertes n’a été trouvée <span className='valid'><Check /></span></h4>
+        <h4>Aucune ligne comprenant des alertes n’a été trouvée <span className='valid'><Check alt='' /></span></h4>
       ) : (
         <div>
           {rowsWithIssuesCount > 1 ? (

--- a/components/bases-locales/validator/report/summary/issue-dialog.js
+++ b/components/bases-locales/validator/report/summary/issue-dialog.js
@@ -21,7 +21,7 @@ function IssueDialog({issue, unknowFields, handleClose}) {
             <h4>{getLabel(issue.code)}</h4>
           </div>
           <button type='button' onClick={handleClose} aria-label='Fermer la fenêtre indiquant les lignes avec alertes'>
-            <X size={40} style={{cursor: 'pointer'}} alt='' />
+            <X size={40} style={{cursor: 'pointer'}} alt />
           </button>
         </div>
         <div className='scroll'>

--- a/components/bases-locales/validator/report/summary/issue-dialog.js
+++ b/components/bases-locales/validator/report/summary/issue-dialog.js
@@ -21,7 +21,7 @@ function IssueDialog({issue, unknowFields, handleClose}) {
             <h4>{getLabel(issue.code)}</h4>
           </div>
           <button type='button' onClick={handleClose} aria-label='Fermer la fenêtre indiquant les lignes avec alertes'>
-            <X size={40} style={{cursor: 'pointer'}} />
+            <X size={40} style={{cursor: 'pointer'}} alt='' />
           </button>
         </div>
         <div className='scroll'>

--- a/components/bases-locales/validator/report/summary/issue-rows.js
+++ b/components/bases-locales/validator/report/summary/issue-rows.js
@@ -26,7 +26,7 @@ function IssueRows({issue, rows, isOnAllLines, onClick, type}) {
         <span className='colored'> {getLabel(issue)}</span>
       </div>
 
-      <div><ZoomIn style={{margin: '0 .5em', verticalAlign: 'middle'}} /></div>
+      <div><ZoomIn style={{margin: '0 .5em', verticalAlign: 'middle'}} alt='' /></div>
 
       <style jsx>{`
         .issue {

--- a/components/bases-locales/validator/report/summary/issue-rows.js
+++ b/components/bases-locales/validator/report/summary/issue-rows.js
@@ -26,7 +26,7 @@ function IssueRows({issue, rows, isOnAllLines, onClick, type}) {
         <span className='colored'> {getLabel(issue)}</span>
       </div>
 
-      <div><ZoomIn style={{margin: '0 .5em', verticalAlign: 'middle'}} alt='' /></div>
+      <div><ZoomIn style={{margin: '0 .5em', verticalAlign: 'middle'}} alt /></div>
 
       <style jsx>{`
         .issue {

--- a/components/bases-locales/validator/report/summary/issues-sumup.js
+++ b/components/bases-locales/validator/report/summary/issues-sumup.js
@@ -24,12 +24,12 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
         &nbsp;({issuesCount} ligne{issuesCount > 1 ? 's' : ''}) {percentageIssues}%
         <div className={`summary-icon ${issueType}`}>
           {issueType === 'error' ? (
-            <X style={{verticalAlign: 'bottom'}} alt='' />
+            <X style={{verticalAlign: 'bottom'}} alt />
           ) : (
             issueType === 'warning' ? (
-              <AlertTriangle style={{verticalAlign: 'bottom'}} alt='' />
+              <AlertTriangle style={{verticalAlign: 'bottom'}} alt />
             ) : (
-              <Info style={{verticalAlign: 'bottom'}} alt='' />
+              <Info style={{verticalAlign: 'bottom'}} alt />
             )
           )}
         </div>

--- a/components/bases-locales/validator/report/summary/issues-sumup.js
+++ b/components/bases-locales/validator/report/summary/issues-sumup.js
@@ -24,12 +24,12 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
         &nbsp;({issuesCount} ligne{issuesCount > 1 ? 's' : ''}) {percentageIssues}%
         <div className={`summary-icon ${issueType}`}>
           {issueType === 'error' ? (
-            <X style={{verticalAlign: 'bottom'}} />
+            <X style={{verticalAlign: 'bottom'}} alt='' />
           ) : (
             issueType === 'warning' ? (
-              <AlertTriangle style={{verticalAlign: 'bottom'}} />
+              <AlertTriangle style={{verticalAlign: 'bottom'}} alt='' />
             ) : (
-              <Info style={{verticalAlign: 'bottom'}} />
+              <Info style={{verticalAlign: 'bottom'}} alt='' />
             )
           )}
         </div>

--- a/components/bases-locales/validator/report/summary/row.js
+++ b/components/bases-locales/validator/report/summary/row.js
@@ -45,9 +45,9 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
         </div>
 
         {showIssues ? (
-          <ChevronUp style={{verticalAlign: 'middle', color: '#222'}} />
+          <ChevronUp style={{verticalAlign: 'middle', color: '#222'}} alt='' />
         ) : (
-          <ChevronDown style={{verticalAlign: 'middle', color: '#222'}} />
+          <ChevronDown style={{verticalAlign: 'middle', color: '#222'}} alt='' />
         )}
       </button>
 

--- a/components/bases-locales/validator/report/summary/row.js
+++ b/components/bases-locales/validator/report/summary/row.js
@@ -45,9 +45,9 @@ function Row({row, isForcedShowIssues, unknowFields, issueType}) {
         </div>
 
         {showIssues ? (
-          <ChevronUp style={{verticalAlign: 'middle', color: '#222'}} alt='' />
+          <ChevronUp style={{verticalAlign: 'middle', color: '#222'}} alt />
         ) : (
-          <ChevronDown style={{verticalAlign: 'middle', color: '#222'}} alt='' />
+          <ChevronDown style={{verticalAlign: 'middle', color: '#222'}} alt />
         )}
       </button>
 

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -13,7 +13,7 @@ function BlogCard({post, onClick}) {
         <h4 className='blog-title'>{post.title}</h4>
       </Link>
       <div className='blog-image-container'>
-        <Image src={post.feature_image || '/images/no-img.png'} alt={post.title} layout='fill' objectFit={post.feature_image ? 'cover' : 'contain'} />
+        <Image src={post.feature_image || '/images/no-img.png'} alt='' layout='fill' objectFit={post.feature_image ? 'cover' : 'contain'} />
       </div>
       <div className='infos-container'>
         <p>Publié par {post.authors[0].name}</p>

--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -13,7 +13,7 @@ function BlogCard({post, onClick}) {
         <h4 className='blog-title'>{post.title}</h4>
       </Link>
       <div className='blog-image-container'>
-        <Image src={post.feature_image || '/images/no-img.png'} alt='' layout='fill' objectFit={post.feature_image ? 'cover' : 'contain'} />
+        <Image src={post.feature_image || '/images/no-img.png'} alt layout='fill' objectFit={post.feature_image ? 'cover' : 'contain'} />
       </div>
       <div className='infos-container'>
         <p>Publié par {post.authors[0].name}</p>

--- a/components/blog-pagination.js
+++ b/components/blog-pagination.js
@@ -16,7 +16,7 @@ function BlogPagination({page, pages, prev, next}) {
       <div className='blog-pagination' role='navigation'>
         {prev && (
           <Link href={`${href}${prev}${tags}`}>
-            <a className='page' aria-label='Aller à la page précédente'><ArrowLeftCircle style={{verticalAlign: 'middle'}} alt='' /></a>
+            <a className='page' aria-label='Aller à la page précédente'><ArrowLeftCircle style={{verticalAlign: 'middle'}} alt /></a>
           </Link>
         )}
         {pageNumbers.map(n => (
@@ -31,7 +31,7 @@ function BlogPagination({page, pages, prev, next}) {
         ))}
         {next && (
           <Link href={`${href}${next}${tags}`}>
-            <a className='page' aria-label='Aller à la page suivante'><ArrowRightCircle style={{verticalAlign: 'middle'}} alt='' /></a>
+            <a className='page' aria-label='Aller à la page suivante'><ArrowRightCircle style={{verticalAlign: 'middle'}} alt /></a>
           </Link>
         )}
       </div>

--- a/components/blog-pagination.js
+++ b/components/blog-pagination.js
@@ -16,7 +16,7 @@ function BlogPagination({page, pages, prev, next}) {
       <div className='blog-pagination' role='navigation'>
         {prev && (
           <Link href={`${href}${prev}${tags}`}>
-            <a className='page'><ArrowLeftCircle aria-label='Aller à la page précédente' style={{verticalAlign: 'middle'}} /></a>
+            <a className='page' aria-label='Aller à la page précédente'><ArrowLeftCircle style={{verticalAlign: 'middle'}} alt='' /></a>
           </Link>
         )}
         {pageNumbers.map(n => (
@@ -31,10 +31,11 @@ function BlogPagination({page, pages, prev, next}) {
         ))}
         {next && (
           <Link href={`${href}${next}${tags}`}>
-            <a className='page' aria-label='Aller à la page suivante'><ArrowRightCircle style={{verticalAlign: 'middle'}} /></a>
+            <a className='page' aria-label='Aller à la page suivante'><ArrowRightCircle style={{verticalAlign: 'middle'}} alt='' /></a>
           </Link>
         )}
       </div>
+
       <style jsx>{`
         .blog-pagination {
           display: flex;

--- a/components/button.js
+++ b/components/button.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types'
 
 import colors from '@/styles/colors'
 
-function Button({size, color, isOutlined, children, ...props}) {
+function Button({size, color, label, isOutlined, children, ...props}) {
   return (
-    <button type='submit' className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
+    <button type='submit' aria-label={label} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
       {children}
 
       <style jsx>{`
@@ -33,6 +33,7 @@ Button.propTypes = {
     'secondary',
     'white'
   ]),
+  label: PropTypes.string,
   isOutlined: PropTypes.bool,
   children: PropTypes.node
 }
@@ -40,6 +41,7 @@ Button.propTypes = {
 Button.defaultProps = {
   size: null,
   color: 'primary',
+  label: null,
   isOutlined: false,
   children: null
 }

--- a/components/card.js
+++ b/components/card.js
@@ -30,7 +30,7 @@ function Card({title, link, action, links, list, children, color}) {
 
       {link ? (
         <a className='download-link' href={link}>
-          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '4px'}} /> {action}
+          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '4px'}} alt='' /> {action}
         </a>
       ) : (
         <div className='no-link'>

--- a/components/card.js
+++ b/components/card.js
@@ -30,7 +30,7 @@ function Card({title, link, action, links, list, children, color}) {
 
       {link ? (
         <a className='download-link' href={link}>
-          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '4px'}} alt='' /> {action}
+          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '4px'}} alt /> {action}
         </a>
       ) : (
         <div className='no-link'>

--- a/components/commune/bal-alert.js
+++ b/components/commune/bal-alert.js
@@ -8,7 +8,7 @@ function BalAlert({alert, type}) {
   return (
     <div className='alert-container'>
       <div className={`alert-type ${type}`}>
-        {type === 'error' ? <AlertOctagon alt='' /> : (type === 'warning' ? <AlertTriangle alt='' /> : <Info alt='' />)}
+        {type === 'error' ? <AlertOctagon alt /> : (type === 'warning' ? <AlertTriangle alt /> : <Info alt />)}
         {type === 'error' ? 'Erreur' : (type === 'warning' ? 'Avertissement' : 'Information')}
       </div>
       <div>{getLabel(alert)}</div>

--- a/components/commune/bal-alert.js
+++ b/components/commune/bal-alert.js
@@ -8,7 +8,7 @@ function BalAlert({alert, type}) {
   return (
     <div className='alert-container'>
       <div className={`alert-type ${type}`}>
-        {type === 'error' ? <AlertOctagon /> : (type === 'warning' ? <AlertTriangle /> : <Info />)}
+        {type === 'error' ? <AlertOctagon alt='' /> : (type === 'warning' ? <AlertTriangle alt='' /> : <Info alt='' />)}
         {type === 'error' ? 'Erreur' : (type === 'warning' ? 'Avertissement' : 'Information')}
       </div>
       <div>{getLabel(alert)}</div>

--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -81,7 +81,7 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
               rel='noreferrer'
               href={`https://mes-adresses.data.gouv.fr/new?commune=${codeCommune}`}
             >
-              Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt='' />
+              Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt />
             </ButtonLink>
           </div>
         </Notification>

--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -81,7 +81,7 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
               rel='noreferrer'
               href={`https://mes-adresses.data.gouv.fr/new?commune=${codeCommune}`}
             >
-              Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} />
+              Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt='' />
             </ButtonLink>
           </div>
         </Notification>

--- a/components/commune/commune-infos.js
+++ b/components/commune/commune-infos.js
@@ -11,7 +11,7 @@ function CommuneInfos({communeInfos}) {
     <Section title='Carte d’identité de la commune'>
       <div className='all-infos-wrapper'>
         <div className='name-container'>
-          <Image src='/images/icons/commune.svg' height={80} width={80} layout='fixed' alt='' />
+          <Image src='/images/icons/commune.svg' height={80} width={80} layout='fixed' alt />
           <div className='name'>{nomCommune} - {codeCommune}</div>
         </div>
 

--- a/components/commune/commune-infos.js
+++ b/components/commune/commune-infos.js
@@ -11,7 +11,7 @@ function CommuneInfos({communeInfos}) {
     <Section title='Carte d’identité de la commune'>
       <div className='all-infos-wrapper'>
         <div className='name-container'>
-          <Image src='/images/icons/commune.svg' height={80} width={80} layout='fixed' />
+          <Image src='/images/icons/commune.svg' height={80} width={80} layout='fixed' alt='' />
           <div className='name'>{nomCommune} - {codeCommune}</div>
         </div>
 

--- a/components/commune/contact-modal.js
+++ b/components/commune/contact-modal.js
@@ -17,7 +17,7 @@ function ContactModal({mairieInfos, onModalClose}) {
           aria-label='Fermer la fenêtre de contact'
           onClick={onModalClose}
         >
-          <XSquare />
+          <XSquare alt='' />
         </button>
         <MairieCard nom={nom} horaires={horaires} email={email} telephone={telephone} />
       </div>

--- a/components/commune/contact-modal.js
+++ b/components/commune/contact-modal.js
@@ -17,7 +17,7 @@ function ContactModal({mairieInfos, onModalClose}) {
           aria-label='Fermer la fenêtre de contact'
           onClick={onModalClose}
         >
-          <XSquare alt='' />
+          <XSquare alt />
         </button>
         <MairieCard nom={nom} horaires={horaires} email={email} telephone={telephone} />
       </div>

--- a/components/commune/download-card.js
+++ b/components/commune/download-card.js
@@ -7,7 +7,7 @@ function DownloadCard({format, url, isAvailable, color}) {
     <div className='card-container'>
       <div className='format'>Format {format}</div>
       <div className={`download-container ${color}`}>
-        <a className='download-link' href={url}><DownloadCloud />Télécharger</a>
+        <a className='download-link' href={url}><DownloadCloud alt='' />Télécharger</a>
       </div>
 
       <style jsx>{`

--- a/components/commune/download-card.js
+++ b/components/commune/download-card.js
@@ -7,7 +7,7 @@ function DownloadCard({format, url, isAvailable, color}) {
     <div className='card-container'>
       <div className='format'>Format {format}</div>
       <div className={`download-container ${color}`}>
-        <a className='download-link' href={url}><DownloadCloud alt='' />Télécharger</a>
+        <a className='download-link' href={url}><DownloadCloud alt />Télécharger</a>
       </div>
 
       <style jsx>{`

--- a/components/commune/historique-item.js
+++ b/components/commune/historique-item.js
@@ -14,14 +14,14 @@ function HistoriqueItem({balData, communeName}) {
   return (
     <div className='item-container'>
       <div className='update-infos'>
-        <div className='status'><Circle color={current ? theme.successBorder : theme.colors.darkGrey} alt='' /></div>
+        <div className='status'><Circle color={current ? theme.successBorder : theme.colors.darkGrey} alt /></div>
         <div className='date'>{sanitizedDateTime(updatedAt)}</div>
       </div>
 
       <div className='user-infos'>
         <div>Par <b>{userName}</b></div>
         <div>Via <b>{client.nom}</b></div>
-        <a href={balURL} aria-label={`Télécharger la version du ${accessibleDateTime(updatedAt)}`}><Download alt='' /></a>
+        <a href={balURL} aria-label={`Télécharger la version du ${accessibleDateTime(updatedAt)}`}><Download alt /></a>
       </div>
 
       <style jsx>{`

--- a/components/commune/historique-item.js
+++ b/components/commune/historique-item.js
@@ -14,14 +14,14 @@ function HistoriqueItem({balData, communeName}) {
   return (
     <div className='item-container'>
       <div className='update-infos'>
-        <div className='status'><Circle color={current ? theme.successBorder : theme.colors.darkGrey} /></div>
+        <div className='status'><Circle color={current ? theme.successBorder : theme.colors.darkGrey} alt='' /></div>
         <div className='date'>{sanitizedDateTime(updatedAt)}</div>
       </div>
 
       <div className='user-infos'>
         <div>Par <b>{userName}</b></div>
         <div>Via <b>{client.nom}</b></div>
-        <a href={balURL} aria-label={`Télécharger la version du ${accessibleDateTime(updatedAt)}`}><Download /></a>
+        <a href={balURL} aria-label={`Télécharger la version du ${accessibleDateTime(updatedAt)}`}><Download alt='' /></a>
       </div>
 
       <style jsx>{`

--- a/components/commune/historique.js
+++ b/components/commune/historique.js
@@ -16,7 +16,7 @@ function Historique({revisions, communeName, hasHistoryAdresses}) {
     <Section title='Historique des mises à jour de la Base Adresse Locale'>
       {hasHistoryAdresses ? (
         <div className='historique-wrapper'>
-          <h4><RefreshCw size={25} /> Retrouvez les cinq dernières mises à jour</h4>
+          <h4><RefreshCw size={25} alt='' /> Retrouvez les cinq dernières mises à jour</h4>
           <div className='historique-items'>
             {sortRevisionsByDate.slice(0, 5).map(revision => <HistoriqueItem key={revision._id} balData={revision} communeName={communeName} />)}
           </div>

--- a/components/commune/historique.js
+++ b/components/commune/historique.js
@@ -16,7 +16,7 @@ function Historique({revisions, communeName, hasHistoryAdresses}) {
     <Section title='Historique des mises à jour de la Base Adresse Locale'>
       {hasHistoryAdresses ? (
         <div className='historique-wrapper'>
-          <h4><RefreshCw size={25} alt='' /> Retrouvez les cinq dernières mises à jour</h4>
+          <h4><RefreshCw size={25} alt /> Retrouvez les cinq dernières mises à jour</h4>
           <div className='historique-items'>
             {sortRevisionsByDate.slice(0, 5).map(revision => <HistoriqueItem key={revision._id} balData={revision} communeName={communeName} />)}
           </div>

--- a/components/commune/statistics.js
+++ b/components/commune/statistics.js
@@ -45,7 +45,7 @@ function Statistics({nbNumeros, nbNumerosCertifies}) {
     return (
       <div className='statistiques-container'>
         <div>
-          <Image src='/images/icons/check.svg' height={150} width={150} alt='' />
+          <Image src='/images/icons/check.svg' height={150} width={150} alt />
           <p className='percent'><b>100%</b> des adresses de la commune sont certifiées</p>
         </div>
 

--- a/components/commune/statistics.js
+++ b/components/commune/statistics.js
@@ -45,7 +45,7 @@ function Statistics({nbNumeros, nbNumerosCertifies}) {
     return (
       <div className='statistiques-container'>
         <div>
-          <Image src='/images/icons/check.svg' height={150} width={150} />
+          <Image src='/images/icons/check.svg' height={150} width={150} alt='' />
           <p className='percent'><b>100%</b> des adresses de la commune sont certifiées</p>
         </div>
 

--- a/components/csv/holder.js
+++ b/components/csv/holder.js
@@ -34,18 +34,18 @@ function Holder({file, placeholder, isLoading, onDrop}) {
             onMouseLeave={() => setIsHovered(false)}
           >
             <input {...inputProps} />
-            <div>{!file && <Plus size={72} color={theme.primary} />}</div>
+            <div>{!file && <Plus size={72} color={theme.primary} alt='Glisser un fichier ou l’ajouter en cliquant sur la zone' />}</div>
             <div className='file-container'>{file ? (
               <div className='file-sumup'>
                 <div className='file-details'>
-                  <FileText size={42} />
+                  <FileText size={42} alt='Fichier déposé' />
                   <div className='file-infos'>
                     <div className='name'>{file.name}</div>
                     <div className='size'>{formatFileSize(file.size)}</div>
                   </div>
                 </div>
                 {isLoading ? (
-                  <div className='loading'>Chargement du fichier… <span><Loader /></span></div>
+                  <div className='loading'>Chargement du fichier… <span><Loader alt='' /></span></div>
                 ) : (
                   <RefreshCcw
                     size={32}
@@ -54,7 +54,6 @@ function Holder({file, placeholder, isLoading, onDrop}) {
                       margin: '0 1em'
                     }} />
                 )}
-
               </div>
             ) : placeholder}</div>
 

--- a/components/csv/holder.js
+++ b/components/csv/holder.js
@@ -45,7 +45,7 @@ function Holder({file, placeholder, isLoading, onDrop}) {
                   </div>
                 </div>
                 {isLoading ? (
-                  <div className='loading'>Chargement du fichier… <span><Loader alt='' /></span></div>
+                  <div className='loading'>Chargement du fichier… <span><Loader alt /></span></div>
                 ) : (
                   <RefreshCcw
                     size={32}

--- a/components/doc-download.js
+++ b/components/doc-download.js
@@ -14,12 +14,12 @@ function DocDownload({title, link, label, src, isReverse, version, children}) {
       <div className='doc-download-container'>
         <div className='doc-infos-container'>
           <div className='preview'>
-            <Image width={200} height={280} layout='fixed' src={src} alt='' />
+            <Image width={200} height={280} layout='fixed' src={src} alt />
           </div>
           {version && <div className='version'>Version {version}</div>}
         </div>
         <a href={link} className='download-url'>
-          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '5px'}} alt='' />
+          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '5px'}} alt />
           {label}
         </a>
       </div>

--- a/components/doc-download.js
+++ b/components/doc-download.js
@@ -4,7 +4,7 @@ import {DownloadCloud} from 'react-feather'
 
 import theme from '@/styles/theme'
 
-function DocDownload({title, link, label, src, alt, isReverse, version, children}) {
+function DocDownload({title, link, label, src, isReverse, version, children}) {
   return (
     <div className='doc-container'>
       <div className='text-container'>
@@ -14,15 +14,16 @@ function DocDownload({title, link, label, src, alt, isReverse, version, children
       <div className='doc-download-container'>
         <div className='doc-infos-container'>
           <div className='preview'>
-            <Image width={200} height={280} layout='fixed' src={src} alt={alt} />
+            <Image width={200} height={280} layout='fixed' src={src} alt='' />
           </div>
           {version && <div className='version'>Version {version}</div>}
         </div>
         <a href={link} className='download-url'>
-          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '5px'}} />
+          <DownloadCloud style={{verticalAlign: 'bottom', marginRight: '5px'}} alt='' />
           {label}
         </a>
       </div>
+
       <style jsx>{`
         .doc-container {
           display: flex;
@@ -76,7 +77,6 @@ DocDownload.propTypes = {
   label: PropTypes.string,
   title: PropTypes.string,
   src: PropTypes.string,
-  alt: PropTypes.string,
   version: PropTypes.string
 }
 
@@ -87,7 +87,6 @@ DocDownload.defaultProps = {
   label: null,
   title: null,
   src: null,
-  alt: null,
   version: null
 }
 

--- a/components/donnees-nationales/intro.js
+++ b/components/donnees-nationales/intro.js
@@ -46,7 +46,7 @@ function Intro() {
 
       <div className='characteristics'>
         <div>
-          <h6><List style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} /> Caractéristiques</h6>
+          <h6><List style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} alt='' /> Caractéristiques</h6>
           <ul>
             <li>Producteur : <strong>Etalab</strong></li>
             <li>Licence : <a href='https://www.etalab.gouv.fr/licence-ouverte-open-licence'>Licence Ouverte</a></li>
@@ -55,7 +55,7 @@ function Intro() {
           </ul>
         </div >
         <div>
-          <h6> <Target style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} /> Chiffres clés</h6>
+          <h6> <Target style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} alt='' /> Chiffres clés</h6>
           <ul>
             <li>250 000 lieux-dits (<span className='new'>beta</span>)</li>
             <li>25 millions d’adresses</li>

--- a/components/donnees-nationales/intro.js
+++ b/components/donnees-nationales/intro.js
@@ -46,7 +46,7 @@ function Intro() {
 
       <div className='characteristics'>
         <div>
-          <h6><List style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} alt='' /> Caractéristiques</h6>
+          <h6><List style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} alt /> Caractéristiques</h6>
           <ul>
             <li>Producteur : <strong>Etalab</strong></li>
             <li>Licence : <a href='https://www.etalab.gouv.fr/licence-ouverte-open-licence'>Licence Ouverte</a></li>
@@ -55,7 +55,7 @@ function Intro() {
           </ul>
         </div >
         <div>
-          <h6> <Target style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} alt='' /> Chiffres clés</h6>
+          <h6> <Target style={{verticalAlign: 'bottom', marginRight: '5px'}} color={theme.primary} alt /> Chiffres clés</h6>
           <ul>
             <li>250 000 lieux-dits (<span className='new'>beta</span>)</li>
             <li>25 millions d’adresses</li>

--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -36,7 +36,7 @@ function EventModal({event, isPassed, onClose}) {
       <div className='modal-container' ref={modalRef}>
         <div className={`close-container close-container-${type}`}>
           <button type='button' onClick={onClose} aria-label='Fermer la fenêtre' className='close-button'>
-            <XSquare />
+            <XSquare alt='' />
           </button>
         </div>
         <div className='modal-content'>
@@ -55,7 +55,7 @@ function EventModal({event, isPassed, onClose}) {
             {isOnlineOnly ? (
               <div className='place'><span>🖥️</span><br />{`${title} ${isPassed ? 's’est déroulé en ligne' : 'se déroulera en ligne'}`}</div>
             ) : (
-              <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} />{nom}, {numero} {voie} - {codePostal} {commune}</div>
+              <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} alt='' />{nom}, {numero} {voie} - {codePostal} {commune}</div>
             )}
 
             {!isPassed && (
@@ -78,7 +78,7 @@ function EventModal({event, isPassed, onClose}) {
           </div>
           <div className='right-content'>
             <div className='head-container'>
-              <Image src={`/images/icons/event-${type}.svg`} height={60} width={60} />
+              <Image src={`/images/icons/event-${type}.svg`} height={60} width={60} alt='' />
               <div className='title-container'>
                 <div className='right-title'>{title}</div>
                 <div>{subtitle}</div>

--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -36,7 +36,7 @@ function EventModal({event, isPassed, onClose}) {
       <div className='modal-container' ref={modalRef}>
         <div className={`close-container close-container-${type}`}>
           <button type='button' onClick={onClose} aria-label='Fermer la fenêtre' className='close-button'>
-            <XSquare alt='' />
+            <XSquare alt />
           </button>
         </div>
         <div className='modal-content'>
@@ -55,7 +55,7 @@ function EventModal({event, isPassed, onClose}) {
             {isOnlineOnly ? (
               <div className='place'><span>🖥️</span><br />{`${title} ${isPassed ? 's’est déroulé en ligne' : 'se déroulera en ligne'}`}</div>
             ) : (
-              <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} alt='' />{nom}, {numero} {voie} - {codePostal} {commune}</div>
+              <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} alt />{nom}, {numero} {voie} - {codePostal} {commune}</div>
             )}
 
             {!isPassed && (
@@ -78,7 +78,7 @@ function EventModal({event, isPassed, onClose}) {
           </div>
           <div className='right-content'>
             <div className='head-container'>
-              <Image src={`/images/icons/event-${type}.svg`} height={60} width={60} alt='' />
+              <Image src={`/images/icons/event-${type}.svg`} height={60} width={60} alt />
               <div className='title-container'>
                 <div className='right-title'>{title}</div>
                 <div>{subtitle}</div>

--- a/components/evenement/event.js
+++ b/components/evenement/event.js
@@ -21,7 +21,7 @@ function Event({event, background, isPassed, id}) {
   return (
     <div id={id} className='event-container'>
       <div className={`header ${type}`}>
-        <Image src={`/images/icons/event-${type}.svg`} height={50} width={50} alt='' />
+        <Image src={`/images/icons/event-${type}.svg`} height={50} width={50} alt />
       </div>
       <div className='general-infos'>
         <div className='title-container'>
@@ -35,7 +35,7 @@ function Event({event, background, isPassed, id}) {
         {isOnlineOnly ? (
           <div>🖥️ <br />Évènement en ligne</div>
         ) : (
-          <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} alt='' />{nom}, {numero} {voie} - {codePostal} {commune}</div>
+          <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} alt />{nom}, {numero} {voie} - {codePostal} {commune}</div>
         )}
         <div className='display-info-container'>
           <Button onClick={() => setIsModalOpen(true)}>Afficher les informations</Button>

--- a/components/evenement/event.js
+++ b/components/evenement/event.js
@@ -21,7 +21,7 @@ function Event({event, background, isPassed, id}) {
   return (
     <div id={id} className='event-container'>
       <div className={`header ${type}`}>
-        <Image src={`/images/icons/event-${type}.svg`} height={50} width={50} />
+        <Image src={`/images/icons/event-${type}.svg`} height={50} width={50} alt='' />
       </div>
       <div className='general-infos'>
         <div className='title-container'>
@@ -35,7 +35,7 @@ function Event({event, background, isPassed, id}) {
         {isOnlineOnly ? (
           <div>🖥️ <br />Évènement en ligne</div>
         ) : (
-          <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} />{nom}, {numero} {voie} - {codePostal} {commune}</div>
+          <div><MapPin strokeWidth={3} size={14} style={{marginRight: 5}} alt='' />{nom}, {numero} {voie} - {codePostal} {commune}</div>
         )}
         <div className='display-info-container'>
           <Button onClick={() => setIsModalOpen(true)}>Afficher les informations</Button>

--- a/components/fantoir/voie-information.js
+++ b/components/fantoir/voie-information.js
@@ -19,7 +19,7 @@ function VoieInformation({voie}) {
         <div className='infos'>{voie.typeVoie}</div>
         <div className='infos'>{voie.codeRivoli}</div>
         <div>
-          {isOpen ? <ChevronUp size={35} /> : <ChevronDown size={35} />}
+          {isOpen ? <ChevronUp size={35} alt='' /> : <ChevronDown size={35} alt='' />}
         </div>
       </button>
       {isOpen && (

--- a/components/fantoir/voie-information.js
+++ b/components/fantoir/voie-information.js
@@ -19,7 +19,7 @@ function VoieInformation({voie}) {
         <div className='infos'>{voie.typeVoie}</div>
         <div className='infos'>{voie.codeRivoli}</div>
         <div>
-          {isOpen ? <ChevronUp size={35} alt='' /> : <ChevronDown size={35} alt='' />}
+          {isOpen ? <ChevronUp size={35} alt /> : <ChevronDown size={35} alt />}
         </div>
       </button>
       {isOpen && (

--- a/components/footer.js
+++ b/components/footer.js
@@ -10,16 +10,16 @@ function Footer() {
         <div className='footer__logo'>
           <Image width={160} height={46} src='/images/logos/etalab.svg' alt='Etalab' />
           <ul className='footer__social'>
-            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Consulter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='Twitter' /></a></li>
-            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Consulter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='Github' /></a></li>
+            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Consulter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='' /></a></li>
+            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Consulter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='' /></a></li>
             <li>
               <Link href='/blog'>
-                <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt='Medium' /></a>
+                <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt='' /></a>
               </Link>
             </li>
             <li>
               <Link href='/nous-contacter'>
-                <a aria-label='Contacter l’équipe'><Image width={25} height={25} src='/images/medias/envelop.svg' alt='Nous contacter' /></a>
+                <a aria-label='Contacter l’équipe'><Image width={25} height={25} src='/images/medias/envelop.svg' alt='' /></a>
               </Link>
             </li>
           </ul>

--- a/components/footer.js
+++ b/components/footer.js
@@ -10,16 +10,16 @@ function Footer() {
         <div className='footer__logo'>
           <Image width={160} height={46} src='/images/logos/etalab.svg' alt='Etalab' />
           <ul className='footer__social'>
-            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Consulter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt='' /></a></li>
-            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Consulter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt='' /></a></li>
+            <li><a href='https://twitter.com/AdresseDataGouv' aria-label='Consulter notre compte Twitter'><Image width={25} height={25} src='/images/medias/twitter.svg' alt /></a></li>
+            <li><a href='https://github.com/etalab/adresse.data.gouv.fr' aria-label='Consulter notre page GitHub'><Image width={25} height={25} src='/images/medias/github.svg' alt /></a></li>
             <li>
               <Link href='/blog'>
-                <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt='' /></a>
+                <a aria-label='Consulter notre blog'><Image width={25} height={25} src='/images/medias/medium.svg' alt /></a>
               </Link>
             </li>
             <li>
               <Link href='/nous-contacter'>
-                <a aria-label='Contacter l’équipe'><Image width={25} height={25} src='/images/medias/envelop.svg' alt='' /></a>
+                <a aria-label='Contacter l’équipe'><Image width={25} height={25} src='/images/medias/envelop.svg' alt /></a>
               </Link>
             </li>
           </ul>

--- a/components/hamburger-menu.js
+++ b/components/hamburger-menu.js
@@ -33,7 +33,7 @@ class HamburgerMenu extends React.Component {
     return (
       <div className='dropdown'>
         <button type='button' aria-label={`${visible ? 'Fermer' : 'Ouvrir'} le menu de navigation`} onClick={this.handleMenu}>
-          {visible ? <X size={22} alt='' /> : <Menu size={22} alt='' />}
+          {visible ? <X size={22} alt /> : <Menu size={22} alt />}
         </button>
 
         {visible && (

--- a/components/hamburger-menu.js
+++ b/components/hamburger-menu.js
@@ -33,7 +33,7 @@ class HamburgerMenu extends React.Component {
     return (
       <div className='dropdown'>
         <button type='button' aria-label={`${visible ? 'Fermer' : 'Ouvrir'} le menu de navigation`} onClick={this.handleMenu}>
-          {visible ? <X size={22} /> : <Menu size={22} />}
+          {visible ? <X size={22} alt='' /> : <Menu size={22} alt='' />}
         </button>
 
         {visible && (

--- a/components/hero.js
+++ b/components/hero.js
@@ -25,7 +25,7 @@ function Hero({title, tagline}) {
           <div className='data-tools'>
             <CircleLink
               href='/download'
-              icon={<Download size={48} color={theme.colors.white} />}
+              icon={<Download size={48} color={theme.colors.white} alt='' />}
               isImportant
               size='80'
             >
@@ -33,7 +33,7 @@ function Hero({title, tagline}) {
             </CircleLink>
             <CircleLink
               href='/contribuer'
-              icon={<Edit3 size={48} color={theme.colors.white} />}
+              icon={<Edit3 size={48} color={theme.colors.white} alt='' />}
               isImportant
               size='80'
             >
@@ -41,7 +41,7 @@ function Hero({title, tagline}) {
             </CircleLink>
             <CircleLink
               href='/bases-locales'
-              icon={<Database size={48} color={theme.colors.white} />}
+              icon={<Database size={48} color={theme.colors.white} alt='' />}
               isImportant
               label='Découvrir la Base Adresse Locale'
               size='80'
@@ -50,7 +50,7 @@ function Hero({title, tagline}) {
             </CircleLink>
             <CircleLink
               href='/outils'
-              icon={<ToolsIcon size={48} color={theme.colors.white} />}
+              icon={<ToolsIcon size={48} color={theme.colors.white} alt='' />}
               isImportant
               size='80'
             >

--- a/components/hero.js
+++ b/components/hero.js
@@ -25,7 +25,7 @@ function Hero({title, tagline}) {
           <div className='data-tools'>
             <CircleLink
               href='/download'
-              icon={<Download size={48} color={theme.colors.white} alt='' />}
+              icon={<Download size={48} color={theme.colors.white} alt />}
               isImportant
               size='80'
             >
@@ -33,7 +33,7 @@ function Hero({title, tagline}) {
             </CircleLink>
             <CircleLink
               href='/contribuer'
-              icon={<Edit3 size={48} color={theme.colors.white} alt='' />}
+              icon={<Edit3 size={48} color={theme.colors.white} alt />}
               isImportant
               size='80'
             >
@@ -41,7 +41,7 @@ function Hero({title, tagline}) {
             </CircleLink>
             <CircleLink
               href='/bases-locales'
-              icon={<Database size={48} color={theme.colors.white} alt='' />}
+              icon={<Database size={48} color={theme.colors.white} alt />}
               isImportant
               label='Découvrir la Base Adresse Locale'
               size='80'
@@ -50,7 +50,7 @@ function Hero({title, tagline}) {
             </CircleLink>
             <CircleLink
               href='/outils'
-              icon={<ToolsIcon size={48} color={theme.colors.white} alt='' />}
+              icon={<ToolsIcon size={48} color={theme.colors.white} alt />}
               isImportant
               size='80'
             >

--- a/components/know-more-section.js
+++ b/components/know-more-section.js
@@ -12,7 +12,7 @@ function KnowMoreSection({links}) {
           links.map(({isFile, href, title}) => {
             return (
               <li key={href}>
-                {isFile ? <FileText alt /> : <ExternalLink alt />}<a href={href}>{title}</a>
+                {isFile ? <FileText alt='Document' /> : <ExternalLink alt='Lien externe' />}<a href={href}>{title}</a>
               </li>
             )
           })

--- a/components/know-more-section.js
+++ b/components/know-more-section.js
@@ -12,7 +12,7 @@ function KnowMoreSection({links}) {
           links.map(({isFile, href, title}) => {
             return (
               <li key={href}>
-                {isFile ? <FileText /> : <ExternalLink />}<a href={href}>{title}</a>
+                {isFile ? <FileText alt='' /> : <ExternalLink alt='' />}<a href={href}>{title}</a>
               </li>
             )
           })

--- a/components/know-more-section.js
+++ b/components/know-more-section.js
@@ -12,7 +12,7 @@ function KnowMoreSection({links}) {
           links.map(({isFile, href, title}) => {
             return (
               <li key={href}>
-                {isFile ? <FileText alt='' /> : <ExternalLink alt='' />}<a href={href}>{title}</a>
+                {isFile ? <FileText alt /> : <ExternalLink alt />}<a href={href}>{title}</a>
               </li>
             )
           })

--- a/components/mairie/mairie-card.js
+++ b/components/mairie/mairie-card.js
@@ -11,7 +11,7 @@ function MairieCard({nom, horaires, email, telephone}) {
   return (
     <div className='mairie-infos'>
       <div className='mairie-name'>
-        <Image src='/images/icons/commune.svg' height={80} width={80} />
+        <Image src='/images/icons/commune.svg' height={80} width={80} alt='' />
         <b>{nom}</b>
       </div>
       <div>

--- a/components/mairie/mairie-card.js
+++ b/components/mairie/mairie-card.js
@@ -11,7 +11,7 @@ function MairieCard({nom, horaires, email, telephone}) {
   return (
     <div className='mairie-infos'>
       <div className='mairie-name'>
-        <Image src='/images/icons/commune.svg' height={80} width={80} alt='' />
+        <Image src='/images/icons/commune.svg' height={80} width={80} alt />
         <b>{nom}</b>
       </div>
       <div>

--- a/components/mairie/mairie-contact.js
+++ b/components/mairie/mairie-contact.js
@@ -5,11 +5,11 @@ function MairieContact({email, phone}) {
   return (
     <div className='contact-infos'>
       <div className='contact-info'>
-        <Mail size={18} style={{marginRight: '10px'}} />
+        <Mail style={{marginRight: '10px'}} alt='Adresse e-mail' />
         {email ? <a href={`mailto:${email}`}>{email}</a> : 'Non renseigné'}
       </div>
       <div className='contact-info'>
-        <Phone size={18} style={{marginRight: '10px'}} />
+        <Phone style={{marginRight: '10px'}} alt='Numéro de téléphone' />
         {phone ? <a href={`tel:+33${phone}`}>{phone}</a> : 'Non renseigné'}
       </div>
 

--- a/components/mairie/mairie-schedules.js
+++ b/components/mairie/mairie-schedules.js
@@ -25,9 +25,9 @@ function CommuneSchedules({scheldules}) {
       >
         Horaires d’ouverture
         {isDisplayed ? (
-          <ChevronDown style={{marginTop: '2px'}} />
+          <ChevronDown style={{marginTop: '2px'}} alt='' />
         ) : (
-          <ChevronRight style={{marginTop: '2px'}} />
+          <ChevronRight style={{marginTop: '2px'}} alt='' />
         )}
       </button>
 

--- a/components/mairie/mairie-schedules.js
+++ b/components/mairie/mairie-schedules.js
@@ -25,9 +25,9 @@ function CommuneSchedules({scheldules}) {
       >
         Horaires d’ouverture
         {isDisplayed ? (
-          <ChevronDown style={{marginTop: '2px'}} alt='' />
+          <ChevronDown style={{marginTop: '2px'}} alt />
         ) : (
-          <ChevronRight style={{marginTop: '2px'}} alt='' />
+          <ChevronRight style={{marginTop: '2px'}} alt />
         )}
       </button>
 

--- a/components/map-bal-section.js
+++ b/components/map-bal-section.js
@@ -15,7 +15,7 @@ function MapBalSection({stats}) {
     <div className='deployement-container'>
       <div className='map-illustration'>
         <div className='map-illustration'>
-          <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} alt='' />
+          <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} alt />
         </div>
       </div>
       <div className='metrics-container'>

--- a/components/map-bal-section.js
+++ b/components/map-bal-section.js
@@ -15,7 +15,7 @@ function MapBalSection({stats}) {
     <div className='deployement-container'>
       <div className='map-illustration'>
         <div className='map-illustration'>
-          <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} />
+          <Image src='/images/france-illustration.svg' layout='responsive' height={400} width={400} alt='' />
         </div>
       </div>
       <div className='metrics-container'>

--- a/components/maplibre/cadastre-layer-control.js
+++ b/components/maplibre/cadastre-layer-control.js
@@ -14,7 +14,7 @@ function CadastreLayerControl({isDisabled, isActived, handleClick}) {
     >
       <Layout color={isDisabled ? '#cdcdcd' : (
         isActived ? theme.primary : theme.darkText
-      )} size={18} />
+      )} size={18} alt='' />
     </button>
   )
 }

--- a/components/maplibre/cadastre-layer-control.js
+++ b/components/maplibre/cadastre-layer-control.js
@@ -14,7 +14,7 @@ function CadastreLayerControl({isDisabled, isActived, handleClick}) {
     >
       <Layout color={isDisabled ? '#cdcdcd' : (
         isActived ? theme.primary : theme.darkText
-      )} size={18} alt='' />
+      )} size={18} alt />
     </button>
   )
 }

--- a/components/maplibre/center-control.js
+++ b/components/maplibre/center-control.js
@@ -10,7 +10,7 @@ function CenterControl({isDisabled, handleClick}) {
       title='Recentrer la carte'
       onClick={handleClick}
     >
-      <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} />
+      <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} alt='' />
     </button>
   )
 }

--- a/components/maplibre/center-control.js
+++ b/components/maplibre/center-control.js
@@ -10,7 +10,7 @@ function CenterControl({isDisabled, handleClick}) {
       title='Recentrer la carte'
       onClick={handleClick}
     >
-      <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} alt='' />
+      <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} alt />
     </button>
   )
 }

--- a/components/maplibre/select-paint-layer.js
+++ b/components/maplibre/select-paint-layer.js
@@ -32,7 +32,7 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
             className='close-icon'
             onClick={() => setIsWrap(true)}
           >
-            <X alt='' />
+            <X alt />
           </button>
         )}
       </div>

--- a/components/maplibre/select-paint-layer.js
+++ b/components/maplibre/select-paint-layer.js
@@ -32,7 +32,7 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
             className='close-icon'
             onClick={() => setIsWrap(true)}
           >
-            <X />
+            <X alt='' />
           </button>
         )}
       </div>

--- a/components/maplibre/switch-map-style.js
+++ b/components/maplibre/switch-map-style.js
@@ -26,7 +26,7 @@ class SwitchMapStyle extends React.Component {
             width={80}
             height={80}
             src={src}
-            alt=''
+            alt
           />
         </button>
         <div className='text'>{style}</div>

--- a/components/maplibre/switch-map-style.js
+++ b/components/maplibre/switch-map-style.js
@@ -25,8 +25,8 @@ class SwitchMapStyle extends React.Component {
           <Image
             width={80}
             height={80}
-            alt={style}
             src={src}
+            alt=''
           />
         </button>
         <div className='text'>{style}</div>

--- a/components/notification.js
+++ b/components/notification.js
@@ -7,7 +7,7 @@ function Notification({message, type, style, isFullWidth, onClose, children}) {
   return (
     <div style={style} className={`notification ${type || ''} ${onClose ? 'closable' : ''} ${isFullWidth ? 'full-width' : ''}`}>
       {onClose && (
-        <Button className='close' aria-label='Fermer' onClick={onClose}><X /></Button>
+        <Button className='close' aria-label='Fermer la notification' onClick={onClose}><X alt='' /></Button>
       )}
       {children || message}
     </div >

--- a/components/notification.js
+++ b/components/notification.js
@@ -7,7 +7,7 @@ function Notification({message, type, style, isFullWidth, onClose, children}) {
   return (
     <div style={style} className={`notification ${type || ''} ${onClose ? 'closable' : ''} ${isFullWidth ? 'full-width' : ''}`}>
       {onClose && (
-        <Button className='close' aria-label='Fermer la notification' onClick={onClose}><X alt='' /></Button>
+        <Button className='close' aria-label='Fermer la notification' onClick={onClose}><X alt /></Button>
       )}
       {children || message}
     </div >

--- a/components/post.js
+++ b/components/post.js
@@ -58,14 +58,14 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
   return (
     <Section>
       <Link href={backLink}>
-        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} alt='' /> Retour</a>
+        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} alt /> Retour</a>
       </Link>
 
       <div className='blog'>
         <h3>{title}</h3>
         {feature_image && (
           <div className='blog-feature-image-container'>
-            <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' alt='' />
+            <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' alt />
           </div>
         )}
         <p className='infos-container'><i>Publié par {authors[0].name}</i> <i>le {new Date(published_at).toLocaleDateString('fr-FR')}</i></p>
@@ -74,7 +74,7 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
       </div>
 
       <Link href={backLink}>
-        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} alt='' /> Retour</a>
+        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} alt /> Retour</a>
       </Link>
 
       <style jsx global>{`

--- a/components/post.js
+++ b/components/post.js
@@ -58,14 +58,14 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
   return (
     <Section>
       <Link href={backLink}>
-        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} /> Retour</a>
+        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} alt='' /> Retour</a>
       </Link>
 
       <div className='blog'>
         <h3>{title}</h3>
         {feature_image && (
           <div className='blog-feature-image-container'>
-            <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' />
+            <Image src={feature_image} layout='fill' objectFit='cover' className='blog-feature-image' alt='' />
           </div>
         )}
         <p className='infos-container'><i>Publié par {authors[0].name}</i> <i>le {new Date(published_at).toLocaleDateString('fr-FR')}</i></p>
@@ -74,7 +74,7 @@ function Post({title, published_at, feature_image, authors, html, backLink}) {
       </div>
 
       <Link href={backLink}>
-        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} /> Retour</a>
+        <a className='blog-back-button'><ArrowLeftCircle size={25} style={{verticalAlign: 'middle', marginRight: '.5em'}} alt='' /> Retour</a>
       </Link>
 
       <style jsx global>{`

--- a/components/question.js
+++ b/components/question.js
@@ -44,7 +44,7 @@ class Question extends React.Component {
           onClick={this.toggle}
         >
           <div className='question'>{question}</div>
-          <div>{open ? <ChevronUp style={{verticalAlign: 'middle'}} /> : <ChevronDown style={{verticalAlign: 'middle'}} />}</div>
+          <div>{open ? <ChevronUp style={{verticalAlign: 'middle'}} alt='' /> : <ChevronDown style={{verticalAlign: 'middle'}} alt='' />}</div>
         </button>
         {open && (
           <div className='answer'>{children}</div>

--- a/components/question.js
+++ b/components/question.js
@@ -44,7 +44,7 @@ class Question extends React.Component {
           onClick={this.toggle}
         >
           <div className='question'>{question}</div>
-          <div>{open ? <ChevronUp style={{verticalAlign: 'middle'}} alt='' /> : <ChevronDown style={{verticalAlign: 'middle'}} alt='' />}</div>
+          <div>{open ? <ChevronUp style={{verticalAlign: 'middle'}} alt /> : <ChevronDown style={{verticalAlign: 'middle'}} alt />}</div>
         </button>
         {open && (
           <div className='answer'>{children}</div>

--- a/components/search-bar.js
+++ b/components/search-bar.js
@@ -21,7 +21,7 @@ const SearchBar = React.forwardRef((props, ref) => {
           className='search'
           aria-label='Recherche'
         />
-        <span className='icon-title'><Search alt='' /></span>
+        <span className='icon-title'><Search alt /></span>
         <style jsx>{`
           .search-input-container {
             position: relative;

--- a/components/search-bar.js
+++ b/components/search-bar.js
@@ -21,7 +21,7 @@ const SearchBar = React.forwardRef((props, ref) => {
           className='search'
           aria-label='Recherche'
         />
-        <span className='icon-title'><Search /></span>
+        <span className='icon-title'><Search alt='' /></span>
         <style jsx>{`
           .search-input-container {
             position: relative;

--- a/components/social-media.js
+++ b/components/social-media.js
@@ -16,13 +16,13 @@ function SocialMedia() {
       <div className='socials'>
         <Link href='/blog'>
           <a aria-label='Consulter notre blog'>
-            <Image src='/images/logos/blog.svg' height={88} width={88} alt='' />
+            <Image src='/images/logos/blog.svg' height={88} width={88} alt />
             <div>En lisant notre blog</div>
           </a>
         </Link>
 
         <a href='https://twitter.com/adressedatagouv?lang=fr' aria-label='Consulter notre compte Twitter'>
-          <Image src='/images/logos/twitter.svg' height={88} width={88} alt='' />
+          <Image src='/images/logos/twitter.svg' height={88} width={88} alt />
           <div>Sur notre fil Twitter</div>
         </a>
 
@@ -32,9 +32,9 @@ function SocialMedia() {
           aria-label='S’inscrire à l’infolettre'
           type='button'
         >
-          <Image src='/images/logos/newsletter.svg' height={88} width={88} alt='' />
+          <Image src='/images/logos/newsletter.svg' height={88} width={88} alt />
           <div className='dropdown'>
-            {isShown ? <ChevronDown alt='' /> : <ChevronRight alt='' />}
+            {isShown ? <ChevronDown alt /> : <ChevronRight alt />}
             En s’inscrivant à l’infolettre
           </div>
         </button>

--- a/components/social-media.js
+++ b/components/social-media.js
@@ -16,13 +16,13 @@ function SocialMedia() {
       <div className='socials'>
         <Link href='/blog'>
           <a aria-label='Consulter notre blog'>
-            <Image src='/images/logos/blog.svg' height={88} width={88} alt='Blog' />
+            <Image src='/images/logos/blog.svg' height={88} width={88} alt='' />
             <div>En lisant notre blog</div>
           </a>
         </Link>
 
         <a href='https://twitter.com/adressedatagouv?lang=fr' aria-label='Consulter notre compte Twitter'>
-          <Image src='/images/logos/twitter.svg' height={88} width={88} alt='Twitter' />
+          <Image src='/images/logos/twitter.svg' height={88} width={88} alt='' />
           <div>Sur notre fil Twitter</div>
         </a>
 
@@ -32,9 +32,9 @@ function SocialMedia() {
           aria-label='S’inscrire à l’infolettre'
           type='button'
         >
-          <Image src='/images/logos/newsletter.svg' height={88} width={88} alt='Newsletter' />
+          <Image src='/images/logos/newsletter.svg' height={88} width={88} alt='' />
           <div className='dropdown'>
-            {isShown ? <ChevronDown /> : <ChevronRight />}
+            {isShown ? <ChevronDown alt='' /> : <ChevronRight alt='' />}
             En s’inscrivant à l’infolettre
           </div>
         </button>

--- a/components/table-list/table/head.js
+++ b/components/table-list/table/head.js
@@ -7,7 +7,7 @@ const order = (a, b, direction) => (
     type='button'
     aria-label={`Trier par ordre ${direction === 'asc' ? 'croissant' : 'décroissant'}`}
   >
-    <ArrowDown alt='' />
+    <ArrowDown alt />
     <div>
       <div>{a}</div>
       <div>{b}</div>

--- a/components/table-list/table/head.js
+++ b/components/table-list/table/head.js
@@ -7,7 +7,7 @@ const order = (a, b, direction) => (
     type='button'
     aria-label={`Trier par ordre ${direction === 'asc' ? 'croissant' : 'décroissant'}`}
   >
-    <ArrowDown />
+    <ArrowDown alt='' />
     <div>
       <div>{a}</div>
       <div>{b}</div>

--- a/pages/accessibilite.js
+++ b/pages/accessibilite.js
@@ -17,12 +17,12 @@ function Accessibilite() {
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Smile size={56} alt='' />} />
+      <Head title={title} icon={<Smile size={56} alt />} />
 
       <Section>
         <div className='accessibility-intro'>
           <div className='accessibility-illustration'>
-            <Image src='/images/accessibilite-illustration.svg' layout='responsive' height={100} width={500} alt='' />
+            <Image src='/images/accessibilite-illustration.svg' layout='responsive' height={100} width={500} alt />
           </div>
 
           <SectionText>
@@ -44,7 +44,7 @@ function Accessibilite() {
 
       <Section background='color' title='État de conformité'>
         <Notification type='warning'>
-          <div className='conformity'><XCircle alt='' /> Non conforme</div>
+          <div className='conformity'><XCircle alt /> Non conforme</div>
         </Notification>
         <SectionText color='secondary'>
           <b>adresse.data.gouv.fr</b> est non conforme avec le <b>référentiel général d’amélioration de l’accessibilité</b> (RGAA), un audit d’accessibilité n’ayant pas encore été réalisé.

--- a/pages/accessibilite.js
+++ b/pages/accessibilite.js
@@ -17,12 +17,12 @@ function Accessibilite() {
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Smile size={56} />} />
+      <Head title={title} icon={<Smile size={56} alt='' />} />
 
       <Section>
         <div className='accessibility-intro'>
           <div className='accessibility-illustration'>
-            <Image src='/images/accessibilite-illustration.svg' layout='responsive' height={100} width={500} />
+            <Image src='/images/accessibilite-illustration.svg' layout='responsive' height={100} width={500} alt='' />
           </div>
 
           <SectionText>
@@ -44,7 +44,7 @@ function Accessibilite() {
 
       <Section background='color' title='État de conformité'>
         <Notification type='warning'>
-          <div className='conformity'><XCircle /> Non conforme</div>
+          <div className='conformity'><XCircle alt='' /> Non conforme</div>
         </Notification>
         <SectionText color='secondary'>
           <b>adresse.data.gouv.fr</b> est non conforme avec le <b>référentiel général d’amélioration de l’accessibilité</b> (RGAA), un audit d’accessibilité n’ayant pas encore été réalisé.

--- a/pages/api-doc/adresse.js
+++ b/pages/api-doc/adresse.js
@@ -11,13 +11,13 @@ const title = 'API Adresse'
 const description = 'Cherchez des adresses et lieux-dits.'
 
 const examples = [
-  {title: 'Recherche par texte', id: 'text', icon: <Search alt='' />}
+  {title: 'Recherche par texte', id: 'text', icon: <Search alt />}
 ]
 
 function Adresse() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Compass color='white' size={56} alt='' />}>
+      <Head title={title} icon={<Compass color='white' size={56} alt />}>
         {description}
       </Head>
 

--- a/pages/api-doc/adresse.js
+++ b/pages/api-doc/adresse.js
@@ -11,13 +11,13 @@ const title = 'API Adresse'
 const description = 'Cherchez des adresses et lieux-dits.'
 
 const examples = [
-  {title: 'Recherche par texte', id: 'text', icon: <Search />}
+  {title: 'Recherche par texte', id: 'text', icon: <Search alt='' />}
 ]
 
 function Adresse() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Compass color='white' size={56} />}>
+      <Head title={title} icon={<Compass color='white' size={56} alt='' />}>
         {description}
       </Head>
 

--- a/pages/api-doc/index.js
+++ b/pages/api-doc/index.js
@@ -13,37 +13,37 @@ function ApiPage() {
       title: 'API Adresse',
       description: 'Recherchez ou normalisez des adresses à l’unité ou en lot. Géocodage direct ou inversé.',
       href: '/api-doc/adresse',
-      icon: <Terminal alt='' />
+      icon: <Terminal alt />
     },
     {
       title: 'API Gestion d\'une Base Adresse Locale',
       description: 'API permettant de créer une Base Adresse Locale et d’en gérer les adresses. Utilisée par Mes Adresses.',
       href: 'https://github.com/BaseAdresseNationale/api-bal/wiki/Documentation-de-l\'API',
-      icon: <Map alt='' />
+      icon: <Map alt />
     },
     {
       title: 'API Dépot d\'une Base Adresse Locale',
       description: 'API permettant de soumettre une Base Adresse Locale à la Base Adresse Nationale. Gestion des habilitations.',
       href: 'https://github.com/BaseAdresseNationale/api-depot/wiki/Documentation',
-      icon: <Folder alt='' />
+      icon: <Folder alt />
     },
     {
       title: 'API FANTOIR',
       description: 'API permettant consulter la base FANTOIR de la DGFiP.',
       href: 'https://github.com/BaseAdresseNationale/api-fantoir/blob/master/README.md#api',
-      icon: <Folder alt='' />
+      icon: <Folder alt />
     },
     {
       title: 'Supervision BAN/BAL',
       description: 'Consultez la disponiblité des différents systèmes grâce à un outil de monitoring.',
       href: 'https://status.adresse.data.gouv.fr/',
-      icon: <Activity alt='' />
+      icon: <Activity alt />
     }
   ]
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Compass color='white' size={56} alt='' />} />
+      <Head title={title} icon={<Compass color='white' size={56} alt />} />
       <Tools items={apis} />
     </Page>
   )

--- a/pages/api-doc/index.js
+++ b/pages/api-doc/index.js
@@ -13,37 +13,37 @@ function ApiPage() {
       title: 'API Adresse',
       description: 'Recherchez ou normalisez des adresses à l’unité ou en lot. Géocodage direct ou inversé.',
       href: '/api-doc/adresse',
-      icon: <Terminal />
+      icon: <Terminal alt='' />
     },
     {
       title: 'API Gestion d\'une Base Adresse Locale',
       description: 'API permettant de créer une Base Adresse Locale et d’en gérer les adresses. Utilisée par Mes Adresses.',
       href: 'https://github.com/BaseAdresseNationale/api-bal/wiki/Documentation-de-l\'API',
-      icon: <Map />
+      icon: <Map alt='' />
     },
     {
       title: 'API Dépot d\'une Base Adresse Locale',
       description: 'API permettant de soumettre une Base Adresse Locale à la Base Adresse Nationale. Gestion des habilitations.',
       href: 'https://github.com/BaseAdresseNationale/api-depot/wiki/Documentation',
-      icon: <Folder />
+      icon: <Folder alt='' />
     },
     {
       title: 'API FANTOIR',
       description: 'API permettant consulter la base FANTOIR de la DGFiP.',
       href: 'https://github.com/BaseAdresseNationale/api-fantoir/blob/master/README.md#api',
-      icon: <Folder />
+      icon: <Folder alt='' />
     },
     {
       title: 'Supervision BAN/BAL',
       description: 'Consultez la disponiblité des différents systèmes grâce à un outil de monitoring.',
       href: 'https://status.adresse.data.gouv.fr/',
-      icon: <Activity />
+      icon: <Activity alt='' />
     }
   ]
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Compass color='white' size={56} />} />
+      <Head title={title} icon={<Compass color='white' size={56} alt='' />} />
       <Tools items={apis} />
     </Page>
   )

--- a/pages/bases-locales.js
+++ b/pages/bases-locales.js
@@ -25,7 +25,7 @@ class BasesAdressesLocalesPage extends React.Component {
 
     return (
       <Page title={title} description={description}>
-        <Head title={title} icon={<Database size={56} />} />
+        <Head title={title} icon={<Database size={56} alt='' />} />
         <BasesLocales datasets={datasets} stats={stats} />
       </Page>
     )

--- a/pages/bases-locales.js
+++ b/pages/bases-locales.js
@@ -25,7 +25,7 @@ class BasesAdressesLocalesPage extends React.Component {
 
     return (
       <Page title={title} description={description}>
-        <Head title={title} icon={<Database size={56} alt='' />} />
+        <Head title={title} icon={<Database size={56} alt />} />
         <BasesLocales datasets={datasets} stats={stats} />
       </Page>
     )

--- a/pages/bases-locales/charte/communes.js
+++ b/pages/bases-locales/charte/communes.js
@@ -26,11 +26,11 @@ function Communes({regions}) {
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Award size={56} />} />
+      <Head title={title} icon={<Award size={56} alt='' />} />
 
       <Section title='Liste des communes partenaires'>
         <div className='award-illustration'>
-          <Image src='/images/icons/award.png' height={235} width={130} />
+          <Image src='/images/icons/award.png' height={235} width={130} alt='' />
         </div>
         <SectionText>
           Cette charte est à l’initiative de communes désireuses de <b>partager leur expérience</b>. La qualité de la Base Adresse Locale réalisée est un prérequis afin de faciliter <b>la diffusion de bonnes pratiques</b>.
@@ -39,7 +39,7 @@ function Communes({regions}) {
         <div className='contact-button'>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
           </ButtonLink>
         </div>
 

--- a/pages/bases-locales/charte/communes.js
+++ b/pages/bases-locales/charte/communes.js
@@ -26,11 +26,11 @@ function Communes({regions}) {
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Award size={56} alt='' />} />
+      <Head title={title} icon={<Award size={56} alt />} />
 
       <Section title='Liste des communes partenaires'>
         <div className='award-illustration'>
-          <Image src='/images/icons/award.png' height={235} width={130} alt='' />
+          <Image src='/images/icons/award.png' height={235} width={130} alt />
         </div>
         <SectionText>
           Cette charte est à l’initiative de communes désireuses de <b>partager leur expérience</b>. La qualité de la Base Adresse Locale réalisée est un prérequis afin de faciliter <b>la diffusion de bonnes pratiques</b>.
@@ -39,7 +39,7 @@ function Communes({regions}) {
         <div className='contact-button'>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt />
           </ButtonLink>
         </div>
 

--- a/pages/bases-locales/charte/index.js
+++ b/pages/bases-locales/charte/index.js
@@ -19,7 +19,7 @@ function Charte() {
 
   return (
     <Page title={title} description={description} >
-      <Head title={title} icon={<Download size={56} alt='' />} />
+      <Head title={title} icon={<Download size={56} alt />} />
 
       <Section background='white' title='Charte de la Base Adresse Locale'>
         <SectionText>
@@ -46,7 +46,7 @@ function Charte() {
         <div className='contact-button'>
           <ButtonLink href='mailto:adresse@data.gouv.fr' color='white' isExternal isOutlined>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt />
           </ButtonLink>
         </div>
 
@@ -59,7 +59,7 @@ function Charte() {
           >
             <Image
               src='/images/previews/charte-communes.png'
-              alt=''
+              alt
               width={150}
               height={200}
               objectFit='contain'
@@ -74,7 +74,7 @@ function Charte() {
           >
             <Image
               src='/images/previews/charte-organismes.png'
-              alt=''
+              alt
               width={150}
               height={200}
               objectFit='contain'

--- a/pages/bases-locales/charte/index.js
+++ b/pages/bases-locales/charte/index.js
@@ -19,7 +19,7 @@ function Charte() {
 
   return (
     <Page title={title} description={description} >
-      <Head title={title} icon={<Download size={56} />} />
+      <Head title={title} icon={<Download size={56} alt='' />} />
 
       <Section background='white' title='Charte de la Base Adresse Locale'>
         <SectionText>
@@ -46,7 +46,7 @@ function Charte() {
         <div className='contact-button'>
           <ButtonLink href='mailto:adresse@data.gouv.fr' color='white' isExternal isOutlined>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
           </ButtonLink>
         </div>
 
@@ -59,7 +59,7 @@ function Charte() {
           >
             <Image
               src='/images/previews/charte-communes.png'
-              alt='miniature de la charte des communes'
+              alt=''
               width={150}
               height={200}
               objectFit='contain'
@@ -74,7 +74,7 @@ function Charte() {
           >
             <Image
               src='/images/previews/charte-organismes.png'
-              alt='miniature de la charte des organismes'
+              alt=''
               width={150}
               height={200}
               objectFit='contain'

--- a/pages/bases-locales/charte/organismes.js
+++ b/pages/bases-locales/charte/organismes.js
@@ -17,7 +17,7 @@ function Organismes() {
   const {epci, companies} = partners
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Award size={56} />} />
+      <Head title={title} icon={<Award size={56} alt='' />} />
 
       <Section title='Liste des organismes partenaires'>
         <SectionText>
@@ -27,7 +27,7 @@ function Organismes() {
         <div className='contact-button'>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
           </ButtonLink>
         </div>
 

--- a/pages/bases-locales/charte/organismes.js
+++ b/pages/bases-locales/charte/organismes.js
@@ -17,7 +17,7 @@ function Organismes() {
   const {epci, companies} = partners
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Award size={56} alt='' />} />
+      <Head title={title} icon={<Award size={56} alt />} />
 
       <Section title='Liste des organismes partenaires'>
         <SectionText>
@@ -27,7 +27,7 @@ function Organismes() {
         <div className='contact-button'>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt />
           </ButtonLink>
         </div>
 

--- a/pages/bases-locales/datasets.js
+++ b/pages/bases-locales/datasets.js
@@ -23,7 +23,7 @@ class Datasets extends React.Component {
 
     return (
       <Page title={title} description={description}>
-        <Head title={title} icon={<Database size={56} />} />
+        <Head title={title} icon={<Database size={56} alt='' />} />
         <BasesAdresseLocales datasets={datasets} />
       </Page>
     )

--- a/pages/bases-locales/datasets.js
+++ b/pages/bases-locales/datasets.js
@@ -23,7 +23,7 @@ class Datasets extends React.Component {
 
     return (
       <Page title={title} description={description}>
-        <Head title={title} icon={<Database size={56} alt='' />} />
+        <Head title={title} icon={<Database size={56} alt />} />
         <BasesAdresseLocales datasets={datasets} />
       </Page>
     )

--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -138,7 +138,7 @@ function PublicationPage({defaultRevision, defaultHabilitation, defaultCommune, 
 
         {commune && (
           <div className='commune-infos'>
-            <Image src='/images/icons/commune.svg' height={60} width={60} alt='' />
+            <Image src='/images/icons/commune.svg' height={60} width={60} alt />
             <Link href={`/commune/${commune.code}`} passHref><div>{commune.nom} - {commune.code}</div></Link>
           </div>
         )}

--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -138,7 +138,7 @@ function PublicationPage({defaultRevision, defaultHabilitation, defaultCommune, 
 
         {commune && (
           <div className='commune-infos'>
-            <Image src='/images/icons/commune.svg' height={60} width={60} />
+            <Image src='/images/icons/commune.svg' height={60} width={60} alt='' />
             <Link href={`/commune/${commune.code}`} passHref><div>{commune.nom} - {commune.code}</div></Link>
           </div>
         )}

--- a/pages/bases-locales/temoignages/[slug].js
+++ b/pages/bases-locales/temoignages/[slug].js
@@ -11,7 +11,7 @@ import Post from '@/components/post'
 function SlugPage({post}) {
   return (
     <Page title={post.title} description={post.excerpt} image={post.feature_image}>
-      <Head title='Témoignages sur les Bases Adresses Locales' icon={<BookOpen size={56} />} />
+      <Head title='Témoignages sur les Bases Adresses Locales' icon={<BookOpen size={56} alt='' />} />
       <Post {...post} backLink='/bases-locales/temoignages' />
     </Page>
   )

--- a/pages/bases-locales/temoignages/[slug].js
+++ b/pages/bases-locales/temoignages/[slug].js
@@ -11,7 +11,7 @@ import Post from '@/components/post'
 function SlugPage({post}) {
   return (
     <Page title={post.title} description={post.excerpt} image={post.feature_image}>
-      <Head title='Témoignages sur les Bases Adresses Locales' icon={<BookOpen size={56} alt='' />} />
+      <Head title='Témoignages sur les Bases Adresses Locales' icon={<BookOpen size={56} alt />} />
       <Post {...post} backLink='/bases-locales/temoignages' />
     </Page>
   )

--- a/pages/bases-locales/temoignages/index.js
+++ b/pages/bases-locales/temoignages/index.js
@@ -15,7 +15,7 @@ function Temoignages({posts, pagination}) {
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<MessageCircle size={56} alt='' />} />
+      <Head title={title} icon={<MessageCircle size={56} alt />} />
       <Section title={description}>
         {posts ? (
           <TemoignagesList pagination={pagination} posts={posts} />

--- a/pages/bases-locales/temoignages/index.js
+++ b/pages/bases-locales/temoignages/index.js
@@ -15,7 +15,7 @@ function Temoignages({posts, pagination}) {
 
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<MessageCircle size={56} />} />
+      <Head title={title} icon={<MessageCircle size={56} alt='' />} />
       <Section title={description}>
         {posts ? (
           <TemoignagesList pagination={pagination} posts={posts} />

--- a/pages/bases-locales/validator.js
+++ b/pages/bases-locales/validator.js
@@ -9,7 +9,7 @@ const title = 'Le validateur BAL'
 function ValidatorPage() {
   return (
     <Page>
-      <Head title={title} icon={<UserCheck size={56} alt='' />} />
+      <Head title={title} icon={<UserCheck size={56} alt />} />
       <Validator />
     </Page>
   )

--- a/pages/bases-locales/validator.js
+++ b/pages/bases-locales/validator.js
@@ -9,7 +9,7 @@ const title = 'Le validateur BAL'
 function ValidatorPage() {
   return (
     <Page>
-      <Head title={title} icon={<UserCheck size={56} />} />
+      <Head title={title} icon={<UserCheck size={56} alt='' />} />
       <Validator />
     </Page>
   )

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -11,7 +11,7 @@ import Post from '@/components/post'
 function SlugPage({post}) {
   return (
     <Page title={post.title} description={post.excerpt} image={post.feature_image}>
-      <Head title='Le Blog de L’Adresse' icon={<BookOpen size={56} />} />
+      <Head title='Le Blog de L’Adresse' icon={<BookOpen size={56} alt='' />} />
       <Post {...post} backLink='/blog' />
     </Page>
   )

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -11,7 +11,7 @@ import Post from '@/components/post'
 function SlugPage({post}) {
   return (
     <Page title={post.title} description={post.excerpt} image={post.feature_image}>
-      <Head title='Le Blog de L’Adresse' icon={<BookOpen size={56} alt='' />} />
+      <Head title='Le Blog de L’Adresse' icon={<BookOpen size={56} alt />} />
       <Post {...post} backLink='/blog' />
     </Page>
   )

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -39,7 +39,7 @@ function BlogIndex({posts, pagination, tags, tagsList}) {
 
   return (
     <Page title='Le Blog de L’Adresse'>
-      <Head title='Le Blog de L’Adresse' icon={<Book size={56} />} />
+      <Head title='Le Blog de L’Adresse' icon={<Book size={56} alt='' />} />
       <Section>
         {posts ? (
           <>
@@ -56,7 +56,7 @@ function BlogIndex({posts, pagination, tags, tagsList}) {
                           key={tag} className='tag'
                           onClick={() => removeTag(tag)}
                         >
-                          {getTagName(tag)} <X size='15' style={{verticalAlign: 'middle'}} />
+                          {getTagName(tag)} <X size='15' style={{verticalAlign: 'middle'}} alt='' />
                         </button>
                       ))}
                     </div>

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -39,7 +39,7 @@ function BlogIndex({posts, pagination, tags, tagsList}) {
 
   return (
     <Page title='Le Blog de L’Adresse'>
-      <Head title='Le Blog de L’Adresse' icon={<Book size={56} alt='' />} />
+      <Head title='Le Blog de L’Adresse' icon={<Book size={56} alt />} />
       <Section>
         {posts ? (
           <>
@@ -56,7 +56,7 @@ function BlogIndex({posts, pagination, tags, tagsList}) {
                           key={tag} className='tag'
                           onClick={() => removeTag(tag)}
                         >
-                          {getTagName(tag)} <X size='15' style={{verticalAlign: 'middle'}} alt='' />
+                          {getTagName(tag)} <X size='15' style={{verticalAlign: 'middle'}} alt />
                         </button>
                       ))}
                     </div>

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -19,7 +19,7 @@ function Commune({communeInfos, mairieInfos, revisions, codeCommune, currentRevi
 
   return (
     <Page id='page' title={`Informations sur la commune de ${communeInfos.nomCommune}`}>
-      <Head title={`Informations sur la commune de ${communeInfos.nomCommune}`} icon={<Home size={56} alt='' />} />
+      <Head title={`Informations sur la commune de ${communeInfos.nomCommune}`} icon={<Home size={56} alt />} />
 
       <CommuneInfos communeInfos={communeInfos} />
       <BALState

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -19,7 +19,7 @@ function Commune({communeInfos, mairieInfos, revisions, codeCommune, currentRevi
 
   return (
     <Page id='page' title={`Informations sur la commune de ${communeInfos.nomCommune}`}>
-      <Head title={`Informations sur la commune de ${communeInfos.nomCommune}`} icon={<Home size={56} />} />
+      <Head title={`Informations sur la commune de ${communeInfos.nomCommune}`} icon={<Home size={56} alt='' />} />
 
       <CommuneInfos communeInfos={communeInfos} />
       <BALState

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -13,7 +13,7 @@ const description = 'Contactez l’équipe de adresse.data.gouv.fr'
 function Contact() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Mail size={56} />} />
+      <Head title={title} icon={<Mail size={56} alt='' />} />
       <Section>
         <div className='sub-section'>
           <Question question='Je suis un particulier ou une entreprise et j’ai constaté une adresse manquante ou incorrecte.' isBold>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -13,7 +13,7 @@ const description = 'Contactez l’équipe de adresse.data.gouv.fr'
 function Contact() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Mail size={56} alt='' />} />
+      <Head title={title} icon={<Mail size={56} alt />} />
       <Section>
         <div className='sub-section'>
           <Question question='Je suis un particulier ou une entreprise et j’ai constaté une adresse manquante ou incorrecte.' isBold>

--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -14,7 +14,7 @@ const description = 'Les différents outils à votre disposition pour contribuer
 function Contribuer() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Edit2 size={56} alt='' />} />
+      <Head title={title} icon={<Edit2 size={56} alt />} />
       <Section subtitle='Que vous soyez une commune, une entreprise ou un simple citoyen, vous pouvez contribuer à la Base Adresse Nationale' background='grey' />
 
       <Section title='En tant que commune' subtitle='Créer une Base Adresse Locale' id='commune'>
@@ -28,7 +28,7 @@ function Contribuer() {
               <b>Plusieurs outils</b> existent leur permettant d’exercer cette compétence essentielle.
             </p>
           </SectionText>
-          <ButtonLink size='large' href='/gerer-mes-adresses'>Gérer mes adresses <MapPin style={{verticalAlign: 'bottom', marginRight: '5px'}} alt='' /></ButtonLink>
+          <ButtonLink size='large' href='/gerer-mes-adresses'>Gérer mes adresses <MapPin style={{verticalAlign: 'bottom', marginRight: '5px'}} alt /></ButtonLink>
         </div>
       </Section>
 
@@ -45,7 +45,7 @@ function Contribuer() {
           <p style={{margin: '3em 0'}}>Vous utilisez les données diffusées par ce site et vous avez identifié des alertes récurrentes sur une typologie d’adresse particulière ou dans une zone ?</p>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt />
           </ButtonLink>
         </div>
       </Section>

--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -14,7 +14,7 @@ const description = 'Les différents outils à votre disposition pour contribuer
 function Contribuer() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Edit2 size={56} />} />
+      <Head title={title} icon={<Edit2 size={56} alt='' />} />
       <Section subtitle='Que vous soyez une commune, une entreprise ou un simple citoyen, vous pouvez contribuer à la Base Adresse Nationale' background='grey' />
 
       <Section title='En tant que commune' subtitle='Créer une Base Adresse Locale' id='commune'>
@@ -28,7 +28,7 @@ function Contribuer() {
               <b>Plusieurs outils</b> existent leur permettant d’exercer cette compétence essentielle.
             </p>
           </SectionText>
-          <ButtonLink size='large' href='/gerer-mes-adresses'>Gérer mes adresses <MapPin style={{verticalAlign: 'bottom', marginRight: '5px'}} /></ButtonLink>
+          <ButtonLink size='large' href='/gerer-mes-adresses'>Gérer mes adresses <MapPin style={{verticalAlign: 'bottom', marginRight: '5px'}} alt='' /></ButtonLink>
         </div>
       </Section>
 
@@ -45,7 +45,7 @@ function Contribuer() {
           <p style={{margin: '3em 0'}}>Vous utilisez les données diffusées par ce site et vous avez identifié des alertes récurrentes sur une typologie d’adresse particulière ou dans une zone ?</p>
           <ButtonLink href='mailto:adresse@data.gouv.fr' isExternal>
             Contactez-nous
-            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} />
+            <Mail style={{verticalAlign: 'bottom', marginLeft: '4px'}} alt='' />
           </ButtonLink>
         </div>
       </Section>

--- a/pages/csv.js
+++ b/pages/csv.js
@@ -10,7 +10,7 @@ const description = 'adresse.data.gouv.fr met en place des outils pour une prise
 function CsvPage() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<FileText size={56} alt='' />} />
+      <Head title={title} icon={<FileText size={56} alt />} />
       <Csv />
     </Page>
   )

--- a/pages/csv.js
+++ b/pages/csv.js
@@ -10,7 +10,7 @@ const description = 'adresse.data.gouv.fr met en place des outils pour une prise
 function CsvPage() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<FileText size={56} />} />
+      <Head title={title} icon={<FileText size={56} alt='' />} />
       <Csv />
     </Page>
   )

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -86,7 +86,7 @@ function EtatDeploiement({datasets, stats}) {
   return (
     <Page>
       <div className='container-map'>
-        <Head title='État du déploiement des Bases Adresses Locales' icon={<Database size={56} />} />
+        <Head title='État du déploiement des Bases Adresses Locales' icon={<Database size={56} alt='' />} />
         <div className='map-stats-container' id='map-stat'>
           <div className='stats'>
             <DoughnutCounter

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -86,7 +86,7 @@ function EtatDeploiement({datasets, stats}) {
   return (
     <Page>
       <div className='container-map'>
-        <Head title='État du déploiement des Bases Adresses Locales' icon={<Database size={56} alt='' />} />
+        <Head title='État du déploiement des Bases Adresses Locales' icon={<Database size={56} alt />} />
         <div className='map-stats-container' id='map-stat'>
           <div className='stats'>
             <DoughnutCounter

--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -15,7 +15,7 @@ const description = 'Fichiers nationaux contenant les adresses du territoire.'
 function DonneesNatioales() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Download size={56} alt='' />} />
+      <Head title={title} icon={<Download size={56} alt />} />
       <Section title='Base Adresse Nationale' subtitle='Base de données de référence pour les adresses en France'>
         <Intro />
       </Section>
@@ -91,7 +91,7 @@ function DonneesNatioales() {
           </div>
         </SectionText>
         <div className='adjust-img'>
-          <Image width={1000} height={600} src='/images/donnees-nationales/schema-donnees-ban.svg' alt='' />
+          <Image width={1000} height={600} src='/images/donnees-nationales/schema-donnees-ban.svg' alt />
         </div>
       </Section>
 

--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -15,7 +15,7 @@ const description = 'Fichiers nationaux contenant les adresses du territoire.'
 function DonneesNatioales() {
   return (
     <Page title={title} description={description}>
-      <Head title={title} icon={<Download size={56} />} />
+      <Head title={title} icon={<Download size={56} alt='' />} />
       <Section title='Base Adresse Nationale' subtitle='Base de données de référence pour les adresses en France'>
         <Intro />
       </Section>
@@ -91,7 +91,7 @@ function DonneesNatioales() {
           </div>
         </SectionText>
         <div className='adjust-img'>
-          <Image width={1000} height={600} src='/images/donnees-nationales/schema-donnees-ban.svg' alt='Schéma représentant les sources de données présentes dans la Base Adresse Nationale' />
+          <Image width={1000} height={600} src='/images/donnees-nationales/schema-donnees-ban.svg' alt='' />
         </div>
       </Section>
 

--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -34,7 +34,7 @@ function Evenements() {
 
   return (
     <Page>
-      <Head title='Les évènements autour de l’adresse' icon={<Calendar size={56} alt='' />} />
+      <Head title='Les évènements autour de l’adresse' icon={<Calendar size={56} alt />} />
       <>
         <Section title='Évènements à venir'>
           <SectionText>

--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -34,7 +34,7 @@ function Evenements() {
 
   return (
     <Page>
-      <Head title='Les évènements autour de l’adresse' icon={<Calendar size={56} />} />
+      <Head title='Les évènements autour de l’adresse' icon={<Calendar size={56} alt='' />} />
       <>
         <Section title='Évènements à venir'>
           <SectionText>

--- a/pages/fantoir/departement/[departement]/commune/[commune]/index.js
+++ b/pages/fantoir/departement/[departement]/commune/[commune]/index.js
@@ -34,7 +34,7 @@ function VoiesList({voies, nomCommune, codeCommune}) {
 
   return (
     <Page title='FANTOIR'>
-      <Head title={`FANTOIR : ${nomCommune}`} icon={<Database size={56} />} />
+      <Head title={`FANTOIR : ${nomCommune}`} icon={<Database size={56} alt='' />} />
       <Section title={`Liste des voies - ${nomCommune}`}>
         <div className='search'>
           <SearchBar
@@ -49,7 +49,7 @@ function VoiesList({voies, nomCommune, codeCommune}) {
             isExternal
           >
             Télécharger au format CSV
-            <Download style={{verticalAlign: 'bottom', padding: '3px'}} />
+            <Download style={{verticalAlign: 'bottom', padding: '3px'}} alt='' />
           </ButtonLink>
         </div>
 

--- a/pages/fantoir/departement/[departement]/commune/[commune]/index.js
+++ b/pages/fantoir/departement/[departement]/commune/[commune]/index.js
@@ -34,7 +34,7 @@ function VoiesList({voies, nomCommune, codeCommune}) {
 
   return (
     <Page title='FANTOIR'>
-      <Head title={`FANTOIR : ${nomCommune}`} icon={<Database size={56} alt='' />} />
+      <Head title={`FANTOIR : ${nomCommune}`} icon={<Database size={56} alt />} />
       <Section title={`Liste des voies - ${nomCommune}`}>
         <div className='search'>
           <SearchBar
@@ -49,7 +49,7 @@ function VoiesList({voies, nomCommune, codeCommune}) {
             isExternal
           >
             Télécharger au format CSV
-            <Download style={{verticalAlign: 'bottom', padding: '3px'}} alt='' />
+            <Download style={{verticalAlign: 'bottom', padding: '3px'}} alt />
           </ButtonLink>
         </div>
 

--- a/pages/fantoir/departement/[departement]/index.js
+++ b/pages/fantoir/departement/[departement]/index.js
@@ -35,7 +35,7 @@ function CommunesList({communes, nomDepartement}) {
 
   return (
     <Page title='FANTOIR'>
-      <Head title={`FANTOIR : ${nomDepartement}`} icon={<Database size={56} alt='' />} />
+      <Head title={`FANTOIR : ${nomDepartement}`} icon={<Database size={56} alt />} />
       <Section title={`Liste des communes - ${nomDepartement}`}>
         <div className='search'>
           <SearchBar

--- a/pages/fantoir/departement/[departement]/index.js
+++ b/pages/fantoir/departement/[departement]/index.js
@@ -35,7 +35,7 @@ function CommunesList({communes, nomDepartement}) {
 
   return (
     <Page title='FANTOIR'>
-      <Head title={`FANTOIR : ${nomDepartement}`} icon={<Database size={56} />} />
+      <Head title={`FANTOIR : ${nomDepartement}`} icon={<Database size={56} alt='' />} />
       <Section title={`Liste des communes - ${nomDepartement}`}>
         <div className='search'>
           <SearchBar

--- a/pages/fantoir/index.js
+++ b/pages/fantoir/index.js
@@ -35,7 +35,7 @@ function Fantoir({departements}) {
 
   return (
     <Page title={title}>
-      <Head title={title} icon={<Database size={56} />} />
+      <Head title={title} icon={<Database size={56} alt='' />} />
       <Section title='Liste des départements'>
         <div className='search'>
           <SearchBar

--- a/pages/fantoir/index.js
+++ b/pages/fantoir/index.js
@@ -35,7 +35,7 @@ function Fantoir({departements}) {
 
   return (
     <Page title={title}>
-      <Head title={title} icon={<Database size={56} alt='' />} />
+      <Head title={title} icon={<Database size={56} alt />} />
       <Section title='Liste des départements'>
         <div className='search'>
           <SearchBar

--- a/pages/gerer-mes-adresses.js
+++ b/pages/gerer-mes-adresses.js
@@ -13,7 +13,7 @@ import theme from '@/styles/theme'
 function GererMesAdresses() {
   return (
     <Page>
-      <Head title='Gérer mes adresses' icon={<MapPin size={56} />} />
+      <Head title='Gérer mes adresses' icon={<MapPin size={56} alt='' />} />
 
       <Section title='Pourquoi et comment gérer les adresses de ma commune ?' subtitle='Un véritable enjeu de souveraineté pour la France et ses territoires'>
         <SectionText>
@@ -68,7 +68,7 @@ function GererMesAdresses() {
             rel='noreferrer'
             href='https://mes-adresses.data.gouv.fr/new'
           >
-            Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} />
+            Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt='' />
           </ButtonLink>
 
           <div className='already-done'>
@@ -79,7 +79,7 @@ function GererMesAdresses() {
 
         <Notification isFullWidth>
           <div>
-            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} />
+            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} alt='' />
             <Link href='/ressources'>Des guides sont à votre disposition</Link> afin de bien débuter, ainsi que le <a href='https://mes-adresses.data.gouv.fr/new?test=1' target='_blank' rel='noopener noreferrer'>mode démonstration de Mes Adresses qui vous permet de le découvrir en toute liberté</a>.
           </div>
         </Notification>
@@ -118,7 +118,7 @@ function GererMesAdresses() {
 
         <Notification isFullWidth>
           <div>
-            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} />
+            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} alt='' />
             Pour en savoir plus sur les <b>différentes méthodes de publication</b>, vous pouvez consulter la documentation <a href='https://doc.adresse.data.gouv.fr/mettre-a-jour-sa-base-adresse-locale/publier-une-base-adresse-locale' target='_blank' rel='noopener noreferrer'>Publier une Base Adresse Locale</a>.
           </div>
         </Notification>
@@ -139,7 +139,7 @@ function GererMesAdresses() {
               color='white'
               isOutlined
             >
-              Accéder à la page dédiée <Book style={{verticalAlign: 'bottom', marginLeft: '3px'}} />
+              Accéder à la page dédiée <Book style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt='' />
             </ButtonLink>
           </div>
         </div>

--- a/pages/gerer-mes-adresses.js
+++ b/pages/gerer-mes-adresses.js
@@ -13,7 +13,7 @@ import theme from '@/styles/theme'
 function GererMesAdresses() {
   return (
     <Page>
-      <Head title='Gérer mes adresses' icon={<MapPin size={56} alt='' />} />
+      <Head title='Gérer mes adresses' icon={<MapPin size={56} alt />} />
 
       <Section title='Pourquoi et comment gérer les adresses de ma commune ?' subtitle='Un véritable enjeu de souveraineté pour la France et ses territoires'>
         <SectionText>
@@ -68,7 +68,7 @@ function GererMesAdresses() {
             rel='noreferrer'
             href='https://mes-adresses.data.gouv.fr/new'
           >
-            Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt='' />
+            Créer votre Base Adresse Locale <Edit2 style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt />
           </ButtonLink>
 
           <div className='already-done'>
@@ -79,7 +79,7 @@ function GererMesAdresses() {
 
         <Notification isFullWidth>
           <div>
-            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} alt='' />
+            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} alt />
             <Link href='/ressources'>Des guides sont à votre disposition</Link> afin de bien débuter, ainsi que le <a href='https://mes-adresses.data.gouv.fr/new?test=1' target='_blank' rel='noopener noreferrer'>mode démonstration de Mes Adresses qui vous permet de le découvrir en toute liberté</a>.
           </div>
         </Notification>
@@ -118,7 +118,7 @@ function GererMesAdresses() {
 
         <Notification isFullWidth>
           <div>
-            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} alt='' />
+            <HelpCircle style={{verticalAlign: 'bottom', marginRight: '1em'}} alt />
             Pour en savoir plus sur les <b>différentes méthodes de publication</b>, vous pouvez consulter la documentation <a href='https://doc.adresse.data.gouv.fr/mettre-a-jour-sa-base-adresse-locale/publier-une-base-adresse-locale' target='_blank' rel='noopener noreferrer'>Publier une Base Adresse Locale</a>.
           </div>
         </Notification>
@@ -139,7 +139,7 @@ function GererMesAdresses() {
               color='white'
               isOutlined
             >
-              Accéder à la page dédiée <Book style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt='' />
+              Accéder à la page dédiée <Book style={{verticalAlign: 'bottom', marginLeft: '3px'}} alt />
             </ButtonLink>
           </div>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -85,7 +85,7 @@ function Home({stats, posts}) {
 
       <Section title='Obtenez des informations sur les adresses d’une commune' id='rechercher-une-commune'>
         <div className='commune-search-section'>
-          <Image src='/images/icons/commune.svg' height={200} width={200} />
+          <Image src='/images/icons/commune.svg' height={200} width={200} alt='' />
           <SectionText>
             Recherchez une commune afin d’obtenir les <b>informations disponibles sur ses adresses</b>, leur composition, leur degré d’achèvement et de certification, et de <b>télécharger ses fichiers adresses</b>.
           </SectionText>
@@ -143,7 +143,7 @@ function Home({stats, posts}) {
       <Section title='Découvrez les évènements autour de l’adresse' background='color'>
         <div className='event-section-container'>
           <div className='event-illustration'>
-            <Image src='/images/event-illustration.svg' layout='responsive' height={400} width={400} />
+            <Image src='/images/event-illustration.svg' layout='responsive' height={400} width={400} alt='' />
           </div>
           <SectionText color='secondary'>
             Que vous soyez maire ou élu, agent municipal, géomaticien, producteur ou utilisateur... vous pouvez consulter la page exposant les événements autour de l’adresse et vous inscrire à ceux adaptés à vos besoins.          </SectionText>

--- a/pages/index.js
+++ b/pages/index.js
@@ -85,7 +85,7 @@ function Home({stats, posts}) {
 
       <Section title='Obtenez des informations sur les adresses d’une commune' id='rechercher-une-commune'>
         <div className='commune-search-section'>
-          <Image src='/images/icons/commune.svg' height={200} width={200} alt='' />
+          <Image src='/images/icons/commune.svg' height={200} width={200} alt />
           <SectionText>
             Recherchez une commune afin d’obtenir les <b>informations disponibles sur ses adresses</b>, leur composition, leur degré d’achèvement et de certification, et de <b>télécharger ses fichiers adresses</b>.
           </SectionText>
@@ -143,7 +143,7 @@ function Home({stats, posts}) {
       <Section title='Découvrez les évènements autour de l’adresse' background='color'>
         <div className='event-section-container'>
           <div className='event-illustration'>
-            <Image src='/images/event-illustration.svg' layout='responsive' height={400} width={400} alt='' />
+            <Image src='/images/event-illustration.svg' layout='responsive' height={400} width={400} alt />
           </div>
           <SectionText color='secondary'>
             Que vous soyez maire ou élu, agent municipal, géomaticien, producteur ou utilisateur... vous pouvez consulter la page exposant les événements autour de l’adresse et vous inscrire à ceux adaptés à vos besoins.          </SectionText>

--- a/pages/outils.js
+++ b/pages/outils.js
@@ -13,37 +13,37 @@ function ToolsPage() {
       title: 'L‘explorateur BAN',
       description: 'Cherchez des adresses dans la Base Adresse Nationale.',
       href: '/base-adresse-nationale#4.4/46.9/1.7',
-      icon: <Map alt='' />
+      icon: <Map alt />
     },
     {
       title: 'Le géocodeur CSV',
       description: 'Uploadez un fichier CSV, définissez les colonnes à utiliser pour le géocodage.',
       href: '/csv',
-      icon: <FileText alt='' />
+      icon: <FileText alt />
     },
     {
       title: 'Le Validateur Base Adresse Locale',
       description: 'Vérifiez la conformité de votre fichier Base Adresse Locale.',
       href: '/bases-locales/validateur',
-      icon: <UserPlus alt='' />,
+      icon: <UserPlus alt />,
     },
     {
       title: 'Les APIS',
       description: 'Découvrez l‘API Adresse, l‘API Base Adresse Locale et l‘API de dépôt...',
       href: '/api-doc',
-      icon: <Terminal alt='' />
+      icon: <Terminal alt />
     },
     {
       title: 'L’explorateur FANTOIR',
       description: 'Consultez la base FANTOIR de la DGFiP en quelques clics',
       href: '/fantoir',
-      icon: <Archive alt='' />
+      icon: <Archive alt />
     }
   ]
 
   return (
     <Page title={title} description='adresse.data.gouv.fr met en place des outils pour une prise en main rapide des données adresses ouvertes.'>
-      <Head title={title} icon={<ToolsIcon color='white' size={56} />} alt='' />
+      <Head title={title} icon={<ToolsIcon color='white' size={56} />} alt />
       <Tools items={tools} />
     </Page>
   )

--- a/pages/outils.js
+++ b/pages/outils.js
@@ -13,37 +13,37 @@ function ToolsPage() {
       title: 'L‘explorateur BAN',
       description: 'Cherchez des adresses dans la Base Adresse Nationale.',
       href: '/base-adresse-nationale#4.4/46.9/1.7',
-      icon: <Map />
+      icon: <Map alt='' />
     },
     {
       title: 'Le géocodeur CSV',
       description: 'Uploadez un fichier CSV, définissez les colonnes à utiliser pour le géocodage.',
       href: '/csv',
-      icon: <FileText />
+      icon: <FileText alt='' />
     },
     {
       title: 'Le Validateur Base Adresse Locale',
       description: 'Vérifiez la conformité de votre fichier Base Adresse Locale.',
       href: '/bases-locales/validateur',
-      icon: <UserPlus />,
+      icon: <UserPlus alt='' />,
     },
     {
       title: 'Les APIS',
       description: 'Découvrez l‘API Adresse, l‘API Base Adresse Locale et l‘API de dépôt...',
       href: '/api-doc',
-      icon: <Terminal />
+      icon: <Terminal alt='' />
     },
     {
       title: 'L’explorateur FANTOIR',
       description: 'Consultez la base FANTOIR de la DGFiP en quelques clics',
       href: '/fantoir',
-      icon: <Archive />
+      icon: <Archive alt='' />
     }
   ]
 
   return (
     <Page title={title} description='adresse.data.gouv.fr met en place des outils pour une prise en main rapide des données adresses ouvertes.'>
-      <Head title={title} icon={<ToolsIcon color='white' size={56} />} />
+      <Head title={title} icon={<ToolsIcon color='white' size={56} />} alt='' />
       <Tools items={tools} />
     </Page>
   )

--- a/pages/ressources.js
+++ b/pages/ressources.js
@@ -13,7 +13,7 @@ import Notification from '@/components/notification'
 function Guides() {
   return (
     <Page>
-      <Head title='Ressources autour de l’adressage' icon={<Book size={56} alt='' />} />
+      <Head title='Ressources autour de l’adressage' icon={<Book size={56} alt />} />
       <Section>
         <SectionText>
           <p>
@@ -34,8 +34,8 @@ function Guides() {
         <p>Cette <b>documentation</b> vous fournit les informations relatives à la <b>Base Adresse Nationale</b>, au format <b>Base Adresse Locale</b>, ainsi que des FAQ et conseils pratiques.</p>
         <div className='button-container'>
           <div className='logos-container'>
-            <Image src='/images/logos/BAN.svg' height={210} width={210} alt='' />
-            <Image src='/images/logos/BAL.svg' height={200} width={200} alt='' />
+            <Image src='/images/logos/BAN.svg' height={210} width={210} alt />
+            <Image src='/images/logos/BAL.svg' height={200} width={200} alt />
           </div>
           <ButtonLink href='https://doc.adresse.data.gouv.fr/' isExternal isOutlined color='white'>
             Accéder à la documentation
@@ -122,7 +122,7 @@ function Guides() {
       <Section background='color' title='F.A.Q'>
         <div className='faq-container'>
           <div className='icon-container'>
-            <Image src='/images/icons/faq.svg' height={190} width={190} alt='' />
+            <Image src='/images/icons/faq.svg' height={190} width={190} alt />
           </div>
           <SectionText color='secondary'>
             Vous vous posez des questions sur <b>la création de votre Base Adresse Locale</b> et sur <b>la gestion de vos adresses</b> ? Certaines disposent déjà d’une réponse !<br />

--- a/pages/ressources.js
+++ b/pages/ressources.js
@@ -13,7 +13,7 @@ import Notification from '@/components/notification'
 function Guides() {
   return (
     <Page>
-      <Head title='Ressources autour de l’adressage' icon={<Book size={56} />} />
+      <Head title='Ressources autour de l’adressage' icon={<Book size={56} alt='' />} />
       <Section>
         <SectionText>
           <p>
@@ -34,8 +34,8 @@ function Guides() {
         <p>Cette <b>documentation</b> vous fournit les informations relatives à la <b>Base Adresse Nationale</b>, au format <b>Base Adresse Locale</b>, ainsi que des FAQ et conseils pratiques.</p>
         <div className='button-container'>
           <div className='logos-container'>
-            <Image src='/images/logos/BAN.svg' height={210} width={210} alt='Logo Base Adresse Nationale' />
-            <Image src='/images/logos/BAL.svg' height={200} width={200} alt='Logo Base Adresse Locale' />
+            <Image src='/images/logos/BAN.svg' height={210} width={210} alt='' />
+            <Image src='/images/logos/BAL.svg' height={200} width={200} alt='' />
           </div>
           <ButtonLink href='https://doc.adresse.data.gouv.fr/' isExternal isOutlined color='white'>
             Accéder à la documentation
@@ -122,7 +122,7 @@ function Guides() {
       <Section background='color' title='F.A.Q'>
         <div className='faq-container'>
           <div className='icon-container'>
-            <Image src='/images/icons/faq.svg' height={190} width={190} />
+            <Image src='/images/icons/faq.svg' height={190} width={190} alt='' />
           </div>
           <SectionText color='secondary'>
             Vous vous posez des questions sur <b>la création de votre Base Adresse Locale</b> et sur <b>la gestion de vos adresses</b> ? Certaines disposent déjà d’une réponse !<br />
@@ -148,7 +148,7 @@ function Guides() {
 
       <Section background='grey' title='En partenariat avec : '>
         <div style={{display: 'flex', justifyContent: 'center'}}>
-          <Image width={190} height={80} src='/images/logos/logo_ANCT.svg' alt='logo ANCT' />
+          <Image width={190} height={80} src='/images/logos/logo_ANCT.svg' alt='l’ANCT' />
         </div>
       </Section>
     </Page>

--- a/partners.json
+++ b/partners.json
@@ -19,8 +19,7 @@
       ],
       "picture": "/images/logos/partners/epci/atd24.png",
       "height": 124,
-      "width": 187,
-      "alt": "Logo de L’Agence Technique Départementale de la Dordogne"
+      "width": 187
     },
     {
       "name": "SiiG",
@@ -44,8 +43,7 @@
       ],
       "picture": "/images/logos/partners/epci/siig.png",
       "height": 124,
-      "width": 116,
-      "alt": "Logo du Syndicat Intercommunal d’Information Géographique"
+      "width": 116
     },
     {
       "name": "SMICA",
@@ -66,8 +64,7 @@
       ],
       "picture": "/images/logos/partners/epci/smica.png",
       "height": 81,
-      "width": 290,
-      "alt": "Logo du Syndicat pour la Modernisation et l'Ingénierie des Collectivités"
+      "width": 290
     },
     {
       "name": "Imaginà-Coworking Balagna",
@@ -86,8 +83,7 @@
       ],
       "picture": "/images/logos/partners/epci/imagina.png",
       "height": 97,
-      "width": 290,
-      "alt": "Logo Imaginà-Coworking Balagna"
+      "width": 290
     },
     {
       "name": "IDéO BFC",
@@ -113,8 +109,7 @@
       ],
       "picture": "/images/logos/partners/epci/ideo.png",
       "height": 124,
-      "width": 84,
-      "alt": "Logo de IDéO BFC"
+      "width": 84
     },
     {
       "name": "Département du Calvados",
@@ -135,8 +130,7 @@
       ],
       "picture": "/images/logos/partners/epci/calvados.png",
       "height": 124,
-      "width": 147,
-      "alt": "Logo du Département du Calvados"
+      "width": 147
     },
     {
       "name": "ATD16",
@@ -157,8 +151,7 @@
       ],
       "picture": "/images/logos/partners/epci/atd16.jpg",
       "height": 124,
-      "width": 123,
-      "alt": "Logo de L’Agence Technique Départementale de la Charente"
+      "width": 123
     },
     {
       "name": "Communauté de Communes du Pont du Gard",
@@ -179,8 +172,7 @@
       ],
       "picture": "/images/logos/partners/epci/ccpg.jpg",
       "height": 124,
-      "width": 256,
-      "alt": "Logo de la Communauté de Communes du Pont du Gard"
+      "width": 256
     },
     {
       "name": "RGD Savoie Mont Blanc",
@@ -201,8 +193,7 @@
       ],
       "picture": "/images/logos/partners/epci/rgdsavoie.png",
       "height": 124,
-      "width": 136,
-      "alt": "Logo de la RGD Savoie Mont Blanc"
+      "width": 136
     },
     {
       "name": "MEGALIS Bretagne",
@@ -225,8 +216,7 @@
       ],
       "picture": "/images/logos/partners/epci/megalis_bretagne.png",
       "height": 124,
-      "width": 294,
-      "alt": "Logo de MEGALIS Bretagne"
+      "width": 294
     },
     {
       "name": "Département de l'Yonne",
@@ -244,8 +234,7 @@
       ],
       "picture": "/images/logos/partners/epci/yonne.png",
       "height": 124,
-      "width": 124,
-      "alt": "Logo du Conseil Départemental de l'Yonne"
+      "width": 124
     },
     {
       "name": "Agglomération de la Région de Compiègne",
@@ -266,8 +255,7 @@
       ],
       "picture": "/images/logos/partners/epci/compiegne.png",
       "height": 129,
-      "width": 290,
-      "alt": "Logo de l’Agglomération de la Région de Compiègne"
+      "width": 290
     },
     {
       "name": "TIGEO",
@@ -287,8 +275,7 @@
       ],
       "picture": "/images/logos/partners/epci/tigeo.png",
       "height": 83,
-      "width": 290,
-      "alt": "Logo de Tarn Information Géographique"
+      "width": 290
     },
     {
       "name": "Pays de Brest",
@@ -308,8 +295,7 @@
       ],
       "picture": "/images/logos/partners/epci/paysBrest.png",
       "height": 118,
-      "width": 290,
-      "alt": "Logo du Pays de Brest"
+      "width": 290
     },
     {
       "name": "GÉOPAL",
@@ -334,8 +320,7 @@
       ],
       "picture": "/images/logos/partners/epci/geopal.png",
       "height": 122,
-      "width": 290,
-      "alt": "Logo de GÉOPAL"
+      "width": 290
     },
     {
       "name": "Communauté d'Agglomération Gaillac Graulhet",
@@ -356,8 +341,7 @@
       ],
       "picture": "/images/logos/partners/epci/gaillac.png",
       "height": 117,
-      "width": 300,
-      "alt": "Logo de la Communauté d'Agglomération Gaillac Graulhet"
+      "width": 300
     },
     {
       "name": "Communauté d'Agglomération Plaine Vallée",
@@ -378,8 +362,7 @@
       ],
       "picture": "/images/logos/partners/epci/plaine-vallee.png",
       "height": 124,
-      "width": 277,
-      "alt": "Logo de la Communauté d'Agglomération Plaine Vallée"
+      "width": 277
     },
     {
       "name": "Réseau Régional des Données Territoriales et Géographiques en Centre-Val de Loire",
@@ -404,8 +387,7 @@
       ],
       "picture": "/images/logos/partners/epci/doterr_geocentre.png",
       "height": 124,
-      "width": 258,
-      "alt": "Logo du Réseau Régional des Données Territoriales et Géographiques en Centre-Val de Loire"
+      "width": 258
     },
     {
       "name": "Somme Numérique",
@@ -424,8 +406,7 @@
       ],
       "picture": "/images/logos/partners/epci/somme-numerique.jpg",
       "height": 73,
-      "width": 290,
-      "alt": "Logo de Somme Numérique"
+      "width": 290
     },
     {
       "name": "Communauté de Communes des Lisières de l’Oise",
@@ -446,8 +427,7 @@
       ],
       "picture": "/images/logos/partners/epci/lisieres-de-oise.png",
       "height": 124,
-      "width": 162,
-      "alt": "Logo de la Communauté de Communes des Lisières de l’Oise"
+      "width": 162
     },
     {
       "name": "Syndicat Départemental d’Aménagement et d’Ingénierie du Lot",
@@ -467,8 +447,7 @@
       ],
       "picture": "/images/logos/partners/epci/lot.jpg",
       "height": 124,
-      "width": 105,
-      "alt": "Logo du Syndicat Départemental d’Aménagement et d’Ingénierie du Lot"
+      "width": 105
     },
     {
       "name": "LOSANGE",
@@ -493,8 +472,7 @@
       ],
       "picture": "/images/logos/partners/epci/losange.jpg",
       "height": 62,
-      "width": 290,
-      "alt": "Logo de LOSANGE"
+      "width": 290
     },
     {
       "name": "OPenIG",
@@ -524,8 +502,7 @@
       ],
       "picture": "/images/logos/partners/epci/openig.png",
       "height": 124,
-      "width": 119,
-      "alt": "Logo de OPENIG"
+      "width": 119
     },
     {
       "name": "Communauté de communes Pays de Forcalquier - Montagne de Lure",
@@ -546,8 +523,7 @@
       ],
       "picture": "/images/logos/partners/epci/forcalquier-lure.jpg",
       "height": 124,
-      "width": 240,
-      "alt": "Logo de Communauté de communes Pays de Forcalquier et Montagne de Lure"
+      "width": 240
     },
     {
       "name": "Colmar Agglomération",
@@ -567,8 +543,7 @@
       ],
       "picture": "/images/logos/partners/epci/colmar.jpg",
       "height": 124,
-      "width": 216,
-      "alt": "Logo de Colmar Agglomération"
+      "width": 216
     },
     {
       "name": "Clermont Auvergne Métropole",
@@ -589,8 +564,7 @@
       ],
       "picture": "/images/logos/partners/epci/clermont.png",
       "height": 124,
-      "width": 195,
-      "alt": "Logo de Clermont Auvergne Métropole"
+      "width": 195
     },
     {
       "name": "Tarn-et-Garonne Numérique",
@@ -609,8 +583,7 @@
       ],
       "picture": "/images/logos/partners/epci/tarn-garonne-numerique.png",
       "height": 124,
-      "width": 121,
-      "alt": "Logo de Tarn et Garonne Numérique"
+      "width": 121
     },
     {
       "name": "Communauté d’Agglomération Pau Béarn Pyrénées Atlantiques",
@@ -630,8 +603,7 @@
       ],
       "picture": "/images/logos/partners/epci/pau.jpg",
       "height": 124,
-      "width": 261,
-      "alt": "Logo de la Communauté d’Agglomération Pau Béarn Pyrénées"
+      "width": 261
     },
     {
       "name": "Communauté de Communes de la Plaine d’Estrées",
@@ -652,8 +624,7 @@
       ],
       "picture": "/images/logos/partners/epci/ccpe.png",
       "height": 124,
-      "width": 246,
-      "alt": "Logo de la Communauté de Communes de la Plaine d’Estrées"
+      "width": 246
     },
     {
       "name": "Communauté d’agglomération Roannais Agglomération",
@@ -672,8 +643,7 @@
       ],
       "picture": "/images/logos/partners/epci/roannais.png",
       "height": 84,
-      "width": 290,
-      "alt": "Logo du partenaire Roannais Agglomération"
+      "width": 290
     },
     {
       "name": "Communauté d’Agglomération du Bassin de Brive",
@@ -692,8 +662,7 @@
       ],
       "picture": "/images/logos/partners/epci/brive.png",
       "height": 154,
-      "width": 100,
-      "alt": "Logo du partenaire Communauté d’Agglomération du Bassin de Brive"
+      "width": 100
     },
     {
       "name": "Communauté d’agglomération de Saint-Quentin-en-Yvelines",
@@ -713,8 +682,7 @@
       ],
       "picture": "/images/logos/partners/epci/saint-quentin-yvelines.jpg",
       "height": 124,
-      "width": 220,
-      "alt": "Logo du partenaire Communauté d’agglomération de Saint-Quentin-en-Yvelines"
+      "width": 220
     },
     {
       "name": "Communauté d’agglomération Royan Atlantique",
@@ -732,8 +700,7 @@
       ],
       "picture": "/images/logos/partners/epci/royan.png",
       "height": 124,
-      "width": 221,
-      "alt": "Logo du partenaire Communauté d’agglomération Royan Atlantique"
+      "width": 221
     },
     {
       "name": "Communauté d’Agglomération Pays Basque",
@@ -753,8 +720,7 @@
       ],
       "picture": "/images/logos/partners/epci/pays-basque.png",
       "height": 124,
-      "width": 125,
-      "alt": "Logo du partenaire Communauté d’Agglomération Pays Basque"
+      "width": 125
     },
     {
       "name": "Manche numérique",
@@ -773,8 +739,7 @@
       ],
       "picture": "/images/logos/partners/epci/manche-numerique.jpg",
       "height": 117,
-      "width": 232,
-      "alt": "Logo du partenaire Manche numérique"
+      "width": 232
     },
     {
       "name": "Communauté d'agglomération de l'Albigeois",
@@ -793,8 +758,7 @@
       ],
       "picture": "/images/logos/partners/epci/albigeois.png",
       "height": 154,
-      "width": 114,
-      "alt": "Logo du partenaire Communauté d'agglomération de l'Albigeois"
+      "width": 114
     },
     {
       "name": "Communauté d'Agglomération Ventoux Comtat Venaissin",
@@ -815,8 +779,7 @@
       ],
       "picture": "/images/logos/partners/epci/la-cove.png",
       "height": 124,
-      "width": 120,
-      "alt": "Logo du partenaire Communauté d’Agglomération Ventoux Comtat Venaissin"
+      "width": 120
     },
     {
       "name": "GéoBretagne",
@@ -838,8 +801,7 @@
       ],
       "picture": "/images/logos/partners/epci/geobretagne.png",
       "height": 45,
-      "width": 232,
-      "alt": "Logo du partenaire GéoBretagne"
+      "width": 232
     },
     {
       "name": "Communauté de Communes du Pays du Coquelicot",
@@ -860,8 +822,7 @@
       ],
       "picture": "/images/logos/partners/epci/coquelicot.jpg",
       "height": 124,
-      "width": 109,
-      "alt": "Logo du partenaire Communauté de Communes du Pays du Coquelicot"
+      "width": 109
     },
     {
       "name": "Pôle Marennes Oléron",
@@ -882,8 +843,7 @@
       ],
       "picture": "/images/logos/partners/epci/marennes-oleron.png",
       "height": 124,
-      "width": 76,
-      "alt": "Logo du partenaire Pôle Marennes Oléron"
+      "width": 76
     },
     {
       "name": "SIDEC du Jura",
@@ -902,8 +862,7 @@
       ],
       "picture": "/images/logos/partners/epci/sidec.png",
       "height": 124,
-      "width": 157,
-      "alt": "Logo du SIDEC du Jura"
+      "width": 157
     },
     {
       "name": "Alès Agglomération",
@@ -924,8 +883,7 @@
       ],
       "picture": "/images/logos/partners/epci/ales.png",
       "height": 124,
-      "width": 109,
-      "alt": "Logo du partenaire Alès Agglomération"
+      "width": 109
     },
     {
       "name": "Géo17 - Soluris",
@@ -944,8 +902,7 @@
       ],
       "picture": "/images/logos/partners/epci/soluris.png",
       "height": 124,
-      "width": 149,
-      "alt": "Logo du partenaire Géo17 - Soluris"
+      "width": 149
     },
     {
       "name": "Toulouse Métropole",
@@ -963,8 +920,7 @@
       ],
       "picture": "/images/logos/partners/epci/toulouse-metro.png",
       "height": 71,
-      "width": 232,
-      "alt": "Logo du partenaire Toulouse Métropole"
+      "width": 232
     },
     {
       "name": "Quimperlé Communauté",
@@ -983,8 +939,7 @@
       ],
       "picture": "/images/logos/partners/epci/quimperle.png",
       "height": 124,
-      "width": 245,
-      "alt": "Logo de Quimperlé Communauté"
+      "width": 245
     }
   ],
   "companies": [
@@ -1005,8 +960,7 @@
       ],
       "picture": "/images/logos/partners/companies/pichjulellu.png",
       "height": 105,
-      "width": 290,
-      "alt": "Logo du partenaire SARL Pichjulellu"
+      "width": 290
     },
     {
       "name": "Adress' & Vous",
@@ -1026,8 +980,7 @@
       ],
       "picture": "/images/logos/partners/companies/adress&vous.jpg",
       "height": 114,
-      "width": 290,
-      "alt": "Logo du partenaire Adress' & Vous"
+      "width": 290
     },
     {
       "name": "SIGNA.CONCEPT",
@@ -1056,8 +1009,7 @@
       ],
       "picture": "/images/logos/partners/companies/signa.jpg",
       "height": 124,
-      "width": 208,
-      "alt": "Logo de Signa.Concept"
+      "width": 208
     },
     {
       "name": "Anne Légaut",
@@ -1079,8 +1031,7 @@
       ],
       "picture": "/images/logos/partners/companies/legaut.jpg",
       "height": 124,
-      "width": 248,
-      "alt": "Logo du partenaire Anne Légaut"
+      "width": 248
     },
     {
       "name": "La Poste Solutions business",
@@ -1097,8 +1048,7 @@
       ],
       "picture": "/images/logos/partners/companies/la-poste.png",
       "height": 124,
-      "width": 102,
-      "alt": "Logo de la Poste"
+      "width": 102
     },
     {
       "name": "SIGEO 3D",
@@ -1115,8 +1065,7 @@
       ],
       "picture": "/images/logos/partners/companies/sigeo.png",
       "height": 89,
-      "width": 290,
-      "alt": "Logo de SIGEO 3D"
+      "width": 290
     },
     {
       "name": "SOGEFI Ingéniérie géomatique",
@@ -1134,8 +1083,7 @@
       ],
       "picture": "/images/logos/partners/companies/sogefi.png",
       "height": 102,
-      "width": 290,
-      "alt": "Logo de la SOGEFI Ingéniérie géomatique"
+      "width": 290
     },
     {
       "name": "PLANIGRAPHE",
@@ -1164,8 +1112,7 @@
       ],
       "picture": "/images/logos/partners/companies/planigraphe.jpg",
       "height": 124,
-      "width": 218,
-      "alt": "Logo de la société PLANIGRAPHE"
+      "width": 218
     }
   ],
   "communes": [
@@ -1188,7 +1135,6 @@
       "picture": "/images/logos/partners/communes/egliseneuve-des-liards.jpg",
       "height": 93,
       "width": 232,
-      "alt": "Blason de la commune de Égliseneuve-des-Liards",
       "signatureDate": "2021-05-11"
     },
     {
@@ -1210,7 +1156,6 @@
       "picture": "/images/logos/partners/communes/rougon.png",
       "height": 124,
       "width": 99,
-      "alt": "Blason de la commune de Rougon",
       "signatureDate": "2022-03-25"
     },
     {
@@ -1233,7 +1178,6 @@
       "picture": "/images/logos/partners/communes/breux-sur-avre.png",
       "height": 124,
       "width": 108,
-      "alt": "Blason de la commune Breux-sur-Avre",
       "signatureDate": "2022-03-29"
     },
     {
@@ -1256,7 +1200,6 @@
       "picture": "/images/logos/partners/communes/breau-mars.jpg",
       "height": 124,
       "width": 122,
-      "alt": "Blason de la commune Bréau-Mars",
       "signatureDate": "2022-04-08"
     },
     {
@@ -1279,7 +1222,6 @@
       "picture": "/images/logos/partners/communes/traverseres.jpg",
       "height": 124,
       "width": 88,
-      "alt": "Illustration de la commune Traversères",
       "signatureDate": "2022-04-08"
     },
     {
@@ -1302,7 +1244,6 @@
       "picture": "/images/logos/partners/communes/castillon-saves.jpg",
       "height": 124,
       "width": 124,
-      "alt": "Blason de la commune de Castillon-Savès",
       "signatureDate": "2022-05-05"
     },
     {
@@ -1325,7 +1266,6 @@
       "picture": "/images/logos/partners/communes/granges.png",
       "height": 124,
       "width": 79,
-      "alt": "Blason de la commune Granges",
       "signatureDate": "2022-05-16"
     },
     {
@@ -1348,7 +1288,6 @@
       "picture": "/images/logos/partners/communes/truchtersheim.jpg",
       "height": 124,
       "width": 136,
-      "alt": "Blason de la commune de Truchtersheim",
       "signatureDate": "2022-06-28"
     },
     {
@@ -1371,7 +1310,6 @@
       "picture": "/images/logos/partners/communes/entre-deux.png",
       "height": 124,
       "width": 286,
-      "alt": "",
       "signatureDate": "2022-06-03"
     }
   ]


### PR DESCRIPTION
Lors de l’insertion d’images dans les contenus, il peut être nécessaire de leur associer un texte de remplacement.

Ce texte est primordial, car c’est lui qui sera lu par les lecteurs d’écran (synthèses vocales et/ou plages brailles). Ce texte s’affiche également lorsque les images ne se chargent pas.

Le texte de remplacement sera à renseigner différemment selon le contexte d’utilisation de l’image. C’est-à-dire selon que l’image est décorative, informative, ou encore une image-lien.

La quasi-totalité des images et icônes présentes sur `adresse.data` sont destinées à **illustrer** et n'apportent aucune informations complémentaires.
Dans ce cas, le champ de texte de remplacement (alt) n'est pas renseigné. En respectant la convention, l'attribut est laissé vide de cette manière : `alt=''`


Sources

- https://www.accede-web.com/notices/editoriale-modele/utiliser-les-images-de-maniere-accessible/
- https://www.a11yproject.com/posts/alt-text/
- https://accessibleweb.com/question-answer/when-should-i-use-a-null-or-empty-alt-tag/

Close  #1200