### PR TITLE
Feat/add matomo to data explorer

### DIFF
--- a/lib/util/analytics-tracker.js
+++ b/lib/util/analytics-tracker.js
@@ -1,0 +1,78 @@
+/* eslint-disable camelcase */
+
+import MatomoTracker from 'matomo-tracker'
+
+const isDevMode = () => process.env?.NODE_ENV !== 'production'
+
+const getAnalyticsTracker = () => {
+  const {
+    NEXT_PUBLIC_MATOMO_URL,
+    NEXT_PUBLIC_MATOMO_SITE_ID: MATOMO_SITE_ID,
+  } = process.env
+  const MATOMO_URL = NEXT_PUBLIC_MATOMO_URL && `${NEXT_PUBLIC_MATOMO_URL}/matomo.php`
+  const DEVMODE = isDevMode()
+
+  const matomoDevLog = tracker => {
+    console.info('[ANALYTICS-DEVLOG] Init matomo')
+    return (data, callback) => {
+      if (tracker && tracker.track) {
+        tracker.track(data, callback)
+      }
+    }
+  }
+
+  const matomoErrorDevLog = err => {
+    console.warn('[ANALYTICS-DEVLOG-ERROR] Error on init matomo:', err)
+    return data => {
+      console.warn('[ANALYTICS-DEVLOG-ERROR] NOT Push to Matomo:', data)
+    }
+  }
+
+  const logMatomoError = err => {
+    console.error('[ANALYTICS-ERROR] error tracking request:', err)
+  }
+
+  try {
+    const tracker = new MatomoTracker(MATOMO_SITE_ID, MATOMO_URL)
+    tracker.on('error', logMatomoError)
+    return DEVMODE ? {track: matomoDevLog(tracker)} : tracker
+  } catch (error) {
+    return {track: matomoErrorDevLog(error)}
+  }
+}
+
+export const getDownloadTrackData = ({
+  downloadDataType,
+  downloadFileName,
+  nbDownload = 1,
+}) => {
+  const DEVMODE = isDevMode()
+
+  // CF. Tracking HTTP API documentation :
+  // https://developer.matomo.org/api-reference/tracking-api
+
+  return {
+    url: `/data/${downloadFileName || ''}`,
+    download: `/data/${downloadFileName || ''}`,
+    e_c: `${DEVMODE ? 'DEVMODE - ' : ''}Download`,
+    e_a: `Download Data ${downloadDataType}`, // Type de download
+    e_n: downloadFileName, // FileName
+    e_v: nbDownload, // Nb download
+  }
+}
+
+export const getAnalyticsPusher = () => {
+  const DEVMODE = isDevMode()
+  const matomo = getAnalyticsTracker()
+  return analyticsTrackData => {
+    matomo.track(analyticsTrackData, (err, response) => {
+      if (err) {
+        console.error('[ANALYTICS-ERROR] Matomo tracking error:', err)
+      } else if (DEVMODE) {
+        console.log('[ANALYTICS-DEVLOG] Matomo Event trackin:', response)
+      }
+    })
+  }
+}
+
+export default getAnalyticsPusher

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "iron-session": "^6.3.1",
     "lodash": "^4.17.21",
     "maplibre-gl": "^1.15.3",
+    "matomo-tracker": "^2.2.4",
     "mime": "^3.0.0",
     "next": "^13.1.2",
     "papaparse": "^5.3.2",

--- a/pages/data/[[...path]].js
+++ b/pages/data/[[...path]].js
@@ -8,6 +8,7 @@ import Head from '@/components/head'
 import Section from '@/components/section'
 import Page from '@/layouts/main'
 import Data from '@/views/data'
+import getAnalyticsPusher, {getDownloadTrackData} from '@/lib/util/analytics-tracker'
 
 import ErrorPage from '../_error'
 
@@ -69,11 +70,18 @@ export function getServerSideProps(context) {
     const fileExtension = path.extname(fileName)
     const contentType = mime.getType(fileExtension) || 'application/octet-stream'
     const fileContents = fs.readFileSync(filePath)
+    const sendToTracker = getAnalyticsPusher()
 
     context.res.setHeader('Content-Type', contentType)
     context.res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
     context.res.statusCode = 200
     context.res.end(fileContents)
+
+    sendToTracker(getDownloadTrackData({
+      downloadDataType: path.dirname(fileName).split('/')[0],
+      downloadFileName: fileName,
+      nbDownload: 1
+    }))
   } catch (err) {
     console.warn(`[${formattedDate} - ERROR]`, 'File access error:', err)
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5388,6 +5388,11 @@ maplibre-gl@^1.15.3:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
 
+matomo-tracker@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/matomo-tracker/-/matomo-tracker-2.2.4.tgz#ee397d915d7b2e7964996ca28a0a03f4f0692453"
+  integrity sha512-7fDy4wRhDQ1dnSxVqmnVqmmos9ACKag0fCBtBD3/Qeoqks7MFqXcO35nfS6S8xU/IXNf7534q/4Gx8fuWKYW6A==
+
 media-engine@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/media-engine/-/media-engine-1.0.3.tgz#be3188f6cd243ea2a40804a35de5a5b032f58dad"


### PR DESCRIPTION
Implement Matomo to data explorer. 

After this, we have the tracking of download into Matomo UI (into 'Event Tracking' tab). 

Note: Tracking into matomo is visible after some unknow delay.