### PR TITLE
page commune en erreur pour les bal sans currentRevision

### DIFF
--- a/components/commune/bal-quality.js
+++ b/components/commune/bal-quality.js
@@ -5,7 +5,7 @@ import Section from '@/components/section'
 import BalAlerts from './bal-alerts'
 
 function BalQuality({currentRevision}) {
-  const harvestErrors = pick(currentRevision.context.extras, 'uniqueErrors', 'nbRowsWithErrors')
+  const harvestErrors = pick(currentRevision?.context.extras, 'uniqueErrors', 'nbRowsWithErrors')
   const errors = harvestErrors.uniqueErrors || []
   const warnings = currentRevision?.validation.warnings ? currentRevision.validation.warnings : []
   const infos = currentRevision?.validation.infos ? currentRevision.validation.infos : []


### PR DESCRIPTION
Certaines page communes sont actuellement inaccessible erreur 500 si elle n'ont pas de currentRevision pour leur bal.
exemple https://adresse.data.gouv.fr/commune/22084
