### PR TITLE
Add type url in partnaire form

### DIFF
--- a/components/bases-locales/charte/candidacy-form.js
+++ b/components/bases-locales/charte/candidacy-form.js
@@ -274,6 +274,7 @@ function CandidacyForm({onClose, partnersServices, departements}) {
             label='Lien vers la charte*'
             nativeInputProps={{
               value: formData.charteURL,
+              type: 'url',
               onChange: handleEdit('charteURL'),
               required: true,
             }}
@@ -282,6 +283,7 @@ function CandidacyForm({onClose, partnersServices, departements}) {
             label='Lien vers le site'
             nativeInputProps={{
               value: formData.link,
+              type: 'url',
               onChange: handleEdit('link')}}
           />
         </div>
@@ -291,12 +293,14 @@ function CandidacyForm({onClose, partnersServices, departements}) {
               label='Lien vers le témoignage'
               nativeInputProps={{
                 value: formData.testimonyURL,
+                type: 'url',
                 onChange: handleEdit('testimonyURL')}}
             />
             <Input
               label='Lien vers la BAL'
               nativeInputProps={{
                 value: formData.balURL,
+                type: 'url',
                 onChange: handleEdit('balURL')}}
             />
           </div>)}
@@ -306,6 +310,7 @@ function CandidacyForm({onClose, partnersServices, departements}) {
               label='Lien vers le témoignage'
               nativeInputProps={{
                 value: formData.testimonyURL,
+                type: 'url',
                 onChange: handleEdit('testimonyURL')}}
             />
           </div>


### PR DESCRIPTION
## Context

Sur Adresse (https://adresse.data.gouv.fr/bases-locales/charte/organismes) certain liens de partenaire redirige vers une 404 de adresse
C'est parce qu'il manque le https:// au url que c'est redirigé en local

## Fonctionalité

Ajout du `type='url'` au champs url du formulaire de candidature des partenaire de la charte