### PR TITLE
Correction de la mise à jour des données de déploiement des BAL

### DIFF
--- a/lib/util/compute.js
+++ b/lib/util/compute.js
@@ -1,6 +1,10 @@
+const got = require('got')
 const {keyBy} = require('lodash')
 
-const {getContourCommune, getCommunesStats} = require('./contours-communes')
+const {getContourCommune} = require('./contours-communes')
+
+const API_DEPOT_URL = process.env.NEXT_PUBLIC_API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr'
 
 function spaceThousands(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
@@ -12,9 +16,10 @@ function getPercentage(value, totalValue) {
   return (roundedPercentage ? String(roundedPercentage).replace('.', ',') : roundedPercentage) || 0
 }
 
-function computeStats() {
-  const {currentRevisions, communesSummary} = getCommunesStats()
+async function computeStats() {
+  const currentRevisions = await got(`${API_DEPOT_URL}/current-revisions`).json()
   const currentRevisionsIndex = keyBy(currentRevisions, 'codeCommune')
+  const communesSummary = await got(`${API_BAN_URL}/api/communes-summary`).json()
   const communesSummaryIndex = keyBy(communesSummary, 'codeCommune')
 
   const otherPublishedCommunes = new Set(

--- a/lib/util/contours-communes.js
+++ b/lib/util/contours-communes.js
@@ -1,11 +1,7 @@
 const got = require('got')
 const {keyBy} = require('lodash')
 
-const API_DEPOT_URL = process.env.NEXT_PUBLIC_API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
-const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr'
-
 let communesIndex
-let communes
 let ready = false
 
 async function getRemoteFeatures(url) {
@@ -13,24 +9,12 @@ async function getRemoteFeatures(url) {
   return response.body.features
 }
 
-async function getRemoteCommunesStats() {
-  const currentRevisions = await got(`${API_DEPOT_URL}/current-revisions`, {responseType: 'json'})
-  const communesSummary = await got(`${API_BAN_URL}/api/communes-summary`, {responseType: 'json'})
-
-  return {
-    currentRevisions: currentRevisions.body,
-    communesSummary: communesSummary.body
-  }
-}
-
 async function prepareContoursCommunes() {
   console.log('Prepare contours communes…')
 
   const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-100m.geojson')
-  const {currentRevisions, communesSummary} = await getRemoteCommunesStats()
 
   communesIndex = keyBy([...communesFeatures], f => f.properties.code)
-  communes = {currentRevisions, communesSummary}
   ready = true
 
   console.log('Dataset ready')
@@ -44,16 +28,7 @@ function getContourCommune(codeCommune) {
   return communesIndex[codeCommune]
 }
 
-function getCommunesStats() {
-  if (!ready) {
-    throw new Error('Dataset not ready')
-  }
-
-  return communes
-}
-
 module.exports = {
   prepareContoursCommunes,
-  getContourCommune,
-  getCommunesStats
+  getContourCommune
 }

--- a/server/deploiement.js
+++ b/server/deploiement.js
@@ -23,7 +23,7 @@ app.route('/couverture-tiles/:z/:x/:y.pbf')
     }
 
     const tileIndex = await useCache('couverture-bal-tiles', 300, async () => {
-      const featureCollection = computeStats()
+      const featureCollection = await computeStats()
       return geojsonVt(featureCollection, {indexMaxZoom: 9})
     })
 

--- a/server/deploiement.js
+++ b/server/deploiement.js
@@ -22,25 +22,29 @@ app.route('/couverture-tiles/:z/:x/:y.pbf')
       return res.status(204).send()
     }
 
-    const tileIndex = await useCache('couverture-bal-tiles', 300, async () => {
-      const featureCollection = await computeStats()
-      return geojsonVt(featureCollection, {indexMaxZoom: 9})
-    })
+    try {
+      const tileIndex = await useCache('couverture-bal-tiles', 300, async () => {
+        const featureCollection = await computeStats()
+        return geojsonVt(featureCollection, {indexMaxZoom: 9})
+      })
 
-    const tile = tileIndex.getTile(z, x, y)
+      const tile = tileIndex.getTile(z, x, y)
 
-    if (!tile) {
-      return res.status(204).send()
+      if (!tile) {
+        return res.status(204).send()
+      }
+
+      const pbf = vtpbf.fromGeojsonVt({communes: tile})
+
+      res.set({
+        'Content-Type': 'application/x-protobuf',
+        'Content-Encoding': 'gzip'
+      })
+
+      res.send(await gzip(Buffer.from(pbf)))
+    } catch (err) {
+      return res.status(404).send({code: 404, message: err})
     }
-
-    const pbf = vtpbf.fromGeojsonVt({communes: tile})
-
-    res.set({
-      'Content-Type': 'application/x-protobuf',
-      'Content-Encoding': 'gzip'
-    })
-
-    res.send(await gzip(Buffer.from(pbf)))
   })
 
 module.exports = app


### PR DESCRIPTION
## Contexte
Une erreur s'est glissée dans la mise à jour des données utilisée pour la carte de l'état du déploiement des BAL. 
Le calcul, prévu pour s'effectuer à chaque fois que le temps de cache était terminé, n'était en réalité pas relancé et seul les données générées au lancement du serveur étaient utilisées.