### PR TITLE
Fix le calcul du bounding box pour les adresses multi-positions

### DIFF
--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -75,7 +75,8 @@ function BaseAdresseNationale({address}) {
       const coordinates = address.positions.map(p => {
         return p.position.coordinates
       })
-      // calcul le bounding box, la premiere position comme initailisation
+      // Calcul le bounding box, la premiere position comme initialisation
+      // eslint-disable-next-line unicorn/no-array-reduce
       bbox = coordinates.reduce((bound, c) => bound.extend(c),
         new maplibregl.LngLatBounds(coordinates[0], coordinates[0])
       ).toArray()

--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -75,8 +75,10 @@ function BaseAdresseNationale({address}) {
       const coordinates = address.positions.map(p => {
         return p.position.coordinates
       })
-
-      bbox = new maplibregl.LngLatBounds(coordinates).toArray()
+      // calcul le bounding box, la premiere position comme initailisation
+      bbox = coordinates.reduce((bound, c) => bound.extend(c),
+        new maplibregl.LngLatBounds(coordinates[0], coordinates[0])
+      ).toArray()
     }
 
     setBBox(bbox)


### PR DESCRIPTION

Si l'adresse a plus de 2 positions, l'affichage de la carte provoquait une erreur 500.
![image](https://user-images.githubusercontent.com/62593305/201945149-31b00e80-de53-4ecf-befd-c5c08dee531f.png)

exemple 
[261 Rue de la Cascade,Courbouzon - 39169 (4 positions : 1 entrée, 1 batiment,  2 logements )](https://adresse.data.gouv.fr/base-adresse-nationale/39169_0035_00261)

attendu
![image](https://user-images.githubusercontent.com/62593305/201944464-8dd7ed67-4068-492b-bef0-44d0eeb53016.png)

fix #1341