### PR TITLE
Corrections mineurs sur les cartes évènements

### DIFF
--- a/components/evenement/event-modal.js
+++ b/components/evenement/event-modal.js
@@ -203,15 +203,9 @@ function EventModal({event, isPassed, onClose}) {
         @media (max-width: 624px) {
           .presentation {
             flex-wrap: wrap;
-            justify-content: center;
-            text-align: center
-          }
-
-          .header-infos {
-            align-items: center;
+            justify-content: flex-end;
           }
         }
-
       `}</style>
     </div>
   )

--- a/events.json
+++ b/events.json
@@ -78,7 +78,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L’objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs. Inscription automatique après adoption de la charte, contacter adresse@data.gouv.fr",
     "type": "partenaire",
     "target": "Communes, EPCI, département, IDG et entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -182,7 +182,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L’objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -207,7 +207,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -232,7 +232,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -257,7 +257,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -282,7 +282,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -307,7 +307,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -332,7 +332,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -357,7 +357,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -382,7 +382,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",
@@ -407,7 +407,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Événement Partenaire de la Charte",
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
     "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l’adresse, les évolutions de l’éditeur Mes Adresses, l’accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l’accompagnement des communes et de fluidifier les retours utilisateurs.",
     "type": "partenaire",
     "target": "EPCI, Départements, IDG, entreprises partenaires de la Charte de la Base Adresse Locale",

--- a/events.json
+++ b/events.json
@@ -72,7 +72,7 @@
       "commune": ""
     },
     "href": "",
-    "isSubscriptionClosed": true,
+    "isSubscriptionClosed": false,
     "instructions": "Inscription automatique après adoption de la charte, contacter adresse@data.gouv.fr",
     "startHour": "14:00",
     "endHour": "15:30"
@@ -927,7 +927,7 @@
       "codePostal": ""
     },
     "href": "",
-    "isSubscriptionClosed": true,
+    "isSubscriptionClosed": false,
     "instructions": "Inscription automatique après adoption de la charte, contacter adresse@data.gouv.fr",
     "startHour": "14:00",
     "endHour": "15:30"


### PR DESCRIPTION
Cette PR apporte 3 modifications concernant les évènements autour de l'adresse.

1. Faire en sorte que les inscriptions aux Événements Partenaires soient toujours ouverte afin d'afficher les instructions. Tous les partenaires sont inscrit par défaut, il n'était donc pas nécessaire de "fermer" les inscriptions.

2. Certains des évènements `Événement Partenaire de la Charte de la Base Adresse Locale` avait un titre plus court (`Événement Partenaire de la Charte`)

3. Les media query permettant d'assurer la version mobile de la modale a été allégée. Les éléments sont maintenant alignés sur la gauche, ce qui est plus cohérent avec la version desktop.

--------------------------------------
### **AVANT**
<img width="428" alt="Capture d’écran 2022-08-31 à 14 56 30" src="https://user-images.githubusercontent.com/66621960/187683529-c7bb7692-0def-4967-86d8-051fc7ae2095.png">

### **APRÈS**
<img width="427" alt="Capture d’écran 2022-08-31 à 14 50 08" src="https://user-images.githubusercontent.com/66621960/187683548-442b0232-0673-4889-abab-a31f6021c858.png">
