### PR TITLE
Ajout message pour evenement 12 decembre

### DIFF
--- a/events.json
+++ b/events.json
@@ -2490,7 +2490,7 @@
   {
     "title": "Adresse_Lab #8",
     "subtitle": "Point d'échange trimestriel T4 2023",
-    "description": "Actualités et point d'avancement des chantiers en cours",
+    "description": "Actualités et point d'avancement des chantiers en cours. Il n’est pas nécessaire de « s’inscrire à l’événement ». Le lien d’inscription correspond au lien qu’il faudra utiliser le 12 décembre pour se connecter au webinaire.",
     "type": "adresselab",
     "target": "utilisateurs de la donnée adresse",
     "date": "2023-12-12",


### PR DESCRIPTION
Ajout du message : « Il n’est pas nécessaire de « s’inscrire à l’événement ». Le lien d’inscription correspond au lien qu’il faudra utiliser le 12 décembre pour se connecter au webinaire. »

Fix #1661 

![Capture d’écran du 2023-11-21 11-11-22](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/03452a85-77a7-4fd4-9ac1-72631230a875)
