### PR TITLE
Passage de la carte explorateur en React-map-gl

### DIFF
--- a/components/maplibre/ban-map/index.js
+++ b/components/maplibre/ban-map/index.js
@@ -1,5 +1,4 @@
-import ReactDOM from 'react-dom'
-import {useCallback, useContext, useEffect, useState} from 'react'
+import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
 import PropTypes from 'prop-types'
 import bboxPolygon from '@turf/bbox-polygon'
 import booleanContains from '@turf/boolean-contains'
@@ -30,6 +29,7 @@ import popupFeatures from './popups'
 import {flatten, forEach} from 'lodash'
 
 import DeviceContext from '@/contexts/device'
+import {Layer, Source, useMap, Popup} from 'react-map-gl/maplibre'
 
 let hoveredFeature = null
 
@@ -105,28 +105,30 @@ const getPositionsFeatures = address => {
   return []
 }
 
-function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbox, onSelect, isMobile}) {
+function BanMap({address, bbox, onSelect, isMobile}) {
+  const map = useMap()
   const {isSafariBrowser} = useContext(DeviceContext)
   const [isCenterControlDisabled, setIsCenterControlDisabled] = useState(true)
   const [selectedPaintLayer, setSelectedPaintLayer] = useState('certification')
   const [isCadastreDisplayable, setIsCadastreDisplayble] = useState(true)
   const [isCadastreLayersShown, setIsCadastreLayersShown] = useState(false)
   const [bound, setBound] = useState()
+  const [infoPopup, setInfoPopup] = useState(null)
 
   const onLeave = useCallback(() => {
     if (hoveredFeature) {
       highLightAdressesByProperties(false, hoveredFeature)
     }
 
-    popup.remove()
-    map.getCanvas().style.cursor = 'grab'
+    setInfoPopup(null)
+    map.current.getCanvas().style.cursor = 'grab'
     hoveredFeature = null
-  }, [map, popup, highLightAdressesByProperties])
+  }, [map, highLightAdressesByProperties])
 
   const highLightAdressesByProperties = useCallback((isHovered, hoveredFeature) => {
     const {nom, id} = hoveredFeature
     forEach(SOURCES, sourceLayer => {
-      forEach(map.querySourceFeatures('base-adresse-nationale', {
+      forEach(map.current.querySourceFeatures('base-adresse-nationale', {
         sourceLayer,
         filter: [
           'any',
@@ -134,7 +136,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
           ['in', id, ['get', 'id']]
         ]
       }), ({id}) => {
-        map.setFeatureState({source: 'base-adresse-nationale', sourceLayer, id}, {hover: isHovered})
+        map.current.setFeatureState({source: 'base-adresse-nationale', sourceLayer, id}, {hover: isHovered})
       })
     })
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -151,17 +153,14 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
       }
       highLightAdressesByProperties(true, hoveredFeature)
 
-      map.getCanvas().style.cursor = 'pointer'
-      const popupNode = document.createElement('div')
-      ReactDOM.render(popupFeatures(e.features), popupNode)
-      popup.setLngLat(e.lngLat)
-        .setDOMContent(popupNode)
-        .addTo(map)
+      map.current.getCanvas().style.cursor = 'pointer'
+
+      setInfoPopup({...e})
     } else {
-      map.getCanvas().style.cursor = 'grab'
-      popup.remove()
+      map.current.getCanvas().style.cursor = 'grab'
+      setInfoPopup(null)
     }
-  }, [map, popup, highLightAdressesByProperties])
+  }, [map, highLightAdressesByProperties])
 
   const handleClick = (e, cb) => {
     const feature = e.features[0]
@@ -170,7 +169,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
 
   const centerAddress = useCallback(() => {
     if (bound && !isCenterControlDisabled) {
-      map.fitBounds(bound, {
+      map.current.fitBounds(bound, {
         padding: 30
       })
       setIsCenterControlDisabled(true)
@@ -179,7 +178,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
 
   const isAddressVisible = useCallback(() => {
     if (address) {
-      const {_sw, _ne} = map.getBounds()
+      const {_sw, _ne} = map.current.getBounds()
       const mapBBox = [
         _sw.lng,
         _sw.lat,
@@ -187,7 +186,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
         _ne.lat
       ]
 
-      const currentZoom = map.getZoom()
+      const currentZoom = map.current.getZoom()
       const isAddressInMapBBox = bound ? isFeatureContained(mapBBox, bound) : false
 
       const isZoomSmallerThanMax = currentZoom <= ZOOM_RANGE[address.type].max
@@ -200,7 +199,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
 
   const handleZoom = useCallback(() => {
     isAddressVisible()
-    const zoom = map.getZoom()
+    const zoom = map.current.getZoom()
     setIsCadastreDisplayble(zoom < PARCELLES_MINZOOM)
   }, [map, isAddressVisible])
 
@@ -209,136 +208,48 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
   }, [address, isAddressVisible, handleZoom])
 
   useEffect(() => {
-    if (map.isStyleLoaded()) {
-      map.setPaintProperty(adresseCircleLayer.id, 'circle-color', paintLayers[selectedPaintLayer].paint)
-      map.setPaintProperty(adresseLabelLayer.id, 'text-color', paintLayers[selectedPaintLayer].paint)
-      map.setPaintProperty(adresseCompletLabelLayer.id, 'text-color', paintLayers[selectedPaintLayer].paint)
+    map.current.off('dragend', handleZoom)
+    map.current.off('zoomend', handleZoom)
 
-      cadastreLayers.map(({id}) => (
-        map.setLayoutProperty(
-          id,
-          'visibility',
-          isCadastreLayersShown ? 'visible' : 'none'
-        )
-      ))
+    map.current.on('dragend', handleZoom)
+    map.current.on('zoomend', handleZoom)
 
-      if (address?.parcelles) {
-        map.setFilter('parcelle-highlighted', ['any', ...address.parcelles.map(id => ['==', ['get', 'id'], id])])
-      } else {
-        map.setFilter('parcelle-highlighted', ['==', ['get', 'id'], ''])
-      }
+    map.current.on('mousemove', 'adresse', onHover)
+    map.current.on('mousemove', 'adresse-label', onHover)
+    map.current.on('mousemove', 'voie', onHover)
+    map.current.on('mousemove', 'toponyme', onHover)
 
-      if (address?.positions?.length > 1) {
-        map.setFilter('adresse', ['!=', ['get', 'id'], address.id])
-        map.setFilter('adresse-label', ['!=', ['get', 'id'], address.id])
-      }
-    }
-  }, [map, selectedPaintLayer, isCadastreLayersShown, address])
+    map.current.on('mouseleave', 'adresse', onLeave)
+    map.current.on('mouseleave', 'adresse-label', onLeave)
+    map.current.on('mouseleave', 'voie', onLeave)
+    map.current.on('mouseleave', 'toponyme', onLeave)
 
-  useEffect(() => {
-    map.off('dragend', handleZoom)
-    map.off('zoomend', handleZoom)
-
-    map.on('dragend', handleZoom)
-    map.on('zoomend', handleZoom)
-
-    map.on('mousemove', 'adresse', onHover)
-    map.on('mousemove', 'adresse-label', onHover)
-    map.on('mousemove', 'voie', onHover)
-    map.on('mousemove', 'toponyme', onHover)
-
-    map.on('mouseleave', 'adresse', onLeave)
-    map.on('mouseleave', 'adresse-label', onLeave)
-    map.on('mouseleave', 'voie', onLeave)
-    map.on('mouseleave', 'toponyme', onLeave)
-
-    map.on('click', 'adresse', e => handleClick(e, onSelect))
-    map.on('click', 'adresse-label', e => handleClick(e, onSelect))
-    map.on('click', 'voie', e => handleClick(e, onSelect))
-    map.on('click', 'toponyme', e => handleClick(e, onSelect))
-
+    map.current.on('click', 'adresse', e => handleClick(e, onSelect))
+    map.current.on('click', 'adresse-label', e => handleClick(e, onSelect))
+    map.current.on('click', 'voie', e => handleClick(e, onSelect))
+    map.current.on('click', 'toponyme', e => handleClick(e, onSelect))
     return () => {
-      map.off('dragend', handleZoom)
-      map.off('zoomend', handleZoom)
+      map.current.off('dragend', handleZoom)
+      map.current.off('zoomend', handleZoom)
 
-      map.off('mousemove', 'adresse', onHover)
-      map.off('mousemove', 'adresse-label', onHover)
-      map.off('mousemove', 'voie', onHover)
-      map.off('mousemove', 'toponyme', onHover)
+      map.current.off('mousemove', 'adresse', onHover)
+      map.current.off('mousemove', 'adresse-label', onHover)
+      map.current.off('mousemove', 'voie', onHover)
+      map.current.off('mousemove', 'toponyme', onHover)
 
-      map.off('mouseleave', 'adresse', onLeave)
-      map.off('mouseleave', 'adresse-label', onLeave)
-      map.off('mouseleave', 'voie', onLeave)
-      map.off('mouseleave', 'toponyme', onLeave)
+      map.current.off('mouseleave', 'adresse', onLeave)
+      map.current.off('mouseleave', 'adresse-label', onLeave)
+      map.current.off('mouseleave', 'voie', onLeave)
+      map.current.off('mouseleave', 'toponyme', onLeave)
 
-      map.off('click', 'adresse', e => handleClick(e, onSelect))
-      map.off('click', 'adresse-label', e => handleClick(e, onSelect))
-      map.off('click', 'voie', e => handleClick(e, onSelect))
-      map.off('click', 'toponyme', e => handleClick(e, onSelect))
+      map.current.off('click', 'adresse', e => handleClick(e, onSelect))
+      map.current.off('click', 'adresse-label', e => handleClick(e, onSelect))
+      map.current.off('click', 'voie', e => handleClick(e, onSelect))
+      map.current.off('click', 'toponyme', e => handleClick(e, onSelect))
     }
 
     // No dependency in order to mock a didMount and avoid duplicating events.
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    setSources([
-      {
-        name: 'base-adresse-nationale',
-        type: 'vector',
-        format: 'pbf',
-        tiles: [
-          'https://plateforme.adresse.data.gouv.fr/tiles/ban/{z}/{x}/{y}.pbf'
-        ],
-        minzoom: 10,
-        maxzoom: 14,
-        promoteId: 'id'
-      },
-      {
-        name: 'cadastre',
-        type: 'vector',
-        url: 'https://openmaptiles.geo.data.gouv.fr/data/cadastre.json'
-      },
-      {
-        name: 'positions',
-        type: 'geojson',
-        data: {
-          type: 'FeatureCollection',
-          features: getPositionsFeatures(address)
-        }
-      }
-    ])
-    setLayers([
-      ...cadastreLayers,
-      adresseCircleLayer,
-      adresseLabelLayer,
-      adresseCompletLabelLayer,
-      voieLayer,
-      toponymeLayer,
-      positionsLabelLayer,
-      positionsCircleLayer
-    ])
-  }, [setSources, setLayers, address])
-
-  useEffect(() => {
-    if (isSourceLoaded && map.getLayer('adresse-complet-label') && map.getLayer('adresse-label')) {
-      if (address && address.type === 'numero') {
-        const {id} = address
-        map.setFilter('adresse-complet-label', [
-          '==', ['get', 'id'], id
-        ])
-        map.setFilter('adresse-label', [
-          '!=', ['get', 'id'], id
-        ])
-      } else {
-        map.setFilter('adresse-complet-label', [
-          '==', ['get', 'id'], ''
-        ])
-        map.setFilter('adresse-label', [
-          '!=', ['get', 'id'], ''
-        ])
-      }
-    }
-  }, [map, isSourceLoaded, address, setLayers])
 
   useEffect(() => {
     if (bbox) {
@@ -347,6 +258,20 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
       setBound(address?.displayBBox)
     }
   }, [map, bbox, address])
+
+  const cadastreFiltre = useMemo(() => address?.parcelles ? ['any', ...address.parcelles.map(id => ['==', ['get', 'id'], id])] : ['==', ['get', 'id'], ''], [address?.parcelles])
+
+  const dataPositionJson = useMemo(() => {
+    return {
+      type: 'FeatureCollection',
+      features: getPositionsFeatures(address)
+    }
+  }
+  , [address])
+
+  const [filtreIsAdresse, filtreIsnotAdresse] = useMemo(() =>
+    [['==', ['get', 'id'], address?.id], ['!=', ['get', 'id'], address?.id]]
+  , [address])
 
   return (
     <>
@@ -374,23 +299,66 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, bbo
         />
       </SelectPaintLayer>
 
-      <style jsx>{`
-        .maplibregl-ctrl-group {
-          position: absolute;
-          box-shadow: none;
-          border: 2px solid #dcd8d5;
-          z-index: 2;
-          right: 8px;
-          top: 80px;
+      { infoPopup?.features && (
+        <Popup closeOnClick={false} closeButton={false} latitude={infoPopup.lngLat.lat} longitude={infoPopup.lngLat.lng}>
+          {popupFeatures(infoPopup?.features || [])}
+        </Popup>
+
+      )}
+      <Source id='cadastre'
+        type='vector'
+        url='https://openmaptiles.geo.data.gouv.fr/data/cadastre.json'
+      >
+        {cadastreLayers.map(cadastreLayerElt => {
+          if (cadastreLayerElt.id === 'parcelle-highlighted') {
+            cadastreLayerElt.filter = cadastreFiltre
+          }
+
+          return <Layer key={cadastreLayerElt.id} {...cadastreLayerElt} layout={{...cadastreLayerElt.layout, visibility: isCadastreLayersShown ? 'visible' : 'none'}} />
         }
-        `}</style>
+        )}
+      </Source>
+      <Source id='base-adresse-nationale'
+        type='vector'
+        format='pbf'
+        tiles={[
+          'https://plateforme.adresse.data.gouv.fr/tiles/ban/{z}/{x}/{y}.pbf'
+        ]}
+        minzoom={10}
+        maxzoom={14}
+        promoteId='id'
+      >
+        <Layer {...adresseCircleLayer} paint={{...adresseCircleLayer.paint, 'circle-color': paintLayers[selectedPaintLayer].paint}} />
+        <Layer {...adresseLabelLayer} filter={address?.type === 'numero' ? filtreIsnotAdresse : true} paint={{...adresseLabelLayer.paint, 'text-color': paintLayers[selectedPaintLayer].paint}} />
+        <Layer {...adresseCompletLabelLayer} filter={address?.type === 'numero' ? filtreIsAdresse : false} paint={{...adresseCompletLabelLayer.paint, 'text-color': paintLayers[selectedPaintLayer].paint}} />
+        <Layer {...voieLayer} />
+        <Layer {...toponymeLayer} />
+      </Source>
+
+      <Source
+        id='positions'
+        type='geojson'
+        data={dataPositionJson}
+      >
+        <Layer {...positionsLabelLayer} />
+        <Layer {...positionsCircleLayer} />
+      </Source>
+      <style jsx>{`
+      .maplibregl-ctrl-group {
+        position: absolute;
+        box-shadow: none;
+        border: 2px solid #dcd8d5;
+        z-index: 2;
+        right: 8px;
+        top: 80px;
+      }
+      `}</style>
     </>
   )
 }
 
 BanMap.defaultProps = {
   address: null,
-  isSourceLoaded: false,
   onSelect: () => {},
   isMobile: false
 }
@@ -407,17 +375,14 @@ BanMap.propTypes = {
     lon: PropTypes.number,
     voie: PropTypes.object
   }),
-  map: PropTypes.object.isRequired,
-  isSourceLoaded: PropTypes.bool,
-  popup: PropTypes.object.isRequired,
+
   contour: PropTypes.shape({
     features: PropTypes.array.isRequired
   }),
   onSelect: PropTypes.func,
-  setSources: PropTypes.func.isRequired,
-  setLayers: PropTypes.func.isRequired,
+
   isMobile: PropTypes.bool,
-  bbox: PropTypes.arrayOf({type: PropTypes.number}),
+  bbox: PropTypes.arrayOf(PropTypes.number),
 }
 
 export default BanMap

--- a/components/maplibre/index.js
+++ b/components/maplibre/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import dynamic from 'next/dynamic'
 
 import {isWebGLSupported} from '@/lib/browser/webgl'
@@ -71,14 +71,32 @@ function NoWebglError() {
   )
 }
 
-class MapWrapper extends React.PureComponent {
+// eslint-disable-next-line node/no-unsupported-features/es-syntax
+const DynamicMap = dynamic(import('./map' /* webpackChunkName: "maplibre-gl" */), {
+  ssr: false,
+  loading: () => (
+    <MapLoader />
+  )
+})
+
+export function MapWrapper(props) {
+  const [showMap, setIsMapShowned] = useState(false)
+  useEffect(() => {
+    setIsMapShowned(true)
+  }, [])
+  return (
+    (showMap && isWebGLSupported()) ? (<DynamicMap {...props} />) : (<MapLoader />)
+  )
+}
+
+export class MapLegacy extends React.PureComponent {
   state = {
     showMap: false
   }
 
   componentDidMount() {
     /* eslint-disable node/no-unsupported-features/es-syntax */
-    this.MapComponent = isWebGLSupported() ? dynamic(import('./map' /* webpackChunkName: "maplibre-gl" */), {
+    this.MapComponent = isWebGLSupported() ? dynamic(import('./map-legacy' /* webpackChunkName: "maplibre-gl" */), {
       ssr: false,
       loading: () => (
         <MapLoader />

--- a/components/maplibre/map-legacy.js
+++ b/components/maplibre/map-legacy.js
@@ -1,0 +1,324 @@
+import {useState, useCallback, useEffect} from 'react'
+import PropTypes from 'prop-types'
+import Head from 'next/head'
+import maplibregl from 'maplibre-gl'
+import mapStyle from 'maplibre-gl/dist/maplibre-gl.css'
+
+import theme from '@/styles/theme'
+
+import vector from './styles/vector.json'
+
+import Notification from '../notification'
+
+import SwitchMapStyle from './switch-map-style'
+
+import useMarker from './hooks/marker'
+import usePopup from './hooks/popup'
+
+export const DEFAULT_CENTER = [1.7, 46.9]
+export const DEFAULT_ZOOM = 4.4
+
+const STYLES = {
+  vector,
+  ortho: {
+    version: 8,
+    glyphs: 'https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf',
+    sources: {
+      'raster-tiles': {
+        type: 'raster',
+        tiles: ['https://wxs.ign.fr/essentiels/geoportail/wmts?layer=ORTHOIMAGERY.ORTHOPHOTOS&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}'],
+        tileSize: 256,
+        attribution: '<a target="_blank" href="https://geoservices.ign.fr/documentation/donnees/ortho/bdortho" /> © IGN </a>'
+      }
+    },
+    layers: [{
+      id: 'simple-tiles',
+      type: 'raster',
+      source: 'raster-tiles'
+    }]
+  }
+}
+
+function Map({hasSwitchStyle, bbox, defaultStyle, hasHash, defaultCenter, defaultZoom, isInteractive, hasControl, isLoading, error, children}) {
+  const [map, setMap] = useState(null)
+  const [mapContainer, setMapContainer] = useState(null)
+  const [isFirstLoad, setIsFirstLoad] = useState(false)
+  const [isSourceLoaded, setIsSourceLoaded] = useState(false)
+  const [isStyleLoaded, setIsStyleLoaded] = useState(true)
+  const [style, setStyle] = useState(defaultStyle)
+  const [sources, setSources] = useState([])
+  const [layers, setLayers] = useState([])
+  const [infos, setInfos] = useState(null)
+  const [tools, setTools] = useState(null)
+  const [marker, setMarkerCoordinates] = useMarker(map)
+  const [popup] = usePopup(marker)
+  const [mapError, setMapError] = useState(error)
+
+  const mapRef = useCallback(ref => {
+    if (ref) {
+      setMapContainer(ref)
+    }
+  }, [])
+
+  const fitBounds = useCallback(bbox => {
+    try {
+      map.fitBounds(bbox, {
+        padding: 30,
+        linear: true,
+        maxZoom: 19,
+        duration: 0
+      })
+    } catch {
+      setMapError('Aucune position n’est renseignée')
+    }
+  }, [map])
+
+  const switchLayer = useCallback(() => {
+    setStyle(style === 'vector' ?
+      'ortho' :
+      'vector'
+    )
+  }, [style])
+
+  const loadData = useCallback(() => {
+    if (map && isStyleLoaded && isFirstLoad) {
+      sources.forEach(source => {
+        const {name, ...properties} = source
+        const src = map.getSource(name)
+
+        if (src && properties.data) {
+          src.setData(properties.data)
+        } else if (!src) {
+          map.addSource(name, properties)
+        }
+      })
+
+      layers.forEach(layer => {
+        if (!map.getLayer(layer.id)) {
+          map.addLayer(layer)
+        }
+      })
+    }
+  }, [map, isFirstLoad, isStyleLoaded, layers, sources])
+
+  const onSourceData = useCallback(event => {
+    setIsSourceLoaded(event.isSourceLoaded)
+  }, [])
+
+  useEffect(() => {
+    loadData()
+  }, [sources, layers, style, isStyleLoaded, loadData])
+
+  useEffect(() => {
+    if (map) {
+      map.setStyle(STYLES[style])
+
+      const onStyleData = () => {
+        if (map.isStyleLoaded()) {
+          setIsStyleLoaded(true)
+        } else {
+          setIsStyleLoaded(false)
+          setTimeout(onStyleData, 200)
+        }
+      }
+
+      map.on('style.load', onStyleData)
+
+      return () => {
+        map.off('style.load', onStyleData)
+      }
+    }
+  }, [style]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (mapContainer) {
+      const map = new maplibregl.Map({
+        container: mapContainer,
+        style: STYLES[style],
+        center: defaultCenter || DEFAULT_CENTER,
+        zoom: defaultZoom || DEFAULT_ZOOM,
+        maxZoom: 19,
+        hash: hasHash,
+        isInteractive
+      })
+
+      if (hasControl) {
+        const navControl = new maplibregl.NavigationControl({
+          showCompass: false
+        })
+        const scaleControl = new maplibregl.ScaleControl({
+          maxWidth: 150,
+          unit: 'metric'
+        })
+        map.addControl(navControl, 'top-right')
+        map.addControl(scaleControl, 'bottom-right')
+      }
+
+      map.on('load', loadData)
+      map.on('sourcedata', onSourceData)
+      map.once('load', () => {
+        setIsFirstLoad(true)
+      })
+
+      setMap(map)
+
+      return () => {
+        map.off('load', loadData)
+        map.off('sourcedata', onSourceData)
+      }
+    }
+
+    // Map should only be created when its container is ready
+    // and should not be re-created
+  }, [mapContainer]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setMapError(error)
+  }, [error])
+
+  useEffect(() => {
+    if (bbox && map) {
+      fitBounds(bbox)
+    }
+  }, [map, bbox, fitBounds])
+
+  return (
+    <div className='maplibre-container'>
+      <div className='map'>
+        {mapError && (
+          <div className='tools error'>
+            <Notification type='error' message={mapError} />
+          </div>
+        )}
+
+        {!mapError && isLoading && (
+          <div className='tools'>Chargement…</div>
+        )}
+
+        {!isLoading && !mapError && infos && (
+          <div className='tools'>{infos}</div>
+        )}
+
+        {!isLoading && !mapError && tools && (
+          <div className='tools right'>{tools}</div>
+        )}
+
+        {map && children({
+          map,
+          marker,
+          popup,
+          style,
+          isSourceLoaded,
+          setSources,
+          setLayers,
+          setInfos,
+          setTools,
+          bbox,
+          setMarkerCoordinates
+        })}
+
+        <div ref={mapRef} className='map-container' />
+
+        {hasSwitchStyle && (
+          <div className='tools bottom switch'>
+            <SwitchMapStyle
+              isVector={style === 'vector'}
+              handleChange={switchLayer}
+            />
+          </div>
+        )}
+
+      </div>
+
+      <Head>
+        <style key='maplibre'
+          dangerouslySetInnerHTML={{__html: mapStyle}} // eslint-disable-line react/no-danger
+        />
+      </Head>
+
+      <style jsx>{`
+          .maplibre-container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+          }
+
+          .map-container {
+            min-width: 250px;
+            flex: 1;
+          }
+
+          .map {
+            display: flex;
+            height: 100%;
+          }
+
+          .tools {
+            position: absolute;
+            max-height: ${hasSwitchStyle ? 'calc(100% - 116px)' : '100%'};
+            overflow-y: ${hasSwitchStyle ? 'scroll' : 'initial'};
+            z-index: 10;
+            padding: 0.5em;
+            margin: 1em;
+            border-radius: 4px;
+            background-color: #ffffffbb;
+            max-width: 80%;
+          }
+
+          .right {
+            right: 0;
+          }
+
+          .bottom {
+            bottom: 0;
+            left: 0;
+          }
+
+          .switch {
+            background-color: none;
+            padding: 0;
+            overflow: hidden;
+          }
+
+          @media (max-width: ${theme.breakPoints.mobile}) {
+            .tools {
+              margin: 0.5em;
+            }
+          }
+        `}</style>
+
+    </div>
+  )
+}
+
+Map.propTypes = {
+  hasSwitchStyle: PropTypes.bool,
+  bbox: PropTypes.array,
+  defaultStyle: PropTypes.oneOf([
+    'vector',
+    'ortho'
+  ]),
+  isInteractive: PropTypes.bool,
+  hasControl: PropTypes.bool,
+  hasHash: PropTypes.bool,
+  defaultCenter: PropTypes.array,
+  defaultZoom: PropTypes.number,
+  isLoading: PropTypes.bool,
+  error: PropTypes.object,
+  children: PropTypes.func.isRequired
+}
+
+Map.defaultProps = {
+  bbox: null,
+  defaultStyle: 'vector',
+  isInteractive: true,
+  hasControl: true,
+  hasHash: false,
+  defaultCenter: DEFAULT_CENTER,
+  defaultZoom: DEFAULT_ZOOM,
+  isLoading: false,
+  error: null,
+  hasSwitchStyle: false
+}
+
+export default Map

--- a/components/maplibre/map.js
+++ b/components/maplibre/map.js
@@ -41,8 +41,6 @@ const STYLES = {
 function Map({hasSwitchStyle, bbox, defaultStyle, hasHash, defaultCenter, defaultZoom, isInteractive, hasControl, isLoading, error, children}) {
   const map = useRef()
   const [style, setStyle] = useState(defaultStyle)
-  const [infos, setInfos] = useState(null)
-  const [tools, setTools] = useState(null)
   const [mapError, setMapError] = useState(error)
 
   const fitBounds = useCallback(bbox => {
@@ -86,14 +84,6 @@ function Map({hasSwitchStyle, bbox, defaultStyle, hasHash, defaultCenter, defaul
 
         {!mapError && isLoading && (
           <div className='tools'>Chargement…</div>
-        )}
-
-        {!isLoading && !mapError && infos && (
-          <div className='tools'>{infos}</div>
-        )}
-
-        {!isLoading && !mapError && tools && (
-          <div className='tools right'>{tools}</div>
         )}
 
         <ReactMap ref={map} hash={hasHash} maxZoom={19} interactive={isInteractive} initialViewState={{bounds: bbox, zoom: defaultZoom || DEFAULT_ZOOM, latitude: defaultCenter?.[1] || DEFAULT_CENTER[1], longitude: defaultCenter?.[0] || DEFAULT_CENTER[0]}} mapStyle={STYLES[style]}>

--- a/layouts/base-adresse-nationale.js
+++ b/layouts/base-adresse-nationale.js
@@ -1,6 +1,6 @@
 import {useContext, useState} from 'react'
 import PropTypes from 'prop-types'
-import {Map, Folder} from 'react-feather'
+import {Map as MapIcone, Folder} from 'react-feather'
 
 import theme from '@/styles/theme'
 
@@ -57,9 +57,9 @@ export function Mobile({address, bbox, handleSelect, hash}) {
 
       <div className={`mobile-container ${selectedLayout === 'map' ? 'show' : 'hidden'}`}>
         <MapLibre defaultCenter={center} defaultZoom={zoom} bbox={bbox} hasSwitchStyle hasHash>
-          {({...maplibreProps}) => (
-            <BanMap address={address} {...maplibreProps} onSelect={handleSelect} isMobile />
-          )}
+
+          <BanMap address={address} onSelect={handleSelect} bbox={bbox} />
+
         </MapLibre>
       </div>
 
@@ -80,7 +80,7 @@ export function Mobile({address, bbox, handleSelect, hash}) {
         <LayoutSelector
           name='Carte'
           value='map'
-          icon={Map}
+          icon={MapIcone}
           isSelected={selectedLayout === 'map'}
           handleClick={setSelectedLayout}
         />
@@ -152,9 +152,9 @@ export function Desktop({address, bbox, handleSelect, hash}) {
       </div>
 
       <MapLibre defaultCenter={center} defaultZoom={zoom} bbox={bbox} hasSwitchStyle hasHash>
-        {({...maplibreProps}) => (
-          <BanMap address={address} {...maplibreProps} onSelect={handleSelect} />
-        )}
+
+        <BanMap address={address} onSelect={handleSelect} bbox={bbox} />
+
       </MapLibre>
 
       <style jsx>{`

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-feather": "^2.0.10",
+    "react-map-gl": "^7.1.6",
     "recharts": "^2.8.0",
     "send": "^0.18.0",
     "sharp": "^0.29.3",

--- a/pages/deploiement-bal.js
+++ b/pages/deploiement-bal.js
@@ -14,7 +14,7 @@ import {getDepartements, getEpcis} from '@/lib/api-geo'
 
 import {useStatsDeploiement} from '@/hooks/stats-deploiement'
 
-import MapLibre from '@/components/maplibre'
+import {MapLegacy as MapLibre} from '@/components/maplibre'
 import BalCoverMap from '@/components/bases-locales/deploiement-bal/bal-cover-map'
 import PanelSource from '@/components/bases-locales/deploiement-bal/panel-source'
 import PanelBal from '@/components/bases-locales/deploiement-bal/panel-bal'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,7 +1508,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz#9aecf642cb00eab1080a57c4f949a65b4a5846d6"
   integrity sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==
 
-"@mapbox/jsonlint-lines-primitives@^2.0.2":
+"@mapbox/jsonlint-lines-primitives@^2.0.2", "@mapbox/jsonlint-lines-primitives@~2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
   integrity sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==
@@ -1533,6 +1533,11 @@
   resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
   integrity sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==
 
+"@mapbox/unitbezier@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz#d32deb66c7177e9e9dfc3bbd697083e2e657ff01"
+  integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
+
 "@mapbox/vector-tile@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
@@ -1544,6 +1549,18 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
+
+"@maplibre/maplibre-gl-style-spec@^19.2.1":
+  version "19.3.3"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz#a106248bd2e25e77c963a362aeaf630e00f924e9"
+  integrity sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==
+  dependencies:
+    "@mapbox/jsonlint-lines-primitives" "~2.0.2"
+    "@mapbox/unitbezier" "^0.0.1"
+    json-stringify-pretty-compact "^3.0.0"
+    minimist "^1.2.8"
+    rw "^1.3.3"
+    sort-object "^3.0.3"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -2077,6 +2094,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/geojson@*":
+  version "7946.0.13"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.13.tgz#e6e77ea9ecf36564980a861e24e62a095988775e"
+  integrity sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -2142,6 +2164,13 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/mapbox-gl@>=1.0.0":
+  version "2.7.19"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.7.19.tgz#d650c30496323a7d429b6f672bc45218c680bda0"
+  integrity sha512-pkRdlhQJNbtwcKJSVC4uuOA6M3OlOObIMhNecqHB991oeaDF5XkjSIRaTE0lh5p4KClptSCxW6MBiREVRHrl2A==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/mime@*":
   version "3.0.1"
@@ -2731,6 +2760,21 @@ bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+bytewise-core@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/bytewise-core/-/bytewise-core-1.2.3.tgz#3fb410c7e91558eb1ab22a82834577aa6bd61d42"
+  integrity sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==
+  dependencies:
+    typewise-core "^1.2"
+
+bytewise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/bytewise/-/bytewise-1.1.0.tgz#1d13cbff717ae7158094aa881b35d081b387253e"
+  integrity sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==
+  dependencies:
+    bytewise-core "^1.2.2"
+    typewise "^1.0.3"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -4404,7 +4448,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-get-value@^2.0.3, get-value@^2.0.6:
+get-value@^2.0.2, get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==
@@ -5316,6 +5360,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stringify-pretty-compact@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
+  integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
+
 json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -5701,6 +5750,11 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -6503,6 +6557,14 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-map-gl@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-7.1.6.tgz#4ea239cd49493cfc9ed15aa52436b024c757c0a9"
+  integrity sha512-9XbrvpFF67Fyi+e6vRLJFnGpo3UF6ZHifIa8cS/wUYSsnv9sVyzGsN++FJy57zkz3Jh3kmf0xKZemR8K0FZLVw==
+  dependencies:
+    "@maplibre/maplibre-gl-style-spec" "^19.2.1"
+    "@types/mapbox-gl" ">=1.0.0"
+
 react-resize-detector@^8.0.4:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-8.1.0.tgz#1c7817db8bc886e2dbd3fbe3b26ea8e56be0524a"
@@ -7091,6 +7153,28 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+sort-asc@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sort-asc/-/sort-asc-0.2.0.tgz#00a49e947bc25d510bfde2cbb8dffda9f50eb2fc"
+  integrity sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==
+
+sort-desc@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sort-desc/-/sort-desc-0.2.0.tgz#280c1bdafc6577887cedbad1ed2e41c037976646"
+  integrity sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==
+
+sort-object@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sort-object/-/sort-object-3.0.3.tgz#945727165f244af9dc596ad4c7605a8dee80c269"
+  integrity sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==
+  dependencies:
+    bytewise "^1.1.0"
+    get-value "^2.0.2"
+    is-extendable "^0.1.1"
+    sort-asc "^0.2.0"
+    sort-desc "^0.2.0"
+    union-value "^1.0.1"
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -7581,6 +7665,18 @@ typescript@^4.2.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
+typewise-core@^1.2, typewise-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/typewise-core/-/typewise-core-1.2.0.tgz#97eb91805c7f55d2f941748fa50d315d991ef195"
+  integrity sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==
+
+typewise@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/typewise/-/typewise-1.0.3.tgz#1067936540af97937cc5dcf9922486e9fa284651"
+  integrity sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==
+  dependencies:
+    typewise-core "^1.2.0"
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -7643,7 +7739,7 @@ unicode-trie@^2.0.0:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
-union-value@^1.0.0:
+union-value@^1.0.0, union-value@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
   integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==


### PR DESCRIPTION
Afin d'éviter les mélanges affichage et bouton via react et des fonctions impératives sur la carte (dom et event) qui compliquent la compréhension et sont source de bug, l'utilisation de la lib react-map-gl est proposée.

Cette mise en place permet également de résoudre le bug https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/issues/1552 de désynchronisation carte/ état des outils

fix #1672

Le composant d'initialisation d'une carte change de signature. L'ancien comportement est dans map-legacy.js.