### PR TITLE
 ajout lien onglet utilisateurs

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -120,6 +120,12 @@ const navigationLinks = [
         },
         text: 'État du déploiement des Bases Adresses Locales',
       },
+      {
+        linkProps: {
+          href: '/contribuer#osmose',
+        },
+        text: 'Rejoignez le collectif des usagers',
+      },
     ]
   },
 ]

--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -39,8 +39,7 @@ function Contribuer() {
         </SectionText>
         <SearchCommuneContact />
       </Section>
-      
-      <a id="osmose"></a>
+      <a id='osmose' />
       <Section title='En tant qu’utilisateur des données' id='utilisateur'>
         <div style={{textAlign: 'center'}}>
           <p style={{margin: '3em 0'}}>Rejoignez notre collectif des usagers de la BAN. Demandez par mail à rejoindre le MTECT-collectif-des-utilisateurs-de-la-ban en envoyant une demande sur adresse@data.gouv.fr</p>

--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -39,7 +39,8 @@ function Contribuer() {
         </SectionText>
         <SearchCommuneContact />
       </Section>
-
+      
+      <a id="osmose"></a>
       <Section title='En tant qu’utilisateur des données' id='utilisateur'>
         <div style={{textAlign: 'center'}}>
           <p style={{margin: '3em 0'}}>Rejoignez notre collectif des usagers de la BAN. Demandez par mail à rejoindre le MTECT-collectif-des-utilisateurs-de-la-ban en envoyant une demande sur adresse@data.gouv.fr</p>


### PR DESCRIPTION
Ajout du lien "Rejoignez le collectif des usagers" dans l'onglet utilisateurs
Le lien pointe vers /contribuer#osmose qui renvoie directement sur la bonne rubrique de la page contribuer
![Capture d’écran du 2023-08-30 14-13-21](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/f0ed57bd-675f-41ad-8483-a3c5407995a8)

Fix #1561 