### PR TITLE
Refacto deployement bal

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_ADRESSE_URL=http://localhost:3000
-NEXT_PUBLIC_API_GEO_URL=https://geo.api.gouv.fr
+NEXT_PUBLIC_API_GEO_URL=https://geo.api.gouv.fr/2022
 NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
 NEXT_PUBLIC_API_ADRESSE=https://api-adresse.data.gouv.fr
 NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=https://etablissements-publics.api.gouv.fr/v3
@@ -16,3 +16,5 @@ NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED=
 GHOST_KEY=
 NEXT_PUBLIC_CRISP_WEBSITE_ID=
 NEXT_PUBLIC_BAL_ADMIN_API_URL=https://bal-admin.adresse.data.gouv.fr/api
+NEXT_PUBLIC_BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
+NEXT_PUBLIC_MES_ADRESSES=https://mes-adresses.data.gouv.fr

--- a/components/bases-locales/deploiement-bal/bal-card.js
+++ b/components/bases-locales/deploiement-bal/bal-card.js
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types'
+import ButtonLink from '@/components/button-link'
+import {sanitizedDate} from '@/lib/date'
+import StatusBadge from '@/components/bases-locales/deploiement-bal/status-badge'
+
+const MES_ADRESSE_URL = process.env.NEXT_PUBLIC_MES_ADRESSES || 'https://mes-adresses.data.gouv.fr'
+
+function BaseLocaleCard({bal}) {
+  const balUrl = MES_ADRESSE_URL + '/bal/' + bal._id
+
+  return (
+    <div>
+      <div className='card'>
+        <div className='card-header'>
+          <div className='card-header-title'>
+            <h4>{bal.commune} {bal.nom}</h4>
+            <p><i>Modifié le {sanitizedDate(bal._updated)}</i></p>
+          </div>
+          <StatusBadge status={bal.status} sync={bal.sync} />
+        </div>
+        <div className='card-body'>
+          <ButtonLink href={balUrl} style={{width: '100%'}} target='_blank'>Consulter</ButtonLink>
+        </div>
+      </div>
+      <style jsx>{`
+          .card {
+            box-shadow: 0 0 1px rgba(67, 90, 111, 0.3), 0 5px 8px -4px rgba(67, 90, 111, 0.47);
+            border: 1px solid #E6E8F0;
+            border-radius: 5px;
+            margin-bottom: 12px;
+            padding: 8px;
+          }
+          .card-header {
+            justify-content: space-between;
+            display: flex;
+            margin-bottom: 12px;
+          }
+          .card-header-title h4 {
+            margin: 0;
+            font-size: 16px;
+          }
+          .card-header-title p {
+            margin: 0;
+            text-align: left;
+            font-size: 12px;
+          }
+      `}</style>
+    </div>
+  )
+}
+
+BaseLocaleCard.propTypes = {
+  bal: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired,
+    commune: PropTypes.string.isRequired,
+    _updated: PropTypes.string,
+    status: PropTypes.oneOf([
+      'replaced',
+      'published',
+      'ready-to-publish',
+      'draft',
+    ]).isRequired,
+    sync: PropTypes.shape({
+      isPaused: PropTypes.bool.isRequired,
+      status: PropTypes.oneOf([
+        'synced',
+        'outdated',
+        'conflict'
+      ]),
+    })
+  }),
+}
+
+export default BaseLocaleCard

