### PR TITLE
Mise à jour du validateur de Base Adresse Locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.5",
-    "@ban-team/validateur-bal": "^2.10.0",
+    "@ban-team/validateur-bal": "^2.11.0",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",
     "@turf/boolean-contains": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,10 +522,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.1.0.tgz#5c1ee73fd98b86723ee9893a426cbfd9a6e5f6b6"
   integrity sha512-+SnPGySf715hd2pvygtCN24uGZNBMAeY8mNvt1WC7a+sPtjz74HL7+S+ff7SiZIrSYioSJi+OZp5t8QHgk2X/A==
 
-"@ban-team/validateur-bal@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.10.0.tgz#47f5f58ce13f2f4ab4b3e490e687ab3bb1d8cdaf"
-  integrity sha512-DPi9hlgbs88exH6UAoJLJ63UyChdBpldD+kzvp0DdXRWYGh7oJwUwroSuw7ixqAB7iXPlSsIfIK3fe6EUle78Q==
+"@ban-team/validateur-bal@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.11.0.tgz#3707aab531f720614d9c842db41ff510d92918d8"
+  integrity sha512-jyixz2ZhvFic4TQKzRyUcZoWDCXoiGfxrxp637kVeG4Yt+BIJW65Ze02qWa9F4OCZJxGNwj8asNzP6HJlEnXcA==
   dependencies:
     "@ban-team/shared-data" "^1.1.0"
     "@etalab/project-legal" "^0.6.0"
@@ -533,7 +533,7 @@
     bluebird "^3.7.2"
     chalk "^4.1.2"
     chardet "^1.4.0"
-    date-fns "^2.28.0"
+    date-fns "^2.29.3"
     file-type "^12.4.2"
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
@@ -2224,10 +2224,10 @@ data-uri-to-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
-date-fns@^2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Mise à jour du validateur de Base Adresse Locale en version [2.11.0](https://github.com/BaseAdresseNationale/validateur-bal/releases/tag/v2.11.0)
