### PR TITLE
N'affiche les statistiques des communes que lorsqu'elle contiennent des numéros

### DIFF
--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -68,7 +68,7 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
 
   return (
     <Section title='État de la Base Adresse Nationale' background='color' subtitle={subtitle}>
-      <Statistics nbNumeros={nbNumeros} nbNumerosCertifies={nbNumerosCertifies} />
+      {nbNumeros > 0 && <Statistics nbNumeros={nbNumeros} nbNumerosCertifies={nbNumerosCertifies} />}
 
       {typeComposition === 'assemblage' && (
         <Notification type='warning'>

--- a/components/commune/bal-state.js
+++ b/components/commune/bal-state.js
@@ -15,6 +15,7 @@ import ButtonLink from '@/components/button-link'
 import Statistics from './statistics'
 
 function sanitedSources(adressesSources) {
+  console.log('🚀 ~ file: bal-state.js ~ line 18 ~ sanitedSources ~ adressesSources', adressesSources)
   const sources =
     {
       cadastre: 'cadastre',
@@ -48,7 +49,11 @@ function BALState({communeInfos, mairieInfos, revision, typeComposition, hasMigr
   const subtitle = useMemo(() => {
     // Aucune BAL créée
     if (typeComposition === 'assemblage') {
-      return `Les données sont actuellement construites à partir des sources historiques suivantes : ${sanitedSources(adressesSources)}`
+      if (adressesSources.length > 0) {
+        return `Les données sont actuellement construites à partir des sources historiques suivantes : ${sanitedSources(adressesSources)}`
+      }
+
+      return null
     }
 
     // BAL non disponible (en migration)


### PR DESCRIPTION
## Contexte
La section statistiques s'affiche même lorsque que la commune ne dispose d'aucun numéro.
![Capture d’écran 2022-11-17 à 17 11 09](https://user-images.githubusercontent.com/7040549/202498315-47942b87-ffaf-4368-93d9-6c324b5133a4.png)

## Évolution
Cette PR n'affiche les statistiques que si la commune comporte des numéros.
![Capture d’écran 2022-11-17 à 17 23 33](https://user-images.githubusercontent.com/7040549/202501147-8291418a-eda1-4cf6-ac03-5e5ce4f72bcc.png)

