### PR TITLE
Map :suffixe du numeros manquant pour les multi-positions

### DIFF
--- a/components/maplibre/ban-map/layers.js
+++ b/components/maplibre/ban-map/layers.js
@@ -95,10 +95,22 @@ export const positionsLabelLayer = {
       ]
     },
     'text-field': [
-      'format',
-      ['get', 'numero'],
-      ' - ',
-      ['get', 'type'],
+      'case',
+      ['has', 'suffixe'],
+      [
+        'format',
+        ['get', 'numero'],
+        ' ',
+        ['get', 'suffixe'],
+        ' - ',
+        ['get', 'type'],
+      ],
+      [
+        'format',
+        ['get', 'numero'],
+        ' - ',
+        ['get', 'type'],
+      ]
     ],
     'text-ignore-placement': false,
     'text-variable-anchor': ['bottom'],


### PR DESCRIPTION
## Contexte
l'affichage des multi positions sur la carte ne reprend pas le suffixe de l'adresse.

![image](https://user-images.githubusercontent.com/62593305/205334853-030ed476-d4e2-4ffb-9ac9-641f77619fcb.png)


## Attendu
affichage du numero (dont suffixe) et du type d'entrée
![image](https://user-images.githubusercontent.com/62593305/205335677-a2ba918d-5c2a-4d14-8baa-f69d2dce91a4.png)

#1353










