### PR TITLE
Amélioration design carte infos des communes partenaires

### DIFF
--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -36,10 +36,11 @@ function Partner({partnerInfos, isCommune}) {
   }, [getMairieInfos])
 
   return (
-    <div className='partner'>
+    <div className={`partner ${isDisplay && isCommune ? 'open-commune-partner' : ''}`}>
       <div className='general-partner-infos'>
         <p className='name'>
           <b><a href={link}>{`${name} ${isCompany ? '(société)' : ''}`}</a></b>
+          {isCommune && <Image src='/images/icons/commune.svg' height={35} width={35} layout='fixed' alt='Ce partenaire est une commune' />}
         </p>
         <div className='logo'>
           <Image
@@ -86,14 +87,21 @@ function Partner({partnerInfos, isCommune}) {
         .partner {
           max-width: 300px;
           width: 100%;
+          height: fit-content;
           grid-template-rows: 0.5fr auto;
           grid-template-columns: 1fr;
           display: grid;
           align-items: start;
           justify-content: center;
-          background: ${isCommune ? '#fceeac' : 'transparent'};
           padding: 1em;
           border-radius: 5px;
+          border: ${isCommune ? `solid 3px ${theme.primary}` : ''};
+        }
+
+        .open-commune-partner {
+          background-image: ${isDisplay && isCommune ? 'url(\'/images/icons/scarf.svg\')' : 'none'};
+          background-repeat:  no-repeat;
+          background-position: 115% 109%;
         }
 
         .general-partner-infos {
@@ -112,6 +120,9 @@ function Partner({partnerInfos, isCommune}) {
           font-weight: bold;
           font-style: normal;
           align-self: flex-start;
+          display: grid;
+          grid-template-columns: 1fr 35px;
+          align-items: center;
         }
 
         a {
@@ -129,7 +140,6 @@ function Partner({partnerInfos, isCommune}) {
           grid-template-rows: 1fr 0.5fr;
           font-style: italic;
           color: ${theme.colors.darkerGrey};
-          background: ${isCommune ? '#fceeac' : 'transparent'};
         }
 
         .button-container {
@@ -137,8 +147,8 @@ function Partner({partnerInfos, isCommune}) {
           grid-template-columns: 1fr 0.1fr;
           align-items: center;
           justify-items: self-start;
+          background: none;
           border-style: none;
-          background: ${isCommune ? '#fceeac' : 'transparent'};
           border-bottom: 2px solid ${theme.colors.lightBlue};
           box-shadow: 0px 14px 21px -15px ${theme.boxShadow};
           width: 100%;

--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -99,7 +99,7 @@ function Partner({partnerInfos, isCommune}) {
         }
 
         .open-commune-partner {
-          background-image: ${isDisplay && isCommune ? 'url(\'/images/icons/scarf.svg\')' : 'none'};
+          background-image: url('/images/icons/scarf.svg');
           background-repeat:  no-repeat;
           background-position: 115% 109%;
         }

--- a/components/mairie/mairie-contact.js
+++ b/components/mairie/mairie-contact.js
@@ -5,11 +5,11 @@ function MairieContact({email, phone}) {
   return (
     <div className='contact-infos'>
       <div className='contact-info'>
-        <Mail style={{marginRight: '10px'}} />
+        <Mail size={18} style={{marginRight: '10px'}} />
         {email ? <a href={`mailto:${email}`}>{email}</a> : 'Non renseigné'}
       </div>
       <div className='contact-info'>
-        <Phone style={{marginRight: '10px'}} />
+        <Phone size={18} style={{marginRight: '10px'}} />
         {phone ? <a href={`tel:+33${phone}`}>{phone}</a> : 'Non renseigné'}
       </div>
 
@@ -17,13 +17,14 @@ function MairieContact({email, phone}) {
         .contact-infos {
           display: flex;
           flex-direction: column;
-          padding-bottom: 1em;
-          gap: 1em;
+          padding-bottom: .5em;
+          gap: 5px;
         }
 
         .contact-info {
           display: flex;
           font-size: ${email.length > 35 ? '14px' : '16px'};
+          align-items: center;
         }
       `}</style>
     </div>

--- a/public/images/icons/scarf.svg
+++ b/public/images/icons/scarf.svg
@@ -1,0 +1,5 @@
+<svg width="110" height="132" viewBox="0 0 110 132" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="13.8232" height="130.762" transform="matrix(0.668125 0.744049 -0.633843 0.773462 82.8826 0)" fill="#0060FF"/>
+<rect width="13.8232" height="130.762" transform="matrix(0.668125 0.744049 -0.633843 0.773462 91.8235 10.1526)" fill="white"/>
+<rect width="13.8232" height="130.762" transform="matrix(0.668125 0.744049 -0.633843 0.773462 100.764 20.5753)" fill="#F70909"/>
+</svg>


### PR DESCRIPTION
Le design des cartes infos des communes partenaires présentaient un design très peu harmonieux et est donc entièrement refait.
Le choix de la petite icône de mairie à côté du nom permet de repérer immédiatement le status de ce partenaire.

### **AVANT**
![Capture d’écran 2022-07-05 à 15 25 52](https://user-images.githubusercontent.com/66621960/177338680-6ec144f6-cf99-4db1-b7f2-405b8bca0b69.png)
![Capture d’écran 2022-07-05 à 15 26 00](https://user-images.githubusercontent.com/66621960/177338677-0b791d3d-660d-402c-bc9a-5dc6b620fa43.png)

### **APRÈS**
![Capture d’écran 2022-07-05 à 15 25 41](https://user-images.githubusercontent.com/66621960/177338723-478e9f4d-7102-4b89-9c2d-059606443941.png)
![Capture d’écran 2022-07-05 à 15 25 33](https://user-images.githubusercontent.com/66621960/177338729-aabb0103-e716-4dc8-949a-5271441fd024.png)
