### PR TITLE
Ajout d’un lien vers les tutoriels SIG

### DIFF
--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -77,6 +77,15 @@ function DonneesNatioales() {
           >
             Visualisation cartographique des adresses BAN en tuiles vectorielles
           </Card>
+
+          <Card
+            title='Tutoriels SIG'
+            link='https://geoservices.ign.fr/documentation/services/utilisation-sig'
+            action='Consulter les tutoriels des SIG'
+            list={['WMS', 'WMTS', 'WFS']}
+          >
+            Tutoriels sur l’utilisation des Systèmes d’Information Géographique
+          </Card>
         </div>
       </Section>
 

--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -81,7 +81,7 @@ function DonneesNatioales() {
         </div>
         <div className='link'>
           <a href='https://geoservices.ign.fr/documentation/services/utilisation-sig'>
-            <ExternalLink style={{verticalAlign: 'bottom'}} /> Retrouvez les tutoriels d’utilisation des SIG
+            <ExternalLink style={{verticalAlign: 'bottom'}} /> Retrouvez les tutoriels d’utilisation des flux avec un outil SIG
           </a>
         </div>
       </Section>

--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -51,11 +51,6 @@ function DonneesNatioales() {
       </Section>
 
       <Section background='grey' title='Services cartographiques'>
-        <div className='link'>
-          <a href='https://geoservices.ign.fr/documentation/services/utilisation-sig'>
-            <ExternalLink style={{verticalAlign: 'bottom'}} /> Retrouvez les tutoriels d’utilisation des SIG
-          </a>
-        </div>
         <div className='card-container'>
           <Card
             title='Format MVT (tuiles vectorielles)'
@@ -83,6 +78,11 @@ function DonneesNatioales() {
           >
             Visualisation cartographique des adresses BAN en WMS
           </Card>
+        </div>
+        <div className='link'>
+          <a href='https://geoservices.ign.fr/documentation/services/utilisation-sig'>
+            <ExternalLink style={{verticalAlign: 'bottom'}} /> Retrouvez les tutoriels d’utilisation des SIG
+          </a>
         </div>
       </Section>
 
@@ -133,7 +133,7 @@ function DonneesNatioales() {
         }
         .link {
           text-align: center;
-          padding-top: 2em;
+          padding-top: 3em;
         }
       `}</style>
     </Page >

--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import {Download} from 'react-feather'
+import {Download, ExternalLink} from 'react-feather'
 
 import Page from '@/layouts/main'
 import Head from '@/components/head'
@@ -51,7 +51,21 @@ function DonneesNatioales() {
       </Section>
 
       <Section background='grey' title='Services cartographiques'>
+        <div className='link'>
+          <a href='https://geoservices.ign.fr/documentation/services/utilisation-sig'>
+            <ExternalLink style={{verticalAlign: 'bottom'}} /> Retrouvez les tutoriels d’utilisation des SIG
+          </a>
+        </div>
         <div className='card-container'>
+          <Card
+            title='Format MVT (tuiles vectorielles)'
+            link='https://github.com/BaseAdresseNationale/ban-plateforme/wiki/Tuiles-vectorielles'
+            action='Consulter la documentation MVT'
+            list={['Mise à jour en temps réel', '1 position par adresse']}
+          >
+            Visualisation cartographique des adresses BAN en tuiles vectorielles
+          </Card>
+
           <Card
             title='Format WFS'
             link='https://geoservices.ign.fr/services-web-experts-adresse'
@@ -68,23 +82,6 @@ function DonneesNatioales() {
             list={['Mise à jour mensuelle', 'Nom de la couche : BAN.DATA.GOUV', '1 position par adresse']}
           >
             Visualisation cartographique des adresses BAN en WMS
-          </Card>
-
-          <Card
-            link='https://github.com/BaseAdresseNationale/ban-plateforme/wiki/Tuiles-vectorielles'
-            action='Consulter la documentation MVT'
-            list={['Mise à jour en temps réel', '1 position par adresse']}
-          >
-            Visualisation cartographique des adresses BAN en tuiles vectorielles
-          </Card>
-
-          <Card
-            title='Tutoriels SIG'
-            link='https://geoservices.ign.fr/documentation/services/utilisation-sig'
-            action='Consulter les tutoriels des SIG'
-            list={['WMS', 'WMTS', 'WFS']}
-          >
-            Tutoriels sur l’utilisation des Systèmes d’Information Géographique
           </Card>
         </div>
       </Section>
@@ -133,6 +130,10 @@ function DonneesNatioales() {
         }
         .adjust-img {
           text-align: center;
+        }
+        .link {
+          text-align: center;
+          padding-top: 2em;
         }
       `}</style>
     </Page >


### PR DESCRIPTION
- Ajout d’un lien vers les tutoriels dans la partie services cartographiques sur la page "Données nationales"

- Restaure le titre "Format MVT"

Capture : 

![image](https://user-images.githubusercontent.com/56537238/186372605-e7c36176-bfcd-40db-81e9-9a3f312615b4.png)


Fix #1266