### PR TITLE
Mise à jour de l'URL des contours communes pour 2023

### DIFF
--- a/lib/util/contours-communes.js
+++ b/lib/util/contours-communes.js
@@ -12,7 +12,7 @@ async function getRemoteFeatures(url) {
 async function prepareContoursCommunes() {
   console.log('Prepare contours communes…')
 
-  const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-100m.geojson')
+  const communesFeatures = await getRemoteFeatures('http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2023/geojson/communes-100m.geojson')
 
   communesIndex = keyBy([...communesFeatures], f => f.properties.code)
   ready = true


### PR DESCRIPTION
# Contexte 

- La commune de Terval est tronquée sur la carte de déploiement BAL. C'est parce que c'est une nouvelle commune créée au 1 janvier 2023 et que l'on utilise le millésime 2022 des contours de communes. 
- En mettant à jour, l'URL ça résout le problème pour Terval mais y'avait-il une raison pour laquelle nous voulions garder les contours communes 2022?