### PR TITLE
Modif  lien  uptimerobot

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -90,7 +90,7 @@ function Footer() {
           },
           {
             text: 'Supervision BAN/BAL',
-            linkProps: {href: 'https://status.adresse.data.gouv.fr/', target: '_blank'}
+            linkProps: {href: 'https://stats.uptimerobot.com/jVEyBiY5jg', target: '_blank'}
           },
           {
             text: 'Github',

--- a/pages/api-doc/index.js
+++ b/pages/api-doc/index.js
@@ -36,7 +36,7 @@ function ApiPage() {
     {
       title: 'Supervision BAN/BAL',
       description: 'Consultez la disponiblité des différents systèmes grâce à un outil de monitoring.',
-      href: 'https://status.adresse.data.gouv.fr/',
+      href: 'https://stats.uptimerobot.com/jVEyBiY5jg',
       icon: <Activity alt='' aria-hidden='true' />
     }
   ]


### PR DESCRIPTION
Corrige le lien dans le footer et /api-doc pour uptimerobot qui est passée de la version payante à gratuite.
Fix #1490 