### PR TITLE
Corriger l'affichage des horaires des mairies

### DIFF
--- a/components/mairie/mairie-schedules.js
+++ b/components/mairie/mairie-schedules.js
@@ -7,7 +7,10 @@ import theme from '@/styles/theme'
 import ActionButtonNeutral from '@/components/action-button-neutral'
 
 const getHours = time => {
-  return new Date('1970-01-01T' + time + 'Z').getHours()
+  const getHour = time.slice(0, 2).replace('0', '')
+  const getMinutes = time.slice(3, 5).replace('00', '')
+
+  return getHour + 'h' + getMinutes
 }
 
 function CommuneSchedules({scheldules}) {
@@ -41,7 +44,7 @@ function CommuneSchedules({scheldules}) {
                 <ul>
                   {scheldule.heures.map(heure => (
                     <li key={`${scheldule.du}-${scheldule.au}&${heure.de}-${heure.a}`} aria-label={`${getHours(heure.de)} heures à ${getHours(heure.a)} heures`}>
-                      <div aria-hidden='true'>De <b>{getHours(heure.de)}h</b> à <b>{getHours(heure.a)}h</b></div>
+                      <div aria-hidden='true'>De <b>{getHours(heure.de)}</b> à <b>{getHours(heure.a)}</b></div>
                     </li>
                   ))}
                 </ul>

--- a/components/mairie/mairie-schedules.js
+++ b/components/mairie/mairie-schedules.js
@@ -7,10 +7,8 @@ import theme from '@/styles/theme'
 import ActionButtonNeutral from '@/components/action-button-neutral'
 
 const getHours = time => {
-  const getHour = time.slice(0, 2).replace('0', '')
-  const getMinutes = time.slice(3, 5).replace('00', '')
-
-  return getHour + 'h' + getMinutes
+  const [hour, minutes] = time.split(':')
+  return hour + 'h' + minutes
 }
 
 function CommuneSchedules({scheldules}) {


### PR DESCRIPTION
Les horaires des mairies affichées par le composant `<CommuneSchedules />` étaient erronées, car les horaires à la demi-heure sont arrondis à l'heure supérieur.

Solution : Utiliser des fonctions de traitement de string au lieu de passer par la création d'un objet Date. La fonction `getHours()` devient plus facilement compréhensible à la lecture et plus facile à manipuler.

------------------------------------
### **AVANT**
<img width="972" alt="Capture d’écran 2022-08-31 à 10 40 22" src="https://user-images.githubusercontent.com/66621960/187637054-a5acb83b-4c47-4fbb-8d7e-1c3eef01c037.png">

### **APRÈS**
<img width="769" alt="Capture d’écran 2022-08-31 à 10 39 49" src="https://user-images.githubusercontent.com/66621960/187637062-6eb3ca47-7518-47ab-9296-ea8b159f6672.png">


Close #1286