### PR TITLE
Téléchargement BAL 1.3 sur page Commune

### DIFF
--- a/components/commune/download-adresses.js
+++ b/components/commune/download-adresses.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
 
-import {getAddressCSVLegacy, getLieuxDitsCSVLegacy} from '@/lib/api-ban'
+import {getAddressCSVLegacy, getLieuxDitsCSVLegacy, getAdressesCsvBal} from '@/lib/api-ban'
 
 import DownloadCard from './download-card'
 import SectionText from '../section-text'
 
 function DownloadAdresses({codeCommune}) {
+  const adressesCsvBalUrl = getAdressesCsvBal(codeCommune)
   const addressLegacyUrl = getAddressCSVLegacy(codeCommune)
   const lieuxDitsLegacyUrl = getLieuxDitsCSVLegacy(codeCommune)
 
@@ -18,6 +19,7 @@ function DownloadAdresses({codeCommune}) {
       </SectionText>
 
       <div className='cards-container'>
+        <DownloadCard format='CSV BAL 1.3' url={adressesCsvBalUrl} isAvailable color='secondary' />
         <DownloadCard format='CSV historique (adresses)' url={addressLegacyUrl} isAvailable color='secondary' />
         <DownloadCard format='CSV historique (lieux-dits)' url={lieuxDitsLegacyUrl} isAvailable color='secondary' />
       </div>

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -54,3 +54,6 @@ export function getLieuxDitsCSVLegacy(codeCommune) {
   return `${API_BAN_URL}/ban/communes/${codeCommune}/download/csv-legacy/lieux-dits`
 }
 
+export function getAdressesCsvBal(codeCommune) {
+  return `${API_BAN_URL}/ban/communes/${codeCommune}/download/csv-bal/adresses`
+}


### PR DESCRIPTION
Ajout du lien pour télécharger les adresses d'une commune au format BAL 1.3