### PR TITLE
Ajout adresse lab

### DIFF
--- a/events.json
+++ b/events.json
@@ -2004,5 +2004,25 @@
     "instructions": "",
     "startHour": "14:00",
     "endHour": "15:30"
+  },
+  {
+    "title": "Adresse_Lab #6",
+    "subtitle": "Point d'échange trimestriel T3 2023",
+    "description": "Point d'étape trimestre 3 : actualités et chantiers en cours",
+    "type": "adresselab",
+    "target": "utilisateurs de la donnée adresse",
+    "date": "2023-09-26",
+    "tags": [
+      "Technique",
+      "Base Adresse Nationale",
+      "Utilisateurs"
+    ],
+    "isOnlineOnly": true,
+    "address": {},
+    "href": "https://webinaire.numerique.gouv.fr//meeting/signin/5699/creator/3324/hash/61fcf6f21947874ba68b105a3433cdd55e43ffb9",
+    "isSubscriptionClosed": false,
+    "instructions": "",
+    "startHour": "15:00",
+    "endHour": "16:30"
   }
 ]

--- a/events.json
+++ b/events.json
@@ -2006,7 +2006,7 @@
     "endHour": "15:30"
   },
   {
-    "title": "Adresse_Lab #6",
+    "title": "Adresse_Lab #7",
     "subtitle": "Point d'échange trimestriel T3 2023",
     "description": "Point d'étape trimestre 3 : actualités et chantiers en cours",
     "type": "adresselab",


### PR DESCRIPTION
Ajout de l'adresse lab du 26 Septembre 2023, il n'est pas prévu de mettre un bouton "rejoindre" dans lévènement"
![Capture d’écran du 2023-07-19 13-00-42](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/51943abe-8eef-4b19-9390-eb1e1d4b25aa)


![Capture d’écran du 2023-07-19 13-01-09](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/6059f00b-7de0-44e3-8ca0-0278ca7250e1)
