### PR TITLE
Add anchor historical bal

### DIFF
--- a/components/commune/historique.js
+++ b/components/commune/historique.js
@@ -21,7 +21,7 @@ function Historique({revisions, communeName, communeCode, hasHistoryAdresses}) {
   }
 
   return (
-    <Section title='Historique des mises à jour de la Base Adresse Locale'>
+    <Section id='historical-bal' title='Historique des mises à jour de la Base Adresse Locale'>
       {hasHistoryAdresses ? (
         <div className='historique-wrapper'>
           <h4><RefreshCw size={25} alt='' aria-hidden='true' /> Retrouvez les cinq dernières mises à jour</h4>


### PR DESCRIPTION
## Context

Dans l'application mes-adresses, nous avons besoin de visualiser directement l'historique des publication de BAL.

## Fonctionnalité

Ajout d'un id ancre `historical-bal` sur la page commune pour que l'historique soit directement accessible via l'url `/commune/codeCommune#historical-bal`