### PR TITLE
Implementation docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Environment config
+.env*
+
+# Runtime
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Logs
+logs
+*.log
+npm-debug.log*
+CHANGELOG.md
+
+# Mac
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Build
+.next
+bundle-stats
+available-flags.json
+
+# Cache
+.yarn-cache
+.npm
+.eslintcache
+.changelog
+
+# Node
+node_modules
+
+# Reports
+coverage
+reports
+
+# Git config
+.git
+.github
+.gitignore
+
+#Editor Config
+.editorconfig
+
+#Docker config
+Dockerfile
+docker-compose
+
+#Other
+*.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# using an optimized node image
+FROM node:16.19.0-alpine as BUILD_IMAGE
+
+# optimzing caching for yarn install
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# copying the root folder into the workdir taking into account the .dockerignore file
+COPY . .
+
+# build
+RUN yarn build
+
+FROM node:16.19.0-alpine
+
+RUN npm install pm2 -g
+
+WORKDIR /app
+# copy from build image
+COPY --from=BUILD_IMAGE /app/package.json ./package.json
+COPY --from=BUILD_IMAGE /app/node_modules ./node_modules
+COPY --from=BUILD_IMAGE /app/.next ./.next
+COPY --from=BUILD_IMAGE /app/public ./public
+COPY --from=BUILD_IMAGE /app/server ./server
+COPY --from=BUILD_IMAGE /app/lib/util ./lib/util
+COPY --from=BUILD_IMAGE /app/process.yml ./process.yml
+
+EXPOSE 5100
+
+CMD ["pm2-runtime", "process.yml"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+# using an optimized node image
+FROM node:16.19.0-alpine
+
+# optimzing caching for yarn install
+WORKDIR /app
+COPY package.json yarn.lock .
+RUN yarn install
+
+# copying the root folder into the workdir taking into account the .dockerignore file
+COPY . .
+
+CMD ["sh", "start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  frontend:
+    build: 
+      dockerfile: 'Dockerfile.dev'
+    container_name: frontend
+    volumes:
+    - ./:/app
+    - /app/node_modules
+    - /app/.next
+    ports:
+      - "3000:3000"

--- a/lib/format-numbers.js
+++ b/lib/format-numbers.js
@@ -46,11 +46,11 @@ export function spaceThousands(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
 }
 
-export function numFormater(num) {
+export function numFormater(num, lang = 'fr-FR') {
   if (num.toString().length > 5) {
     const formatedNumber = (Math.round(num / 10000) / 100)
-    return `${new Intl.NumberFormat().format(formatedNumber)} million${formatedNumber > 1.99 ? 's' : ''}`
+    return `${new Intl.NumberFormat(lang).format(formatedNumber)} million${formatedNumber > 1.99 ? 's' : ''}`
   }
 
-  return new Intl.NumberFormat().format(num)
+  return new Intl.NumberFormat(lang).format(num)
 }

--- a/process.yml
+++ b/process.yml
@@ -1,0 +1,7 @@
+apps:
+  - name : 'adresse-website'
+    script : 'server/index.js'
+    instances: '2'
+    env:
+      PORT : 5100
+      NODE_ENV : 'production'

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+yarn build-available-flags
+yarn dev


### PR DESCRIPTION
I. Implémentation déploiement local (dev) du site avec docker et docker-compose 

Pour tester en local, utiliser la commande suivante à la racine du repo : 

`docker-compose up --build -d`

Le service est relancé à chaque modification d'un fichier du repo (même comportement qu'avec la commande 'yarn dev')

II. Début d'implémentation déploiement pour la production 

L'image utilise pm2 et lance 2 instances de node (comme en production actuellement)

Pour tester le build et le run de l'image de production (mais en local), utiliser les commandes suivantes à la racine du repo :

`docker build -t adressedatagouv .`
`docker run -p 5100:5100 --name adressedatagouv adressedatagouv` 

Ce qu'il restera à faire : 
=> Créer un registry pour publier les images
=> Il suffira alors de récupérer l'image sur le server ban-1 et de la run