### PR TITLE
Acces aux positions d'un numéros

### DIFF
--- a/components/base-adresse-nationale/numero/coordinates-copy.js
+++ b/components/base-adresse-nationale/numero/coordinates-copy.js
@@ -47,7 +47,7 @@ function CoordinatesCopy({coordinates, setCopyError, setIsCopySucceded, setIsCop
         <Button
           type='button'
           size='small'
-          style={{width: '100%'}}
+          style={{width: '100%', padding: '.5em'}}
           onClick={handleClick}
         >
           Copier la position GPS

--- a/components/base-adresse-nationale/positions-types.js
+++ b/components/base-adresse-nationale/positions-types.js
@@ -24,14 +24,15 @@ function PositionsTypes({positions, isMobile, isSafariBrowser, setCopyError, set
       <div>
         {positions.map(p => (
           <div key={uniqueId()} className='array-positions'>
-            <span className='position' style={{backgroundColor: positionsColors[p?.positionType]?.color || '#FF6347'}}>
+            <span className='position' size='small' style={{color: positionsColors[p?.positionType]?.color || '#FF6347'}}>
               {positionsColors[p.positionType]?.name || 'Inconnu'}
             </span>
-              <a href={`#18/${p.position.coordinates[1]}/${p.position.coordinates[0]}`}>
-                <Button size='small' style={{display: 'flex'}} label='Centrer sur la position' >
-                  Centrer sur la carte<TargetLockIcon alt aria-hidden='true' />
-                </Button>
-              </a>
+
+            <a href={`#18/${p.position.coordinates[1]}/${p.position.coordinates[0]}`}>
+              <Button color='secondary' size='small' style={{padding: '.5em'}} label='Centrer sur la position' >
+                Centrer sur la carte<TargetLockIcon style={{verticalAlign: 'middle'}} alt aria-hidden='true' />
+              </Button>
+            </a>
             <CoordinatesCopy
               isMobile={isMobile}
               isSafariBrowser={isSafariBrowser}
@@ -57,17 +58,16 @@ function PositionsTypes({positions, isMobile, isSafariBrowser, setCopyError, set
 
         .position {
           color: #FFF;
-          padding: 3px 10px;
-          margin: auto .5em;
-          border-radius: 4px;
+          padding: 3px;
           font-weight: 600;
           text-align: center;
           flex: 1;
         }
 
         .array-positions {
-          display: ${isMobile ? 'block' : 'flex'};
-          padding: ${isMobile ? '.5em 0' : '.5em'};
+          display: flex;
+          padding: ${isMobile ? '.5em 0.25em' : '.25em'};
+          gap: 0.5ch;
         }
       `}</style>
     </div>

--- a/components/base-adresse-nationale/positions-types.js
+++ b/components/base-adresse-nationale/positions-types.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import {uniqueId} from 'lodash'
 
 import CoordinatesCopy from './numero/coordinates-copy'
+import TargetLockIcon from '@/components/icons/target-lock'
+import Button from '../button'
 
 export const positionsColors = {
   entrée: {name: 'Entrée', color: '#00CED1'},
@@ -25,6 +27,11 @@ function PositionsTypes({positions, isMobile, isSafariBrowser, setCopyError, set
             <span className='position' style={{backgroundColor: positionsColors[p?.positionType]?.color || '#FF6347'}}>
               {positionsColors[p.positionType]?.name || 'Inconnu'}
             </span>
+              <a href={`#18/${p.position.coordinates[1]}/${p.position.coordinates[0]}`}>
+                <Button size='small' style={{display: 'flex'}} label='Centrer sur la position' >
+                  Centrer sur la carte<TargetLockIcon alt aria-hidden='true' />
+                </Button>
+              </a>
             <CoordinatesCopy
               isMobile={isMobile}
               isSafariBrowser={isSafariBrowser}

--- a/components/icons/target-lock.js
+++ b/components/icons/target-lock.js
@@ -1,0 +1,27 @@
+import {forwardRef} from 'react'
+import PropTypes from 'prop-types'
+
+const TargetLockIcon = forwardRef(({color = 'currentColor', size = 24, ...rest}, ref) => {
+  return (
+    <svg
+      ref={ref}
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      viewBox='0 0 24 24'
+      style={{fill: color}}
+      {...rest}
+    >{ /* Source SVG : https://boxicons.com/ */}
+      <circle cx='12' cy='12' r='3' />
+      <path d='M13 4.069V2h-2v2.069A8.008 8.008 0 0 0 4.069 11H2v2h2.069A8.007 8.007 0 0 0 11 19.931V22h2v-2.069A8.007 8.007 0 0 0 19.931 13H22v-2h-2.069A8.008 8.008 0 0 0 13 4.069zM12 18c-3.309 0-6-2.691-6-6s2.691-6 6-6 6 2.691 6 6-2.691 6-6 6z' />
+    </svg>
+  )
+})
+
+TargetLockIcon.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number
+}
+TargetLockIcon.displayName = 'TargetLock'
+
+export default TargetLockIcon

--- a/components/icons/target-lock.js
+++ b/components/icons/target-lock.js
@@ -9,8 +9,8 @@ const TargetLockIcon = forwardRef(({color = 'currentColor', size = 24, ...rest},
       width={size}
       height={size}
       viewBox='0 0 24 24'
-      style={{fill: color}}
       {...rest}
+      style={{fill: color, ...rest.style}}
     >{ /* Source SVG : https://boxicons.com/ */}
       <circle cx='12' cy='12' r='3' />
       <path d='M13 4.069V2h-2v2.069A8.008 8.008 0 0 0 4.069 11H2v2h2.069A8.007 8.007 0 0 0 11 19.931V22h2v-2.069A8.007 8.007 0 0 0 19.931 13H22v-2h-2.069A8.008 8.008 0 0 0 13 4.069zM12 18c-3.309 0-6-2.691-6-6s2.691-6 6-6 6 2.691 6 6-2.691 6-6 6z' />

--- a/components/maplibre/map.js
+++ b/components/maplibre/map.js
@@ -205,6 +205,7 @@ function Map({hasSwitchStyle, bbox, defaultStyle, hasHash, defaultCenter, defaul
           setLayers,
           setInfos,
           setTools,
+          bbox,
           setMarkerCoordinates
         })}
 

--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -71,7 +71,7 @@ function BaseAdresseNationale({address}) {
   useEffect(() => {
     let bbox = address?.displayBBox
 
-    if (!initialHash && address?.positions?.length > 1) {
+    if (address?.positions?.length > 1) {
       const coordinates = address.positions.map(p => {
         return p.position.coordinates
       })


### PR DESCRIPTION
# contexte
Le chargement de la page numero affiche une fiche du numéro indiquant sa ou ses positions et une carte.

Si le numero possède plusieurs positions l'utilisateur peut avoir du mal à les distinguer dans la carte ou les "perdre" si il se déplace sur la carte.

Cette pr vise à donner la posibilité  à l'utilisateur de localiser ces positions.

# changements
- ajout d'un bouton/lien à chaque position qui recentre la carte sur la position
 ( avec modification du style du libellé pour ne pas confondre avec un bouton)
  *Avant*
![image](https://user-images.githubusercontent.com/62593305/212735321-b8fbd537-4cf8-4461-9a88-4509a43b7465.png)
 *Après*
![image](https://user-images.githubusercontent.com/62593305/212734209-b4a00d01-34bd-4f99-9a1a-0e404d9d034f.png)

- modification du comportement du bouton cible dans la carte (recentre sur l'ensemble des positions et pas seulement la position du géocodage) 
![image](https://user-images.githubusercontent.com/62593305/208175532-d4b605c9-b96e-4d99-92c9-7a5a08040487.png)


