### PR TITLE
carte explorer distinguer les multipositions des autres points adresses

### DIFF
--- a/components/maplibre/ban-map/layers.js
+++ b/components/maplibre/ban-map/layers.js
@@ -56,23 +56,15 @@ export const positionsCircleLayer = {
   source: 'positions',
   type: 'circle',
   paint: {
-    'circle-color': ['match', ['get', 'type'], ...colors, '#000'],
+    'circle-color': 'transparent',
     'circle-stroke-color': [
-      'case',
-      ['boolean', ['feature-state', 'hover'], false],
-      theme.primary,
-      '#fff'
+      'match', ['get', 'type'], ...colors, '#000'
     ],
-    'circle-stroke-width': [
-      'case',
-      ['boolean', ['feature-state', 'hover'], false],
-      3,
-      1
-    ],
+    'circle-stroke-width': 3,
     'circle-radius': {
       stops: [
         [12, 0.8],
-        [17, 6]
+        [17, 5]
       ]
     }
   }


### PR DESCRIPTION
Les positions multiples sont affichées par un disque de couleur et ont en libellé leur numeros + suffix  + position. 
- Le libellé peut être absent suivant la densité d'écriture qui se trouve autour.
- point d'adresse peuvent être coloré soit par source d'adresse (8 couleurs ) et les multipostions par type de position ( 9 différentes). Une représentation par couleur unique donne une palette de couleur trop importante pour les distingué.

Il est proposé de changé le rendu des pastille multipostions par un cercle.

[exemple 725bis, le point rouge est un batiment pas une adresse non certifiée ](https://adresse.data.gouv.fr/base-adresse-nationale/39169_0002_00725_bis#19/46.6557679/5.5392287/0/15)

![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/62593305/3b64c837-9c85-493e-bb07-343b519ac971)

![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/62593305/8ab9892c-8469-4db1-81c0-97ee36f8c4ad)