--- a/components/bases-locales/deploiement-bal/commune-bal-list.js
+++ b/components/bases-locales/deploiement-bal/commune-bal-list.js
@@ -1,0 +1,71 @@
+import PropTypes from 'prop-types'
+import {keyBy} from 'lodash'
+import communes from '@etalab/decoupage-administratif/data/communes.json'
+import styled from 'styled-components'
+import {Accordion} from '@codegouvfr/react-dsfr/Accordion'
+
+import BaseLocaleCard from '@/components/bases-locales/deploiement-bal/bal-card'
+
+const communesIndex = keyBy(communes, 'code')
+
+const findCommuneName = codeCommune => {
+  return communesIndex[codeCommune]?.nom || ''
+}
+
+const StyledAccordion = styled(Accordion)`
+  .fr-accordion__btn {
+    font-size: 16px;
+    font-weight: bold;
+  }
+  .fr-accordion__btn:hover {
+    background: none !important;
+  }
+  .fr-collapse--expanded {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .accordion {
+    padding: 10px;
+  }
+`
+
+function CommuneBALList({codeCommune, balsCommune}) {
+  const nomCommune = findCommuneName(codeCommune)
+  const title = `${codeCommune} ${nomCommune} - ${balsCommune.length > 0 ? balsCommune.length + ' BAL(s)' : 'Aucune BAL'} `
+
+  return (
+    <div>
+      {balsCommune.length > 0 ? (
+        <StyledAccordion label={title} className='accordion'>
+          {balsCommune.map(bal => (
+            <BaseLocaleCard key={bal._id} bal={bal} />
+          ))}
+        </StyledAccordion>
+      ) : (
+        <section className='section-no-bal'>
+          <p>{title}</p>
+        </section>
+      )}
+      <style jsx>{`
+          .section-no-bal {
+            margin-bottom: -1px;
+          }
+          .section-no-bal p {
+            font-size: 16px;
+            line-height: 3em;
+            margin: 0;
+            text-align: left;
+            padding-left: 16px;
+            border-bottom: 1px solid #ddd;
+          }
+          `}</style>
+    </div>
+  )
+}
+
+CommuneBALList.propTypes = {
+  codeCommune: PropTypes.string.isRequired,
+  balsCommune: PropTypes.array.isRequired
+}
+
+export default CommuneBALList

