### PR TITLE
deploiement-bal v2

### DIFF
--- a/components/bases-locales/deploiement-bal/bal-cover-map.js
+++ b/components/bases-locales/deploiement-bal/bal-cover-map.js
@@ -8,6 +8,7 @@ import SelectPaintLayer from '@/components/maplibre/select-paint-layer'
 import MapLegends from '@/components/maplibre/map-legends'
 
 import {DEFAULT_CENTER, DEFAULT_ZOOM} from '@/components/maplibre/map'
+import theme from '@/styles/theme'
 
 const ADRESSE_URL = process.env.NEXT_PUBLIC_ADRESSE_URL || 'http://localhost:3000'
 
@@ -18,10 +19,10 @@ const paintLayers = {
       {
         title: 'Déploiement BAL',
         content: {
-          mesadresses: {name: 'Mes Adresses', color: '#228833'},
-          form: {name: 'Formulaire', color: '#EE6677'},
-          moissoneur: {name: 'Moissonneur', color: '#AA3377'},
-          api: {name: 'Api', color: '#66CCEE'},
+          mesadresses: {name: 'Mes Adresses', color: theme.colors.mapGreen},
+          moissoneur: {name: 'Moissonneur', color: theme.colors.mapOrange},
+          form: {name: 'Formulaire', color: theme.colors.mapBlue},
+          api: {name: 'Api', color: theme.colors.mapYellow},
         }
       },
       {
@@ -38,28 +39,28 @@ const paintLayers = {
             ['==', ['get', 'hasBAL'], true],
             ['==', ['get', 'idClient'], 'mes-adresses']
           ], // Mes Adresses
-          color: '#228833'
+          color: theme.colors.mapGreen
         },
         {
           expression: [
             ['==', ['get', 'hasBAL'], true],
             ['==', ['get', 'idClient'], 'moissonneur-bal']
           ], // Moissonneur
-          color: '#AA3377'
+          color: theme.colors.mapOrange
         },
         {
           expression: [
             ['==', ['get', 'hasBAL'], true],
             ['==', ['get', 'idClient'], 'formulaire-publication']
           ], // Formaulaire
-          color: '#EE6677'
+          color: theme.colors.mapBlue
         },
         {
           expression: [
             ['==', ['get', 'hasBAL'], true],
             ['==', ['has', 'idClient'], true]
           ], // API
-          color: '#66CCEE'
+          color: theme.colors.mapYellow
         },
       ],
       default: '#ddd'
@@ -71,15 +72,15 @@ const paintLayers = {
       {
         title: 'Mes Adresses',
         content: {
-          published: {name: 'Publiée', color: '#228833'},
-          pap: {name: 'Prête a être publiée', color: '#AA3377'},
-          draft: {name: 'Brouillon', color: '#EE6677'},
+          published: {name: 'Publiée', color: theme.colors.mapGreen},
+          pap: {name: 'Prête a être publiée', color: theme.colors.mapBlue},
+          draft: {name: 'Brouillon', color: theme.colors.mapYellow},
         }
       },
       {
         title: 'Autre source',
         content: {
-          other: {name: 'Api, formulaire, moissonneur', color: '#66CCEE'},
+          other: {name: 'Api, formulaire, moissonneur', color: theme.colors.mapOrange},
         }
       }
     ],
@@ -90,25 +91,25 @@ const paintLayers = {
           expression: [
             ['==', ['get', 'statusBals'], 'published'],
           ], // Mes Adresses
-          color: '#228833'
+          color: theme.colors.mapGreen
         },
         {
           expression: [
             ['==', ['get', 'statusBals'], 'ready-to-publish'],
           ], // Mes Adresses
-          color: '#AA3377'
+          color: theme.colors.mapBlue
         },
         {
           expression: [
             ['==', ['get', 'statusBals'], 'draft'],
           ], // Mes Adresses
-          color: '#EE6677'
+          color: theme.colors.mapYellow
         },
         {
           expression: [
             ['==', ['get', 'hasBAL'], true],
           ],
-          color: '#66CCEE'
+          color: theme.colors.mapOrange
         },
       ],
       default: '#ddd'

--- a/components/bases-locales/deploiement-bal/panel-bal.js
+++ b/components/bases-locales/deploiement-bal/panel-bal.js
@@ -4,6 +4,7 @@ import {groupBy} from 'lodash'
 import {Doughnut} from 'react-chartjs-2'
 import {Chart as ChartJS, ArcElement, Tooltip, Legend} from 'chart.js'
 
+import theme from '@/styles/theme'
 import {getBals} from '@/lib/mes-adresse-api'
 import CommuneBALList from './commune-bal-list'
 
