### PR TITLE
Fix default num formater locale not to depend on runner context

### DIFF
--- a/lib/format-numbers.js
+++ b/lib/format-numbers.js
@@ -46,11 +46,11 @@ export function spaceThousands(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
 }
 
-export function numFormater(num) {
+export function numFormater(num, lang = 'fr-FR') {
   if (num.toString().length > 5) {
     const formatedNumber = (Math.round(num / 10000) / 100)
-    return `${new Intl.NumberFormat().format(formatedNumber)} million${formatedNumber > 1.99 ? 's' : ''}`
+    return `${new Intl.NumberFormat(lang).format(formatedNumber)} million${formatedNumber > 1.99 ? 's' : ''}`
   }
 
-  return new Intl.NumberFormat().format(num)
+  return new Intl.NumberFormat(lang).format(num)
 }


### PR DESCRIPTION
This commit aims to fix the "text content does not match server-rendered HTML" error that appear depending on the running environnement. The error appears when the running context has a locale different from 'fr-FR'. The error appears in a local deployment with docker for example, or in production (do not appear with local 'dev' mode without docker).

<img width="949" alt="216076604-389412eb-7cd4-4d1c-a34c-40c0490a463a" src="https://user-images.githubusercontent.com/52679050/216439415-145ee291-5ba5-427e-bbc6-e0032109592c.png">

<img width="376" alt="216077619-3c81e2e8-7809-427e-a279-15e5d424c700" src="https://user-images.githubusercontent.com/52679050/216439406-67a22ea6-5d3b-494f-bfa9-43ca4e4e548a.png">

