### PR TITLE
Corrige le problème d’affichage du numéro au chargement de la page

### DIFF
--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -12,7 +12,6 @@ import DeviceContext from '@/contexts/device'
 
 function BaseAdresseNationale({address}) {
   const {isMobileDevice} = useContext(DeviceContext)
-  const [initialHash, setInitialHash] = useState(null)
   const [bBox, setBBox] = useState(null)
   const Layout = isMobileDevice ? Mobile : Desktop
 
@@ -52,26 +51,9 @@ function BaseAdresseNationale({address}) {
   }, [router])
 
   useEffect(() => {
-    const {hash} = window.location
-
-    if (hash) {
-      setInitialHash(hash)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (address && initialHash) {
-      const {hash} = window.location
-      if (hash !== initialHash) {
-        setInitialHash(null)
-      }
-    }
-  }, [address, initialHash])
-
-  useEffect(() => {
     let bbox = address?.displayBBox
 
-    if (!initialHash && address?.positions?.length > 1) {
+    if (address?.positions?.length > 1) {
       const coordinates = address.positions.map(p => {
         return p.position.coordinates
       })
@@ -80,7 +62,7 @@ function BaseAdresseNationale({address}) {
     }
 
     setBBox(bbox)
-  }, [initialHash, address])
+  }, [address])
 
   return (
     <Page title={title} description={description} hasFooter={false}>
@@ -88,7 +70,6 @@ function BaseAdresseNationale({address}) {
         address={address}
         bbox={bBox}
         handleSelect={selectAddress}
-        hash={initialHash}
       />
     </Page>
   )


### PR DESCRIPTION
Cette PR corrige le problème d’affichage du numéro au chargement de la page.

Captures : 

Actuellement, en allant à [cette adresse](https://adresse.data.gouv.fr/base-adresse-nationale/60667_0280_00031#18.66/49.31455/2.74105) : 

![image](https://user-images.githubusercontent.com/56537238/197211961-90766dc7-672a-4c7b-bb34-b3b05cfb8195.png)

Avec la correction de cette PR : 

![image](https://user-images.githubusercontent.com/56537238/197212086-d59faa09-5a38-4c42-a43f-c14887a3ee85.png)

Fix #1328 