### PR TITLE
Mise à jour des évènements

### DIFF
--- a/events.json
+++ b/events.json
@@ -1555,5 +1555,45 @@
     "instructions": "",
     "startHour": "10:30",
     "endHour": "12:00"
-  }
+  },
+  {
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
+    "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l'adresse, les évolutions de l'éditeur Mes Adresses, l'accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l'accompagnement des communes et de fluidifier les retours utilisateurs",
+    "type": "partenaire",
+    "target": "Communes, EPCI, départements, IDG et entreprises partenaires de la Charte de la Base Adresse Locale ",
+    "date": "2023-05-30",
+    "tags": [
+      "Programme Base Adresse Locale",
+      "Base Adresse Locale",
+      "Base Adresse Nationale",
+      "Gouvernance"
+    ],
+    "isOnlineOnly": true,
+    "address": {},
+    "href": "",
+    "isSubscriptionClosed": false,
+    "instructions": "Inscription automatique après adoption de la charte, contacter adresse@data.gouv.fr",
+    "startHour": "14:00",
+    "endHour": "15:30"
+    },
+    {
+    "title": "Événement Partenaire de la Charte de la Base Adresse Locale",
+    "description": "Chaque mois, les organismes partenaires de la Charte de la Base Adresse Locale sont invités à échanger sur l'adresse, les évolutions de l'éditeur Mes Adresses, l'accompagnement, la formation, les avancées législatives, etc. L'objectif est de faciliter l'accompagnement des communes et de fluidifier les retours utilisateurs.",
+    "type": "partenaire",
+    "target": "Communes, EPCI, départements, IDG et entreprises partenaires de la Charte de la Base Adresse Locale ",
+    "date": "2023-06-20",
+    "tags": [
+      "Programme Base Adresse Locale",
+      "Base Adresse Locale",
+      "Base Adresse Nationale",
+      "Gouvernance"
+    ],
+    "isOnlineOnly": true,
+    "address": {},
+    "href": "",
+    "isSubscriptionClosed": false,
+    "instructions": "Inscription automatique après adoption de la charte, contacter adresse@data.gouv.fr",
+    "startHour": "14:00",
+    "endHour": "15:30"
+    }
 ]


### PR DESCRIPTION
## Contexte
Ajoute des webinaires partenaires de la charte du 30 mai et du 20 juin 2023.

![Capture d’écran 2023-04-06 à 16 16 59](https://user-images.githubusercontent.com/7040549/230405239-92d43c61-59ed-4f99-a8fa-c89391a2c7f7.png)

Fix #1468