### PR TITLE
rendu mobile : fix la disposition dans l'explorer

### DIFF
--- a/layouts/base-adresse-nationale.js
+++ b/layouts/base-adresse-nationale.js
@@ -97,7 +97,7 @@ export function Mobile({address, bbox, handleSelect, hash}) {
 
         .mobile-container {
           width: 100%;
-          height: calc(${viewHeight} - ${styleParam.mobile.headerHeight}px - 489px); // Max heigth available - sum of header, searchbar and layout selector heights
+          height: calc(${viewHeight} - ${styleParam.mobile.headerHeight}px - 115px); // Max heigth available - sum of header - (searchbar and layout selector heights)
         }
 
         .show {


### PR DESCRIPTION
# description
Possible coquille sur le calcul rendu de la hauteur de la zone centrale sur "mobile" dans l'explorer.
La zone pourrait etre ramassé ou les boutons (explorer, carte) de sélection en dessous non accessible.

# visualisation
## émulé sous edge
![adresse data gouv fr_(Samsung Galaxy S8+)](https://user-images.githubusercontent.com/62593305/228627459-ab196a3a-64a8-486f-a1e1-8f79f97dfd4b.png)

## attendu
![Capture d’écran 2023-03-29 à 19 56 44](https://user-images.githubusercontent.com/62593305/228628258-8484a90e-9c9a-4054-a565-4846138180bc.png)
