### PR TITLE
plus de clef rivoli dans topo

### DIFF
--- a/components/fantoir/voie-information.js
+++ b/components/fantoir/voie-information.js
@@ -29,7 +29,6 @@ function VoieInformation({voie}) {
       {isOpen && (
         <div className='voie-tags'>
           <div>Code Rivoli : <span>{voie.codeRivoli}</span></div>
-          <div>Clé Rivoli : <span>{voie.cleRivoli}</span></div>
           <div>Date d’ajout : <span>{voie.dateAjout}</span></div>
           {voie.natureVoie && (
             <div>Nature de la voie : <span>{voie.natureVoie}</span></div>


### PR DESCRIPTION
Avec le changement de format du fichier fantoir -> Topo l'information clef rivoli disparait.
On ne doit plus l'afficher dans l'explorateur.
Voici le résultat : 
![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7045982/9801c24c-9fd6-4fbb-8615-06aa0f791f35)

fix #1569 