### PR TITLE
Changement de l'url vers la Communauté d’agglomération de Saint-Quentin-en-Yvelines

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -666,7 +666,7 @@
     },
     {
       "name": "Communauté d’agglomération de Saint-Quentin-en-Yvelines",
-      "link": "https://www.saint-quentin-en-yvelines.fr/fr",
+      "link": "https://www.saint-quentin-en-yvelines.fr/fr/les-bases-adresse-de-sqy",
       "infos": "La Direction des Systèmes d’Information de Saint-Quentin-en-Yvelines accompagne les 12 communes de l’agglomération sur un outil mutualisé et assure la publication de leurs Bases Adresses Locales.",
       "perimeter": "Communes de l’agglomération de Saint-Quentin-en-Yvelines",
       "codeDepartement": [


### PR DESCRIPTION
`https://www.saint-quentin-en-yvelines.fr/fr` devient `https://www.saint-quentin-en-yvelines.fr/fr/les-bases-adresse-de-sqy` à la demande de la Communauté d’agglomération de Saint-Quentin-en-Yvelines.

Close  #1247