### PR TITLE
Correction CSS cartes communes partenaires

### DIFF
--- a/components/bases-locales/charte/dropdown.js
+++ b/components/bases-locales/charte/dropdown.js
@@ -17,7 +17,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
   }
 
   return (
-    <ActionButtonNeutral isFullWidth onClick={dropdownToggle} label={`${isOpen ? 'Masquer' : 'Afficher'} les informations`}>
+    <ActionButtonNeutral isFullWidth onClick={dropdownToggle} label={`${isOpen ? 'Masquer' : 'Afficher'} les informations`} isFullSize>
       <div
         className={`
           dropdown-container
@@ -84,6 +84,7 @@ function Dropdown({code, nom, communesCount, size, color, children}) {
         .name {
           font-size: x-large;
           font-weight: bold;
+          text-align: start;
         }
 
         .communes-length {


### PR DESCRIPTION
Ajout d'une prop oubliée permettant d'afficher la carte de la région sur 100% de la largeur.

### **AVANT**
<img width="1197" alt="Capture d’écran 2022-09-27 à 15 27 09" src="https://user-images.githubusercontent.com/66621960/192544924-d7e49dae-ab07-4e4c-8908-8b67eb4edd97.png">

### **APRÈS**
<img width="1224" alt="Capture d’écran 2022-09-27 à 15 49 38" src="https://user-images.githubusercontent.com/66621960/192544951-8f5edd57-3858-4cb9-952b-73cb37d0016c.png">

Close #1308