### PR TITLE
Centrer le texte sur la carte d'identité de la commune

### DIFF
--- a/components/commune-id-card.js
+++ b/components/commune-id-card.js
@@ -57,6 +57,7 @@ function CommuneIdCard({region, departement, codesPostaux, population, color, si
           font-weight: 100;
           font-size: ${size === 'regular' ? '18px' : '14px'};
           justify-self: center;
+          text-align: center;
         }
       `}</style>
     </div>

--- a/components/commune-id-card.js
+++ b/components/commune-id-card.js
@@ -51,6 +51,7 @@ function CommuneIdCard({region, departement, codesPostaux, population, color, si
           font-size: ${size === 'regular' ? '20px' : '15px'};
           font-weight: bold;
           justify-self: center;
+          text-align: center;
         }
 
         .value {


### PR DESCRIPTION
Le texte n'étant pas centré, lorsque certain nom de région ou de département se mettent à la ligne, le design n'est plus harmonieux. 

 ---------------------

### **AVANT**
<img width="460" alt="Capture d’écran 2022-08-24 à 17 26 41" src="https://user-images.githubusercontent.com/66621960/186458954-44f00220-e045-4524-876f-c8d7c49b6471.png">


### **APRÈS**
<img width="460" alt="Capture d’écran 2022-08-24 à 17 26 25" src="https://user-images.githubusercontent.com/66621960/186458961-a5e3b183-c819-4ca3-9ae8-18a8252bf97f.png">
