### PR TITLE
Améliorer la distinction entre les sources (couleurs) d'adresse sur l'explorateur

### DIFF
--- a/components/maplibre/ban-map/layers.js
+++ b/components/maplibre/ban-map/layers.js
@@ -5,7 +5,6 @@ export const sources = {
   bal: {name: 'Base Adresse Locale', color: '#009E73'},
   cadastre: {name: 'Cadastre', color: '#56B4E9'},
   ftth: {name: 'Opérateur THD', color: '#E69F00'},
-  'insee-ril': {name: 'INSEE', color: '#a6611a'},
   'ign-api-gestion-ign': {name: 'IGN', color: '#0072B2'},
   'ign-api-gestion-laposte': {name: 'La Poste', color: '#F0E442'},
   'ign-api-gestion-sdis': {name: 'SDIS (Pompiers)', color: '#D55E00'},

--- a/components/maplibre/ban-map/layers.js
+++ b/components/maplibre/ban-map/layers.js
@@ -2,14 +2,14 @@ import theme from '@/styles/theme'
 import {positionsColors} from '@/components/base-adresse-nationale/positions-types'
 
 export const sources = {
-  bal: {name: 'Base Adresse Locale', color: '#4dac26'},
-  cadastre: {name: 'Cadastre', color: '#2c7bb6'},
-  ftth: {name: 'Opérateur THD', color: '#118571'},
+  bal: {name: 'Base Adresse Locale', color: '#009E73'},
+  cadastre: {name: 'Cadastre', color: '#56B4E9'},
+  ftth: {name: 'Opérateur THD', color: '#E69F00'},
   'insee-ril': {name: 'INSEE', color: '#a6611a'},
-  'ign-api-gestion-ign': {name: 'IGN', color: '#455d7a'},
-  'ign-api-gestion-laposte': {name: 'La Poste', color: '#fecd51'},
-  'ign-api-gestion-sdis': {name: 'SDIS (Pompiers)', color: '#d7191c'},
-  'ign-api-gestion-municipal_administration': {name: 'Guichet Adresse', color: '#7b3294'}
+  'ign-api-gestion-ign': {name: 'IGN', color: '#0072B2'},
+  'ign-api-gestion-laposte': {name: 'La Poste', color: '#F0E442'},
+  'ign-api-gestion-sdis': {name: 'SDIS (Pompiers)', color: '#D55E00'},
+  'ign-api-gestion-municipal_administration': {name: 'Guichet Adresse', color: '#CC79A7'}
 }
 
 export const defaultLayerPaint = [


### PR DESCRIPTION
# Constat
Certaines couleurs sembles trop proches ou pas assez contrastées et mènent parfois à confusion.

Palette actuelle
![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/62593305/44a55c72-1dce-4517-b1ed-69c5b801b217)
https://davidmathlogic.com/colorblind/#%234dac26-%232c7bb6-%23118571-%23a6611a-%23455d7a-%23fecd51-%23d7191c-%237b3294

# Proposition
Changement de la palette de couleurs des sources d'adresse sur l'explorateur : 
[x] Utilisation de la palette Wong afin d'avoir des couleurs distinctes et plus adaptées aux daltoniens et à nos fonds carto.
![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/62593305/07a2c05c-774b-405c-92d4-d59d0cacdb78)

https://davidmathlogic.com/colorblind/#%23000000-%23E69F00-%2356B4E9-%23009E73-%23F0E442-%230072B2-%23D55E00-%23CC79A7

[x] suppression de l'insee de la légende, cette donnée n'est plus remonté.

#1415 