### PR TITLE
fix respect du hash sur chargement de la carte

### DIFF
--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -82,7 +82,7 @@ function BaseAdresseNationale({address}) {
       ).toArray()
     }
 
-    setBBox(initialHash ? undefined : bbox)
+    setBBox(initialHash ? null : bbox)
   }, [initialHash, address])
 
   return (

--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -82,7 +82,7 @@ function BaseAdresseNationale({address}) {
       ).toArray()
     }
 
-    setBBox(bbox)
+    setBBox(initialHash ? undefined : bbox)
   }, [initialHash, address])
 
   return (


### PR DESCRIPTION
# context
L'accés au [numero via une url sans hash](https://adresse.data.gouv.fr/base-adresse-nationale/60667_0280_00033) est cadré sur

- le displayBBox, qui correspond pour le moment à la position "préférée" (remontée par le geocodage ou autre représentation à 1 position)
- ou si il y a plusieurs positions, sur l'étendu de l'ensemble des points
l'accés au [numero via une url avec hash](https://adresse.data.gouv.fr/base-adresse-nationale/60667_0280_00033#18.61/49.31465/2.7411) est cadré suivant les parametres du hash (zoom , centre ...).

ce comportement n'est pas respecté pour un premier chargement : [cadrage hors des positions](https://adresse.data.gouv.fr/base-adresse-nationale/60667_0280_00033#17.76/49.312178/2.739666 "le cimetière au sud des positions")
![cadrage cimetiere 33 Rue des Moulins Verberie (60667) - Base Adresse Nationale](https://user-images.githubusercontent.com/62593305/211885861-2e43bf70-850c-4038-a394-64de1f8d1ac1.png)
 est redirigé sur l'entrée [la position préférée](https://adresse.data.gouv.fr/base-adresse-nationale/60667_0280_00033#18.61/49.31465/2.7411)_
![cadrage geoloc 33 Rue des Moulins Verberie (60667) - Base Adresse Nationale](https://user-images.githubusercontent.com/62593305/211885913-56b4ca3c-c06c-4765-a730-bcb09194962e.png)

Avec ce correctif
la carte est centrée suivant le hash si il est present  (pas de redirection ou recentrage)

related #1328