@@ -32,9 +33,9 @@ const initialStats = {
   datasets: [{
     data: [0, 0, 0],
     backgroundColor: [
-      '#228833',
-      '#AA3377',
-      '#EE6677'
+      theme.colors.mapGreen,
+      theme.colors.mapBlue,
+      theme.colors.mapYellow
     ],
     hoverOffset: 4
   }]

--- a/components/bases-locales/deploiement-bal/panel-bal.js
+++ b/components/bases-locales/deploiement-bal/panel-bal.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
+import {useEffect, useState, useMemo, useCallback} from 'react'
 import {groupBy} from 'lodash'
 import {Doughnut} from 'react-chartjs-2'
 import {Chart as ChartJS, ArcElement, Tooltip, Legend} from 'chart.js'
 
+import {getBals} from '@/lib/mes-adresse-api'
 import CommuneBALList from './commune-bal-list'
 
 ChartJS.register(ArcElement, Tooltip, Legend)
@@ -21,47 +23,81 @@ const options = {
   }
 }
 
-function PanelBal({filteredCodesCommmune, bals}) {
-  const balsByCommune = groupBy(bals, 'commune')
-
-  const data = {
-    labels: [
-      'Publiée',
-      'Prête à être publiée',
-      'Brouillon'
+const initialStats = {
+  labels: [
+    'Publiée',
+    'Prête à être publiée',
+    'Brouillon'
+  ],
+  datasets: [{
+    data: [0, 0, 0],
+    backgroundColor: [
+      '#228833',
+      '#AA3377',
+      '#EE6677'
     ],
-    datasets: [{
-      data: [
-        bals?.filter(bal => bal.status === 'published')?.length,
-        bals?.filter(bal => bal.status === 'ready-to-publish')?.length,
-        bals?.filter(bal => bal.status === 'draft')?.length
-      ],
-      backgroundColor: [
-        '#228833',
-        '#AA3377',
-        '#EE6677'
-      ],
-      hoverOffset: 4
-    }]
-  }
+    hoverOffset: 4
+  }]
+}
+
+function PanelBal({filteredCodesCommmune}) {
+  const [bals, setBals] = useState([])
+  const [dataStats, setDataStats] = useState(initialStats)
+
+  useEffect(() => {
+    async function getBalsFiltered() {
+      const fields = ['_id', 'commune', 'status', 'nom', '_updated', 'sync']
+      const balsFiltered = await getBals(fields, filteredCodesCommmune)
+      setDataStatsWithBal(balsFiltered)
+      if (filteredCodesCommmune.length > 0) {
+        setBals(balsFiltered)
+      }
+    }
+
+    getBalsFiltered()
+  }, [filteredCodesCommmune, setDataStatsWithBal])
+
+  const balsByCommune = useMemo(() => {
+    return groupBy(bals, 'commune')
+  }, [bals])
+
+  const setDataStatsWithBal = useCallback(balsFiltered => {
+    const data = [
+      balsFiltered.filter(bal => bal.status === 'published').length,
+      balsFiltered.filter(bal => bal.status === 'ready-to-publish').length,
+      balsFiltered.filter(bal => bal.status === 'draft').length
+    ]
+
+    setDataStats(dataStats => {
+      return {
+        ...dataStats,
+        datasets: [
+          {
+            ...dataStats.datasets[0],
+            data
+          }
+        ]
+      }
+    })
+  }, [setDataStats, dataStats])
 
   return (
     <div>
       <br />
+      <h3>Statut des BAL(s)</h3>
+      <div className='stats'>
+        <div className='donut'>
+          <Doughnut data={dataStats} options={options} />
+        </div>
+      </div>
+      <br />
+      <h3>Liste des Communes</h3>
       {filteredCodesCommmune.length > 0 ? (
         <div>
-          <h3>Statut des BAL(s)</h3>
-          <div className='donut'>
-            <Doughnut data={data} options={options} />
-          </div>
-          <br />
-          <h3>Liste des Communes</h3>
-
-          {filteredCodesCommmune.map(codeCommune => {
+          {Object.keys(balsByCommune).map(codeCommune => {
             const balsCommune = balsByCommune[codeCommune] || []
             return <CommuneBALList key={codeCommune} codeCommune={codeCommune} balsCommune={balsCommune} />
           })}
-
         </div>
       ) : (
         <p>Aucun Département ou EPCI sélectionné</p>
@@ -70,11 +106,15 @@ function PanelBal({filteredCodesCommmune, bals}) {
         h3 {
           text-align: left;
         }
-        .donut {
+        .stats {
           border: 1px solid lightgrey;
           padding: 1em;
           border-radius: 5px;
-          max-width: 300px;
+          display: flex;
+          justify-content: center;
+        }
+        .donut {
+          width: 60%;
         }
       `}</style>
     </div>
@@ -83,7 +123,6 @@ function PanelBal({filteredCodesCommmune, bals}) {
 
 PanelBal.propTypes = {
   filteredCodesCommmune: PropTypes.array.isRequired,
-  bals: PropTypes.array.isRequired
 }
 
 export default PanelBal

--- a/components/maplibre/map-legends.js
+++ b/components/maplibre/map-legends.js
@@ -19,6 +19,7 @@ function MapLegends({title, legend, hasBorderRadius}) {
         .legend-container {
           display: flex;
           align-items: center;
+          text-align: left;
         }
 
         .legend-color {

--- a/components/maplibre/select-paint-layer.js
+++ b/components/maplibre/select-paint-layer.js
@@ -37,7 +37,8 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
       {!isWrap && (
         <div className='content'>
           {children}
-        </div>)}
+        </div>
+      )}
 
       <style jsx>{`
         .select-paint-container {
@@ -49,6 +50,7 @@ function SelectPaintLayer({options, selected, handleSelect, isMobile, children})
           padding: 0.5em;
           left: 10px;
           top: 8px;
+          width: 225px;
           background-color: rgba(255,255,255,0.9);
         }
 

--- a/lib/mes-adresse-api.js
+++ b/lib/mes-adresse-api.js
@@ -34,3 +34,6 @@ export async function getBals(fields, codesCommunes) {
   return _fetch('/stats/bals?' + query.join('&'), 'POST', codesCommunes)
 }
 
+export async function getBalsStatus() {
+  return _fetch('/stats/bals/status', 'GET')
+}

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -11,7 +11,6 @@ import departementCenterMap from '@/data/geo/departement-center.json'
 
 import {_fetch, getStats} from '@/lib/api-ban'
 import {getDepartements, getEpcis} from '@/lib/api-geo'
-import {getBals} from '@/lib/mes-adresse-api'
 
 import {useStatsDeploiement} from '@/hooks/stats-deploiement'
 
@@ -31,7 +30,6 @@ function EtatDeploiement({initialStats, departements}) {
   const [isLoading, setIsLoading] = useState(false)
   const [results, setResults] = useState([])
   const {stats, formatedStats, filter, setFilter, filteredCodesCommmune, geometry} = useStatsDeploiement({initialStats})
-  const [bals, setBals] = useState([])
   const [selectedPanel, setSelectedPanel] = useState('source')
 
   const handleSearch = useCallback(debounce(async input => {
@@ -54,16 +52,6 @@ function EtatDeploiement({initialStats, departements}) {
     setFilter(null)
     setInput('')
   }
-
-  useEffect(() => {
-    async function getBalsFiltered() {
-      const fields = ['_id', 'commune', 'status', 'nom', '_updated', 'sync']
-      const balsFiltered = await getBals(fields, filteredCodesCommmune)
-      setBals(balsFiltered)
-    }
-
-    getBalsFiltered()
-  }, [filteredCodesCommmune])
 
   const handleSelect = async item => {
     setFilter(item)
@@ -134,7 +122,7 @@ function EtatDeploiement({initialStats, departements}) {
             {selectedPanel === 'source' ? (
               <PanelSource stats={stats} formatedStats={formatedStats} />
             ) : (
-              <PanelBal filteredCodesCommmune={filteredCodesCommmune} bals={bals} />
+              <PanelBal filteredCodesCommmune={filteredCodesCommmune} />
             )}
           </div>
           <div className='bal-cover-map-container'>

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -24,5 +24,10 @@ export default ({
   lightRed: '#F8E1E7',
   purple: '#8200BF',
   lightPurple: '#FCE6FF',
-  yellow: '#FFD700'
+  yellow: '#FFD700',
+
+  mapGreen: '#009E73',
+  mapOrange: '#E69F00',
+  mapBlue: '#0072B2',
+  mapYellow: '#F0E442'
 })


### PR DESCRIPTION
## Context

Après la migration de la page /dashboard de mes adresses vers /deploiement-bal de adresse, il manque quelque fonctionnalité pour que la page soit optimal

## Lien

PR Mes-adresses-api : https://github.com/BaseAdresseNationale/mes-adresses-api/pull/411

## Fonctionnalité

Avec le graphique de publication Bal par defaut:
<img width="1639" alt="Capture d’écran 2023-09-25 à 16 58 30" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/10faf670-4eeb-4047-a63d-70176f768984">

Avec seulement les communes qui ont des BALs
<img width="1637" alt="Capture d’écran 2023-09-25 à 16 58 59" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/a4119d82-b88d-47c3-ba8e-5a53d3102a87">
