### PR TITLE
Remplacer Gécodeur actuel par Géocodeur Géoplateforme

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,13 @@
 NEXT_PUBLIC_ADRESSE_URL=http://localhost:3000
 NEXT_PUBLIC_API_GEO_URL=https://geo.api.gouv.fr/2022
 NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
+
+#Pour le géococdeur actuel
 NEXT_PUBLIC_API_ADRESSE=https://api-adresse.data.gouv.fr
+
+# Pour le géocodeur géoplateforme IGN
+NEXT_PUBLIC_API_ADRESSE=https://data.geopf.fr/geocodage
+
 NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=https://etablissements-publics.api.gouv.fr/v3
 NEXT_PUBLIC_MATOMO_URL=
 NEXT_PUBLIC_MATOMO_SITE_ID=


### PR DESCRIPTION
Nous souhaitons remplacer le geocodeur actuel par le Géocodeur Géoplateforme IGN sur la barre de recherche et sur la carte.
Il n'y a qu'un changement d'url à faire sur .env

Fix #1662 
