### PR TITLE
Corrige l’erreur lors de la recherche sur la page d’accueil

### DIFF
--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -59,14 +59,16 @@ function BanSearch() {
   }, [results])
 
   useEffect(() => {
-    if ((input.trim()).length >= 3) {
-      if (/[^A-Za-z\d]+/.test(input.slice(0, 3))) {
-        setError({message: 'Les trois premiers caractères doivent être des lettres ou des chiffres'})
-      } else {
+    const trimmedInput = input.trim()
+
+    if (trimmedInput.length >= 3) {
+      if (/^[A-z][A-z\d]{0,3}/.test(trimmedInput)) {
         setResults([])
         setLoading(true)
         setError(null)
-        handleSearch(input)
+        handleSearch(trimmedInput)
+      } else {
+        setError({message: 'Les trois premiers caractères doivent être des lettres ou des chiffres'})
       }
     }
   }, [handleSearch, input])

--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -59,7 +59,7 @@ function BanSearch() {
   }, [results])
 
   useEffect(() => {
-    if (input) {
+    if (input && input.length > 2) {
       setResults([])
       setLoading(true)
       setError(null)

--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -59,11 +59,15 @@ function BanSearch() {
   }, [results])
 
   useEffect(() => {
-    if (input && input.length > 2) {
-      setResults([])
-      setLoading(true)
-      setError(null)
-      handleSearch(input)
+    if ((input.trim()).length >= 3) {
+      if (/[^A-Za-z\d]+/.test(input.slice(0, 3))) {
+        setError({message: 'Les trois premiers caractères doivent être des lettres ou des chiffres'})
+      } else {
+        setResults([])
+        setLoading(true)
+        setError(null)
+        handleSearch(input)
+      }
     }
   }, [handleSearch, input])
 


### PR DESCRIPTION
Un message d’erreur apparaissait lorsqu’on effaçait toutes les lettres dans la barre de recherche ou lorsqu’on écrivait seulement une ou deux lettres.

Cette PR ajoute une condition qui permet de lancer la recherche uniquement si au moins trois caractères ont été entrés.
(Cette limite vient de l’API)