### PR TITLE
Correction erreur 500 contact mairie

### DIFF
--- a/components/mairie/mairie-contact.js
+++ b/components/mairie/mairie-contact.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import {Mail, Phone} from 'react-feather'
 
 function MairieContact({email, phone}) {
-  console.log(email)
   return (
     <div className='contact-infos'>
       <div className='contact-info'>

--- a/components/mairie/mairie-contact.js
+++ b/components/mairie/mairie-contact.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import {Mail, Phone} from 'react-feather'
 
 function MairieContact({email, phone}) {
+  console.log(email)
   return (
     <div className='contact-infos'>
       <div className='contact-info'>
@@ -23,8 +24,7 @@ function MairieContact({email, phone}) {
 
         .contact-info {
           display: flex;
-          font-size: ${email.length > 35 ? '14px' : '16px'};
-          align-items: center;
+          font-size: ${email?.length > 35 ? '14px' : '16px'};
         }
       `}</style>
     </div>


### PR DESCRIPTION
Corrige l'erreur 500 sur la page commune, occasionnée à l'ouverture de la modale contenant les infos de la mairie lorsque la `clef/valeur` email n'existe pas.

https://user-images.githubusercontent.com/66621960/177182966-1312fe01-86cf-4489-bc0f-43fdf07fc944.mp4