--- a/components/bases-locales/deploiement-bal/panel-bal.js
+++ b/components/bases-locales/deploiement-bal/panel-bal.js
@@ -1,0 +1,89 @@
+import PropTypes from 'prop-types'
+import {groupBy} from 'lodash'
+import {Doughnut} from 'react-chartjs-2'
+import {Chart as ChartJS, ArcElement, Tooltip, Legend} from 'chart.js'
+
+import CommuneBALList from './commune-bal-list'
+
+ChartJS.register(ArcElement, Tooltip, Legend)
+
+const options = {
+  height: 50,
+  width: 50,
+  responsive: true,
+  plugins: {
+    legend: {
+      display: true,
+    },
+    tooltip: {
+      enabled: true
+    }
+  }
+}
+
+function PanelBal({filteredCodesCommmune, bals}) {
+  const balsByCommune = groupBy(bals, 'commune')
+
+  const data = {
+    labels: [
+      'Publiée',
+      'Prête à être publiée',
+      'Brouillon'
+    ],
+    datasets: [{
+      data: [
+        bals?.filter(bal => bal.status === 'published')?.length,
+        bals?.filter(bal => bal.status === 'ready-to-publish')?.length,
+        bals?.filter(bal => bal.status === 'draft')?.length
+      ],
+      backgroundColor: [
+        '#228833',
+        '#AA3377',
+        '#EE6677'
+      ],
+      hoverOffset: 4
+    }]
+  }
+
+  return (
+    <div>
+      <br />
+      {filteredCodesCommmune.length > 0 ? (
+        <div>
+          <h3>Statut des BAL(s)</h3>
+          <div className='donut'>
+            <Doughnut data={data} options={options} />
+          </div>
+          <br />
+          <h3>Liste des Communes</h3>
+
+          {filteredCodesCommmune.map(codeCommune => {
+            const balsCommune = balsByCommune[codeCommune] || []
+            return <CommuneBALList key={codeCommune} codeCommune={codeCommune} balsCommune={balsCommune} />
+          })}
+
+        </div>
+      ) : (
+        <p>Aucun Département ou EPCI sélectionné</p>
+      )}
+      <style jsx>{`
+        h3 {
+          text-align: left;
+        }
+        .donut {
+          border: 1px solid lightgrey;
+          padding: 1em;
+          border-radius: 5px;
+          max-width: 300px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+PanelBal.propTypes = {
+  filteredCodesCommmune: PropTypes.array.isRequired,
+  bals: PropTypes.array.isRequired
+}
+
+export default PanelBal

--- a/components/bases-locales/deploiement-bal/panel-source.js
+++ b/components/bases-locales/deploiement-bal/panel-source.js
@@ -1,0 +1,82 @@
+import PropTypes from 'prop-types'
+import {numFormater} from '@/lib/format-numbers'
+import DoughnutCounter from '@/components/doughnut-counter'
+
+const options = {
+  height: 200,
+  width: 200,
+  responsive: true,
+  plugins: {
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      enabled: false
+    }
+  }
+}
+
+function PanelSource({stats, formatedStats}) {
+  const {
+    dataPopulationCouverte,
+    communesCouvertesPercent,
+    dataCommunesCouvertes,
+    adressesGereesBALPercent,
+    dataAdressesGereesBAL,
+    adressesCertifieesPercent,
+    dataAdressesCertifiees,
+    total
+  } = formatedStats
+
+  return (
+    <div>
+      <div className='stats'>
+        {!Number.isNaN(adressesGereesBALPercent) && <DoughnutCounter
+          title='Adresses issues des BAL'
+          valueUp={numFormater(stats.bal.nbAdresses)}
+          valueDown={`${adressesGereesBALPercent}% des ${numFormater(stats.ban.nbAdresses)} d’adresses présentes dans la BAN`}
+          data={dataAdressesGereesBAL}
+          options={options}
+        />}
+        <DoughnutCounter
+          title='Communes couvertes'
+          valueUp={numFormater(stats.bal.nbCommunesCouvertes)}
+          valueDown={`${communesCouvertesPercent}% des ${numFormater(total.nbCommunes)} communes`}
+          data={dataCommunesCouvertes}
+          options={options}
+        />
+        <DoughnutCounter
+          title='Population couverte'
+          valueUp={numFormater(stats.bal.populationCouverte)}
+          valueDown={`${Math.round((stats.bal.populationCouverte * 100) / total.population)}% des ${numFormater(total.population)} d’habitants`}
+          data={dataPopulationCouverte}
+          options={options}
+        />
+        {!Number.isNaN(adressesGereesBALPercent) && <DoughnutCounter
+          title='Adresses certifiées'
+          valueUp={numFormater(stats.bal.nbAdressesCertifiees)}
+          valueDown={`${adressesCertifieesPercent}% des ${numFormater(stats.ban.nbAdresses)} d’adresses présentes dans la BAN`}
+          data={dataAdressesCertifiees}
+          options={options}
+        />}
+      </div>
+
+      <style jsx>{`
+        .stats {
+          height: fit-content;
+          display: grid;
+          grid-template-columns: repeat( auto-fit, minmax(250px, 1fr) );
+          gap: 1em;
+          margin-top: 1em;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+PanelSource.propTypes = {
+  stats: PropTypes.object.isRequired,
+  formatedStats: PropTypes.object.isRequired,
+}
+
+export default PanelSource

--- a/components/bases-locales/deploiement-bal/status-badge.js
+++ b/components/bases-locales/deploiement-bal/status-badge.js
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types'
+import {Badge} from '@codegouvfr/react-dsfr/Badge'
+
+const STATUSES = {
+  conflict: {
+    label: 'Conflit',
+    intent: 'error',
+  },
+  paused: {
+    label: 'Suspendue',
+    intent: 'warning',
+  },
+  outdated: {
+    label: 'Mise à jour programmée',
+    intent: 'new',
+  },
+  synced: {
+    label: 'À jour',
+    intent: 'success',
+  },
+  'ready-to-publish': {
+    content: 'Cette Base Adresse Locale est désormais prête à être publiée',
+    label: 'Prête à être publiée',
+    intent: 'info',
+  },
+  draft: {
+    label: 'Brouillon',
+    intent: undefined,
+  },
+  demo: {
+    label: 'Démonstration',
+    intent: undefined,
+  }
+}
+
+function computeStatus(balStatus, sync) {
+  if (balStatus === 'replaced' || sync?.status === 'conflict') {
+    return STATUSES.conflict
+  }
+
+  if (sync?.isPaused) {
+    return STATUSES.paused
+  }
+
+  if (balStatus === 'published') {
+    return STATUSES[sync.status]
+  }
+
+  return STATUSES[balStatus]
+}
+
+function StatusBadge({status, sync}) {
+  const balStatus = computeStatus(status, sync)
+  return (
+    <Badge noIcon severity={balStatus.intent}>{balStatus.label}</Badge>
+  )
+}
+
+StatusBadge.defaultProps = {
+  sync: undefined,
+}
+
+StatusBadge.propTypes = {
+  status: PropTypes.oneOf([
+    'replaced',
+    'published',
+    'ready-to-publish',
+    'draft',
+    'demo',
+  ]).isRequired,
+  sync: PropTypes.shape({
+    isPaused: PropTypes.bool.isRequired,
+    status: PropTypes.oneOf([
+      'synced',
+      'outdated',
+      'conflict'
+    ]),
+  })
+}
+
+export default StatusBadge

--- a/components/doughnut-counter.js
+++ b/components/doughnut-counter.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import {Doughnut} from 'react-chartjs-2'
-import {Chart as ChartJS, ArcElement} from 'chart.js'
+import {Chart as ChartJS, ArcElement, Tooltip, Legend} from 'chart.js'
 
-ChartJS.register(ArcElement)
+ChartJS.register(ArcElement, Tooltip, Legend)
 
 function DoughnutCounter({title, valueUp, valueDown, data, options}) {
   return (

--- a/components/maplibre/map-legends.js
+++ b/components/maplibre/map-legends.js
@@ -13,8 +13,7 @@ function MapLegends({title, legend, hasBorderRadius}) {
       <style jsx>{`
         .legend-title {
           font-weight: bold;
-          width: 80%;
-          margin-bottom: 0.5em;
+          text-align: left;
         }
 
         .legend-container {

--- a/lib/mes-adresse-api.js
+++ b/lib/mes-adresse-api.js
@@ -1,0 +1,36 @@
+import HttpError from './http-error'
+
+const API_MES_ADRESSES_URL = process.env.NEXT_PUBLIC_BAL_API_URL || 'https://api-bal.adresse.data.gouv.fr/v1'
+
+async function _fetch(url, method, body) {
+  const options = {
+    method,
+    mode: 'cors'
+  }
+
+  if (method === 'POST') {
+    options.headers = {'Content-Type': 'application/json'}
+    if (body) {
+      options.body = JSON.stringify(body)
+    }
+  }
+
+  const response = await fetch(API_MES_ADRESSES_URL + url, options)
+  const contentType = response.headers.get('content-type')
+
+  if (!response.ok) {
+    throw new HttpError(response)
+  }
+
+  if (contentType && contentType.includes('application/json')) {
+    return response.json()
+  }
+
+  throw new Error('Une erreur est survenue')
+}
+
+export async function getBals(fields, codesCommunes) {
+  const query = fields.map(field => `fields=${field}`)
+  return _fetch('/stats/bals?' + query.join('&'), 'POST', codesCommunes)
+}
+

--- a/lib/util/compute.js
+++ b/lib/util/compute.js
@@ -1,10 +1,11 @@
 const got = require('got')
-const {keyBy} = require('lodash')
+const {keyBy, groupBy} = require('lodash')
 
 const {getContourCommune} = require('./contours-communes')
 
 const API_DEPOT_URL = process.env.NEXT_PUBLIC_API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
 const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr'
+const API_BAL_URL = process.env.NEXT_PUBLIC_BAL_API_URL || 'https://api-bal.adresse.data.gouv.fr/v1'
 
 function spaceThousands(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
@@ -18,25 +19,66 @@ function getPercentage(value, totalValue) {
 
 async function fetchStatsData() {
   const currentRevisions = await got(`${API_DEPOT_URL}/current-revisions`).json()
-  const currentRevisionsIndex = keyBy(currentRevisions, 'codeCommune')
   const communesSummary = await got(`${API_BAN_URL}/api/communes-summary`).json()
-  const communesSummaryIndex = keyBy(communesSummary, 'codeCommune')
+  const bals = await got.post(`${API_BAL_URL}/stats/bals?fields=_id&fields=commune&fields=status`).json()
 
-  return {
-    currentRevisions,
-    currentRevisionsIndex,
-    communesSummary,
-    communesSummaryIndex
-  }
+  return {currentRevisions, communesSummary, bals}
 }
 
-function computeStats(statsData, codesCommune) {
-  const {
-    currentRevisions,
-    currentRevisionsIndex,
-    communesSummary,
-    communesSummaryIndex
-  } = statsData
+function computeStatusBals(bals = []) {
+  if (bals.map(b => b.status).includes('published')) {
+    return 'published'
+  }
+
+  if (bals.map(b => b.status).includes('ready-to-publish')) {
+    return 'ready-to-publish'
+  }
+
+  if (bals.map(b => b.status).includes('replaced')) {
+    return 'replaced'
+  }
+
+  if (bals.map(b => b.status).includes('draft')) {
+    return 'draft'
+  }
+
+  return 'unknown'
+}
+
+function createFeature(codeCommune, currentRevisionsIndex, communesSummaryIndex, communesBalsIndex) {
+  const revisions = currentRevisionsIndex[codeCommune]
+  const summary = communesSummaryIndex[codeCommune]
+  const contourCommune = getContourCommune(codeCommune)
+  const {nom, code} = contourCommune.properties
+  const nbNumeros = spaceThousands(summary.nbNumeros)
+  const certificationPercentage = getPercentage(summary.nbNumerosCertifies, summary.nbNumeros)
+  const hasBAL = summary.typeComposition === 'bal'
+  const statusBals = computeStatusBals(communesBalsIndex[codeCommune])
+
+  const feature = {
+    type: 'Feature',
+    properties: {
+      nom,
+      code,
+      nbNumeros,
+      hasBAL,
+      certificationPercentage,
+      ...((hasBAL && revisions) ? {
+        idClient: revisions.client.id || '',
+        nomClient: revisions.client.nom || '',
+      } : {}),
+      statusBals,
+    },
+    geometry: contourCommune.geometry
+  }
+
+  return feature
+}
+
+function computeStats({currentRevisions, communesSummary, bals}, codesCommune) {
+  const currentRevisionsIndex = keyBy(currentRevisions, 'codeCommune')
+  const communesSummaryIndex = keyBy(communesSummary, 'codeCommune')
+  const communesBalsIndex = groupBy(bals, 'commune')
 
   const communes = codesCommune?.length > 0 ? new Set(codesCommune) : new Set([...currentRevisions.map(c => c.codeCommune), ...communesSummary.map(c => c.codeCommune)])
 
@@ -44,32 +86,7 @@ function computeStats(statsData, codesCommune) {
     type: 'FeatureCollection',
     features: [...communes]
       .filter(codeCommune => communesSummaryIndex[codeCommune] && getContourCommune(codeCommune))
-      .map(codeCommune => {
-        const revisions = currentRevisionsIndex[codeCommune]
-        const summary = communesSummaryIndex[codeCommune]
-        const contourCommune = getContourCommune(codeCommune)
-        const {nom, code} = contourCommune.properties
-        const nbNumeros = spaceThousands(summary.nbNumeros)
-        const certificationPercentage = getPercentage(summary.nbNumerosCertifies, summary.nbNumeros)
-        const hasBAL = summary.typeComposition === 'bal'
-
-        return {
-          type: 'Feature',
-          properties: {
-            nom,
-            code,
-            nbNumeros,
-            hasBAL,
-            certificationPercentage,
-            ...(hasBAL ? {
-              idClient: revisions ? revisions.client.id : 'moissonneur-bal',
-              nomClient: revisions ? revisions.client.nom : 'Moissonneur BAL'
-            } : {})
-
-          },
-          geometry: contourCommune.geometry
-        }
-      })
+      .map(codeCommune => createFeature(codeCommune, currentRevisionsIndex, communesSummaryIndex, communesBalsIndex))
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ban-team/shared-data": "^1.2.0",
     "@ban-team/validateur-bal": "^2.16.0",
     "@codegouvfr/react-dsfr": "^0.41.0",
+    "@etalab/decoupage-administratif": "^3.0.0",
     "@react-pdf/renderer": "^3.1.9",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -11,51 +11,28 @@ import departementCenterMap from '@/data/geo/departement-center.json'
 
 import {_fetch, getStats} from '@/lib/api-ban'
 import {getDepartements, getEpcis} from '@/lib/api-geo'
-import {numFormater} from '@/lib/format-numbers'
+import {getBals} from '@/lib/mes-adresse-api'
 
 import {useStatsDeploiement} from '@/hooks/stats-deploiement'
 
 import MapLibre from '@/components/maplibre'
-import DoughnutCounter from '@/components/doughnut-counter'
-import BalCoverMap from '@/components/bases-locales/bal-cover-map'
+import BalCoverMap from '@/components/bases-locales/deploiement-bal/bal-cover-map'
+import PanelSource from '@/components/bases-locales/deploiement-bal/panel-source'
+import PanelBal from '@/components/bases-locales/deploiement-bal/panel-bal'
 import SearchInput from '@/components/search-input'
 import SearchSelected from '@/components/search-input/search-selected'
 import StatsSearchItem from '@/components/search-input/stats-search-item'
 
 const ADRESSE_URL = process.env.NEXT_PUBLIC_ADRESSE_URL || 'http://localhost:3000'
 
-const options = {
-  height: 200,
-  width: 200,
-  responsive: true,
-  plugins: {
-    legend: {
-      display: false,
-    },
-    tooltip: {
-      enabled: false
-    }
-  }
-}
-
 const mapToSearchResult = (values, type) => values.map(({code, nom, centre, contour}) => ({value: code, type, nom, center: centre, contour}))
-
 function EtatDeploiement({initialStats, departements}) {
   const [input, setInput] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [results, setResults] = useState([])
   const {stats, formatedStats, filter, setFilter, filteredCodesCommmune, geometry} = useStatsDeploiement({initialStats})
-
-  const {
-    dataPopulationCouverte,
-    communesCouvertesPercent,
-    dataCommunesCouvertes,
-    adressesGereesBALPercent,
-    dataAdressesGereesBAL,
-    adressesCertifieesPercent,
-    dataAdressesCertifiees,
-    total
-  } = formatedStats
+  const [bals, setBals] = useState([])
+  const [selectedPanel, setSelectedPanel] = useState('source')
 
   const handleSearch = useCallback(debounce(async input => {
     setIsLoading(true)
@@ -78,7 +55,17 @@ function EtatDeploiement({initialStats, departements}) {
     setInput('')
   }
 
-  const handleSelect = item => {
+  useEffect(() => {
+    async function getBalsFiltered() {
+      const fields = ['_id', 'commune', 'status', 'nom', '_updated', 'sync']
+      const balsFiltered = await getBals(fields, filteredCodesCommmune)
+      setBals(balsFiltered)
+    }
+
+    getBalsFiltered()
+  }, [filteredCodesCommmune])
+
+  const handleSelect = async item => {
     setFilter(item)
     setInput(item.nom)
   }
@@ -144,36 +131,11 @@ function EtatDeploiement({initialStats, departements}) {
               wrapperStyle={{position: 'relative'}}
               renderItem={StatsSearchItem}
             />
-            <div className='stats'>
-              {!Number.isNaN(adressesGereesBALPercent) && <DoughnutCounter
-                title='Adresses issues des BAL'
-                valueUp={numFormater(stats.bal.nbAdresses)}
-                valueDown={`${adressesGereesBALPercent}% des ${numFormater(stats.ban.nbAdresses)} d’adresses présentes dans la BAN`}
-                data={dataAdressesGereesBAL}
-                options={options}
-              />}
-              <DoughnutCounter
-                title='Communes couvertes'
-                valueUp={numFormater(stats.bal.nbCommunesCouvertes)}
-                valueDown={`${communesCouvertesPercent}% des ${numFormater(total.nbCommunes)} communes`}
-                data={dataCommunesCouvertes}
-                options={options}
-              />
-              <DoughnutCounter
-                title='Population couverte'
-                valueUp={numFormater(stats.bal.populationCouverte)}
-                valueDown={`${Math.round((stats.bal.populationCouverte * 100) / total.population)}% des ${numFormater(total.population)} d’habitants`}
-                data={dataPopulationCouverte}
-                options={options}
-              />
-              {!Number.isNaN(adressesGereesBALPercent) && <DoughnutCounter
-                title='Adresses certifiées'
-                valueUp={numFormater(stats.bal.nbAdressesCertifiees)}
-                valueDown={`${adressesCertifieesPercent}% des ${numFormater(stats.ban.nbAdresses)} d’adresses présentes dans la BAN`}
-                data={dataAdressesCertifiees}
-                options={options}
-              />}
-            </div>
+            {selectedPanel === 'source' ? (
+              <PanelSource stats={stats} formatedStats={formatedStats} />
+            ) : (
+              <PanelBal filteredCodesCommmune={filteredCodesCommmune} bals={bals} />
+            )}
           </div>
           <div className='bal-cover-map-container'>
             <MapLibre>
@@ -187,6 +149,8 @@ function EtatDeploiement({initialStats, departements}) {
                     center={geometry.center}
                     zoom={geometry.zoom}
                     filteredCodesCommmune={filteredCodesCommmune}
+                    selectedPaintLayer={selectedPanel}
+                    setSelectedPaintLayer={setSelectedPanel}
                   />
                 )
               }}
@@ -205,15 +169,16 @@ function EtatDeploiement({initialStats, departements}) {
           .map-stats-container {
             display: flex;
             justify-content: space-around;
-            height: 100%;
+            height: calc(100vh - 270px);
             text-align: center;
           }
 
           .stats-wrapper {
             display: flex;
             flex-direction: column;
-            flex: 1;
+            width: 30%;
             padding: 1em;
+            overflow: scroll;
           }
 
           .stats {
@@ -227,7 +192,7 @@ function EtatDeploiement({initialStats, departements}) {
           .bal-cover-map-container {
             height: 100%;
             min-height: 400px;
-            flex: 1;
+            width: 70%;
           }
 
           .bal-cover-map-container children {
@@ -237,6 +202,14 @@ function EtatDeploiement({initialStats, departements}) {
           @media (max-width: ${theme.breakPoints.desktop}) {
             .map-stats-container {
               flex-direction: column;
+            }
+            .bal-cover-map-container {
+              width: 100%;
+              height: 100%;
+            }
+            .stats-wrapper {
+              width: 100%;
+              height: 100%;
             }
           }
           `}</style>
@@ -259,7 +232,7 @@ EtatDeploiement.getInitialProps = async () => {
 
   return {
     initialStats: await getStats(),
-    departements: departementsWithCenter
+    departements: departementsWithCenter,
   }
 }
 

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -23,5 +23,6 @@ export default ({
   red: '#D1335B',
   lightRed: '#F8E1E7',
   purple: '#8200BF',
-  lightPurple: '#FCE6FF'
+  lightPurple: '#FCE6FF',
+  yellow: '#FFD700'
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,6 +1395,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@etalab/decoupage-administratif@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz#1d0d54b5b884c3df9555b4b8db543f83559629d3"
+  integrity sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw==
+
 "@etalab/project-legal@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@etalab/project-legal/-/project-legal-0.6.0.tgz#9932f023b85e91578fb3249e885677cb18ec072d"


### PR DESCRIPTION
## Context

Le `/dashboard` sur mes-adresses a été fermé
Il faut migrer la partie déploiement des BAL sur la page `deploiement-bal`

## Fonctionnalité

- Ajout d'un select dans la légende pour rajouter l'onglet `Suivis du statut des BALs` avec une nouvelle colorimétrie pour les états des BALs
- Ajout des BALs par commune dans le panel de gauche lorsque l'onglet `Suivis du statut des BALs` est sélectionné

## Link

https://github.com/BaseAdresseNationale/mes-adresses-api/pull/410

## Attention

Utiliser la branch `fufeck_refacto-deploiement-bal` de `mes-adresses-api` pour tester

Ne pas oublier les 2 variables environnemental pour le deploy
NEXT_PUBLIC_BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
NEXT_PUBLIC_MES_ADRESSES=https://mes-adresses.data.gouv.fr

## Apercu

![Capture d’écran 2023-09-06 à 15 49 34](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/de67135a-4c78-46ff-ad01-db1062b5130b)

![Capture d’écran 2023-09-06 à 15 49 55](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/722cda75-9e99-4644-a68e-35ff01fb0587)

