### PR TITLE
Correction des espacements entre les éléments des cartes blogs

### DIFF
--- a/components/blog-card.js
+++ b/components/blog-card.js
@@ -37,15 +37,15 @@ function BlogCard({post, onClick}) {
 
       <style jsx>{`
         .blog-container {
-          display: flex;
-          flex-direction: column;
+          display: grid;
+          grid-template-rows: 70px .5fr 33px 0fr 0fr 0fr;
           gap: .2em;
         }
 
         .blog-title {
           font-size: 1.2em;
           display: flex;
-          align-items: flex-start;
+          align-items: center;
           cursor: pointer;
         }
 
@@ -63,6 +63,7 @@ function BlogCard({post, onClick}) {
         }
 
         .blog-tags-container button {
+          height: fit-content;
           background-color: ${colors.lighterBlue};
           text-decoration: underline;
           cursor: pointer;
@@ -98,8 +99,8 @@ function BlogCard({post, onClick}) {
           cursor: pointer;
         }
 
-        .blog-link-container a {
-          padding: .5em;
+        h4 {
+          margin: 0;
         }
       `}</style>
     </div>


### PR DESCRIPTION
Les articles et témoignages ayant un titre de plus d'une ligne posaient un souci d'alignement. 

### **AVANT**
![179514141-b4879722-6834-4550-aad4-bb9fc1e3f719](https://user-images.githubusercontent.com/66621960/179524343-857f8a6e-f694-426e-b3f5-785627de67db.png)

### **APRÈS**
![Capture d’écran 2022-07-18 à 15 37 47](https://user-images.githubusercontent.com/66621960/179524416-167dec26-67b7-47df-943a-d2674bbe362c.png)

Close #1238