### PR TITLE
Corrige erreur 500 & Affichage des suffixes numériques

### DIFF
--- a/components/base-adresse-nationale/positions-types.js
+++ b/components/base-adresse-nationale/positions-types.js
@@ -22,8 +22,8 @@ function PositionsTypes({positions, isMobile, isSafariBrowser, setCopyError, set
       <div>
         {positions.map(p => (
           <div key={uniqueId()} className='array-positions'>
-            <span className='position' style={{backgroundColor: positionsColors[p.positionType].color}}>
-              {positionsColors[p.positionType].name}
+            <span className='position' style={{backgroundColor: positionsColors[p?.positionType]?.color || '#FF6347'}}>
+              {positionsColors[p.positionType]?.name || 'Inconnu'}
             </span>
             <CoordinatesCopy
               isMobile={isMobile}

--- a/components/maplibre/ban-map/index.js
+++ b/components/maplibre/ban-map/index.js
@@ -96,7 +96,7 @@ const getPositionsFeatures = address => {
       },
       properties: {
         ...address,
-        type: p.positionType,
+        type: p?.positionType || 'inconnu',
         nomVoie: address.voie.nomVoie
       }
     }))

--- a/lib/ban.js
+++ b/lib/ban.js
@@ -1,4 +1,11 @@
 export function getNumeroComplet({numero, suffixe}) {
+  const suffixeCode = suffixe?.codePointAt(0) || null
+
+  // Check if suffixeCode is a String number
+  if (suffixeCode > 47 && suffixeCode < 58) {
+    return `${numero}-${suffixe || ''}`
+  }
+
   return `${numero}${suffixe || ''}`
 }
 


### PR DESCRIPTION
Cette PR corrige le problème d’erreur 500 pouvant arriver lorsqu’un numéro ne possède pas de type de position.

Elle ajoute également une fonction pour afficher correctement les numéros avec un suffixe numérique.

Pour tester, utiliser [Route d’Amien, Villers-Bretonneux](https://adresse.data.gouv.fr/base-adresse-nationale/80799_0020#15.26/49.87065/2.5081)

### Captures :  
#### Avant : 
![image](https://user-images.githubusercontent.com/56537238/193573092-828960b4-c7a4-4a1f-9c61-49247676df32.png)

#### Après : 
![image](https://user-images.githubusercontent.com/56537238/193573184-cefa3749-f4b2-4dc5-9c49-758ddab74b33.png)

