### PR TITLE
suppression telechargement données ign

### DIFF
--- a/pages/donnees-nationales/index.js
+++ b/pages/donnees-nationales/index.js
@@ -105,13 +105,6 @@ function DonneesNationales() {
 
       <Section title='Autres fichiers nationaux' background='grey'>
         <div className='card-container'>
-          <Card
-            title='Export de l’API de gestion IGN'
-            action='Télécharger les exports'
-            link='https://adresse.data.gouv.fr/data/ban/export-api-gestion/latest/'
-          >
-            Ce fichier contient toutes les données que l’IGN exporte chaque semaine de son API de gestion d’adresses.
-          </Card>
 
           <Card
             title='Adresses extraites du cadastre'


### PR DESCRIPTION
Suppression du téléchargement des anciennes bases de données IGN sur la page d'accès aux données (https://adresse.data.gouv.fr/donnees-nationales) 
Résultat de la modification
![Capture d’écran du 2023-08-30 10-31-35](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/2b5b89b8-364c-47d2-b5cf-cdf78c148e00)
Fix #1546 