### PR TITLE
Gestion des erreurs détectées pendant un moissonnage

### DIFF
--- a/components/commune/bal-alerts.js
+++ b/components/commune/bal-alerts.js
@@ -5,11 +5,11 @@ import theme from '@/styles/theme'
 import Notification from '@/components/notification'
 import BalAlert from './bal-alert'
 
-function BalAlerts({errors, warnings, infos}) {
-  const hasAlerts = Boolean(warnings.length > 0 || errors.length > 0 || infos.length > 0)
+function BalAlerts({errors, nbRowsWithErrors, warnings, infos}) {
   const numberOfErrors = errors.length
   const numberOfWarnings = warnings.length
   const numberOfInfos = infos.length
+  const hasAlerts = Boolean(numberOfErrors > 0 || numberOfWarnings > 0 || numberOfInfos > 0)
 
   return (
     <div className='bal-alerts-types-container'>
@@ -18,6 +18,11 @@ function BalAlerts({errors, warnings, infos}) {
           {numberOfErrors > 0 && (
             <div className='alerts-type-container'>
               <h4>{numberOfErrors > 1 ? `${numberOfErrors} erreurs détectées` : `${numberOfErrors} erreur détectée`}</h4>
+              {nbRowsWithErrors && (
+                <i className='error'>
+                  {nbRowsWithErrors} {`${nbRowsWithErrors > 1 ? 'lignes n’ont pas pu être prisent' : 'ligne n’a pas pu être prise'} en compte dans la Base Adresse Nationale`}
+                </i>
+              )}
               {errors.map(error => <BalAlert key={error} alert={error} type='error' />)}
             </div>
           )}
@@ -47,6 +52,10 @@ function BalAlerts({errors, warnings, infos}) {
       <style jsx>{`
         .bal-alerts-types-container {
           margin-top: 3em;
+        }
+
+        .error {
+          color: ${theme.errorBorder};
         }
 
         .conform-container {
@@ -81,8 +90,13 @@ function BalAlerts({errors, warnings, infos}) {
   )
 }
 
+BalAlerts.defaultProps = {
+  nbRowsWithErrors: 0
+}
+
 BalAlerts.propTypes = {
   errors: PropTypes.array.isRequired,
+  nbRowsWithErrors: PropTypes.number,
   warnings: PropTypes.array.isRequired,
   infos: PropTypes.array.isRequired
 }

--- a/components/commune/bal-quality.js
+++ b/components/commune/bal-quality.js
@@ -5,7 +5,7 @@ import Section from '@/components/section'
 import BalAlerts from './bal-alerts'
 
 function BalQuality({currentRevision}) {
-  const harvestErrors = pick(currentRevision.client.extra, 'uniqueErrors', 'nbRowsWithErrors')
+  const harvestErrors = pick(currentRevision.context.extras, 'uniqueErrors', 'nbRowsWithErrors')
   const errors = harvestErrors.uniqueErrors || []
   const warnings = currentRevision?.validation.warnings ? currentRevision.validation.warnings : []
   const infos = currentRevision?.validation.infos ? currentRevision.validation.infos : []

--- a/components/commune/bal-quality.js
+++ b/components/commune/bal-quality.js
@@ -1,17 +1,24 @@
 import PropTypes from 'prop-types'
+import {pick} from 'lodash'
 
 import Section from '@/components/section'
 import BalAlerts from './bal-alerts'
 
 function BalQuality({currentRevision}) {
-  const errors = currentRevision && currentRevision.validation.errors ? currentRevision.validation.errors : []
-  const warnings = currentRevision && currentRevision.validation.warnings ? currentRevision.validation.warnings : []
-  const infos = currentRevision && currentRevision.validation.infos ? currentRevision.validation.infos : []
+  const harvestErrors = pick(currentRevision.client.extra, 'uniqueErrors', 'nbRowsWithErrors')
+  const errors = harvestErrors.uniqueErrors || []
+  const warnings = currentRevision?.validation.warnings ? currentRevision.validation.warnings : []
+  const infos = currentRevision?.validation.infos ? currentRevision.validation.infos : []
 
   return (
     <Section background='grey' title='Qualité des adresses' subtitle='Liste des types d’alertes détectés dans la Base Adresse Locale'>
       {currentRevision ? (
-        <BalAlerts errors={errors} warnings={warnings} infos={infos} />
+        <BalAlerts
+          errors={errors}
+          nbRowsWithErrors={harvestErrors.nbRowsWithErrors}
+          warnings={warnings}
+          infos={infos}
+        />
       ) : (
         <p>Retrouvez bientôt des informations concernant la qualité de la Base Adresse Locale de la commune.</p>
       )}

--- a/components/commune/bal-quality.js
+++ b/components/commune/bal-quality.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types'
 import Section from '@/components/section'
 import BalAlerts from './bal-alerts'
 
-function BalQuality({currentRevision, hasQualityAdresses}) {
+function BalQuality({currentRevision}) {
   const errors = currentRevision && currentRevision.validation.errors ? currentRevision.validation.errors : []
   const warnings = currentRevision && currentRevision.validation.warnings ? currentRevision.validation.warnings : []
   const infos = currentRevision && currentRevision.validation.infos ? currentRevision.validation.infos : []
 
   return (
     <Section background='grey' title='Qualité des adresses' subtitle='Liste des types d’alertes détectés dans la Base Adresse Locale'>
-      {hasQualityAdresses ? (
+      {currentRevision ? (
         <BalAlerts errors={errors} warnings={warnings} infos={infos} />
       ) : (
         <p>Retrouvez bientôt des informations concernant la qualité de la Base Adresse Locale de la commune.</p>
@@ -27,8 +27,7 @@ function BalQuality({currentRevision, hasQualityAdresses}) {
 }
 
 BalQuality.propTypes = {
-  currentRevision: PropTypes.object,
-  hasQualityAdresses: PropTypes.bool.isRequired
+  currentRevision: PropTypes.object
 }
 
 BalQuality.defaultTypes = {

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -30,12 +30,10 @@ function Commune({communeInfos, mairieInfos, revisions, codeCommune, currentRevi
         typeComposition={typeCompositionAdresses}
         hasMigratedBAL={hasRevision}
       />
+
       {typeCompositionAdresses !== 'assemblage' && (
         <>
-          <BalQuality
-            currentRevision={currentRevision}
-            hasQualityAdresses={hasRevision}
-          />
+          <BalQuality currentRevision={currentRevision} />
           <Historique
             revisions={revisions}
             communeName={communeInfos.nomCommune}


### PR DESCRIPTION
## Contexte
Lors d'un moissonnage, seules les lignes valides alimentent la BAN. Les lignes en erreur sont filtrées sans que le producteur de la donnée en ait connaissance.

Cette PR permet d'avertir sur la page commune si des erreurs ont été rencontrées et combien de ligne sont n'ont pas pu alimenter la BAN.

## Prévisualisation
![Capture d’écran 2022-11-09 à 15 31 56](https://user-images.githubusercontent.com/7040549/200871305-0bba9eab-3d38-4a5a-922a-953d8dea036c.png)

------
⚠️ DRAFT : Le `moissonneur-bal` ne renvoi pas encore les informations nécessaires dans `clent.extra` (développement en cours)