### PR TITLE
Garder les labels de toponyme bien visible sur la carte

### DIFF
--- a/components/maplibre/ban-map/layers.js
+++ b/components/maplibre/ban-map/layers.js
@@ -314,8 +314,7 @@ export const toponymeLayer = {
     'text-size': {
       stops: [
         [0, 3],
-        [10, 15],
-        [17, 8]
+        [10, 15]
       ]
     },
     'text-field': ['get', 'nomVoie'],


### PR DESCRIPTION
# Description
Sur l'explorateur adresse le label des toponymes est trop petit à un au niveau de zoom.  Etant une information que l'on souhaite mettre en valeur, la police doit rester de taille convenable.

# aperçu toponyme zoom niveau 17
## avant
![avant police trop petite](https://user-images.githubusercontent.com/62593305/221227245-f3764a03-d79e-4fb9-aedf-85c949b2c19c.png )

## après
![taille de police conserevé](https://user-images.githubusercontent.com/62593305/221229477-c43d2390-12e8-42a0-bff9-639387360e98.png)
