### PR TITLE
Mise à jour de @ban-team/validateur-bal

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.5",
-    "@ban-team/validateur-bal": "^2.7.1",
+    "@ban-team/validateur-bal": "^2.8.0",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",
     "@turf/boolean-contains": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,10 +517,10 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@ban-team/validateur-bal@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.7.1.tgz#ff9f530593d9fbca6592b980888eec37c6cdc739"
-  integrity sha512-Xa3QdKPgISKsmhFHurtUYu3S9OZR+LLuwG5xFk2pyEliFTfRkt/+DUnICa7z/492atH31h5+QRp5w2ujN9JDcQ==
+"@ban-team/validateur-bal@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.8.0.tgz#09c8b5854ab6b96d8779287bc7430150dbaeccf7"
+  integrity sha512-LusrzcHN9+0mjX0XIUjTjsrjiOD7158XPOucVtLxYEJ6I83ySdTg4MyW4QkJOxrsruf/ylEcdc+ZN2u0N5y3AQ==
   dependencies:
     "@etalab/project-legal" "^0.6.0"
     blob-to-buffer "^1.2.9"


### PR DESCRIPTION
Mise à jour de @ban-team/validateur-bal de la version `2.7.1` à `2.8.0`.

Voir les détails de cette version 
https://github.com/BaseAdresseNationale/validateur-bal/releases/tag/v2.8.0