### PR TITLE
Fix: Analytics do not receive data from backend download

### DIFF
--- a/lib/util/analytics-tracker.js
+++ b/lib/util/analytics-tracker.js
@@ -3,8 +3,7 @@
 // https://developer.matomo.org/api-reference/tracking-api
 
 import os from 'node:os'
-
-const getEnvMode = () => process.env?.NODE_ENV !== 'production'
+import getConfig from 'next/config'
 
 const logMatomoError = err => {
   console.log('error tracking request:', err)
@@ -16,14 +15,18 @@ const encodeParams = params => Object.fromEntries(
     .map(([key, value]) => [key, typeof value === 'string' ? encodeURIComponent(value) : value]),
 )
 
-export const getTrackEvent = ({category, action, name, value = 1}) => ({
-  e_c: encodeURIComponent(`${getEnvMode() ? 'DEVMODE - ' : ''}${category}`), // Category name
-  e_a: encodeURIComponent(action), // Action name
-  e_n: encodeURIComponent(name), // Name
-  e_v: value, // Value
-})
+export const getTrackEvent = ({category, action, name, value = 1}) => {
+  const {isDevMode} = getConfig().publicRuntimeConfig
 
-export const getDownloadTrackEvent = ({
+  return {
+    e_c: `${isDevMode ? 'DEVMODE - ' : ''}${category}`, // Category name
+    e_a: action, // Action name
+    e_n: name, // Name
+    e_v: value, // Value
+  }
+}
+
+export const getDownloadToEventTracker = ({
   downloadDataType,
   downloadFileName,
   nbDownload = 1,
@@ -33,7 +36,6 @@ export const getDownloadTrackEvent = ({
 
   return {
     url,
-    download: url,
     trackEvent: {
       category: 'Download',
       action: `Download Data ${downloadDataType}`,
@@ -50,28 +52,27 @@ export const sendToTracker = async (params = {}) => {
     NEXT_PUBLIC_MATOMO_SITE_ID: MATOMO_SITE_ID,
     MATOMO_TOKEN_AUTH,
   } = process.env
-  const matomoUrl = `${MATOMO_URL}/matomo.php`
 
-  const safeOtherParams = encodeParams(otherParams)
   const requiredParams = {
     idsite: MATOMO_SITE_ID,
     rec: 1,
-    ua: ua || encodeURIComponent(`${os.hostname()} / Node.JS ${process.version} / ${os.version()}`),
+    ua: ua || `${os.hostname()} / Node.JS ${process.version} / ${os.version()}`,
     ...(MATOMO_TOKEN_AUTH ? {token_auth: MATOMO_TOKEN_AUTH} : {}),
   }
-  const urlSearchParams = new URLSearchParams({
-    ...requiredParams,
-    ...safeOtherParams,
-    ...(url ? {url: encodeURIComponent(url)} : {}),
-    ...(download ? {download: encodeURIComponent(download)} : {}),
-    ...(trackEvent ? getTrackEvent(trackEvent) : {}),
-  })
+  const urlSearchParams = new URLSearchParams(
+    encodeParams({
+      ...requiredParams,
+      ...otherParams,
+      ...(url ? {url} : {}),
+      ...(download ? {download} : {}),
+      ...(trackEvent ? getTrackEvent(trackEvent) : {}),
+    })
+  ).toString()
+
+  const matomoUrl = `${MATOMO_URL}/matomo.php${urlSearchParams ? `?${urlSearchParams}` : ''}`
 
   try {
-    const sentToMatomoWithHTTP = await fetch(matomoUrl, {
-      method: 'POST',
-      body: urlSearchParams,
-    })
+    const sentToMatomoWithHTTP = await fetch(matomoUrl, {method: 'POST'})
 
     if (sentToMatomoWithHTTP.status !== 200) {
       throw new Error(`Matomo HTTP API returned ${sentToMatomoWithHTTP.status}`)

--- a/pages/data/[[...path]].js
+++ b/pages/data/[[...path]].js
@@ -8,7 +8,7 @@ import Head from '@/components/head'
 import Section from '@/components/section'
 import Page from '@/layouts/main'
 import Data from '@/views/data'
-import sendToTracker, {getDownloadTrackEvent} from '@/lib/util/analytics-tracker'
+import sendToTracker, {getDownloadToEventTracker} from '@/lib/util/analytics-tracker'
 
 import ErrorPage from '../_error'
 
@@ -138,7 +138,7 @@ export async function getServerSideProps(context) {
   }
 
   try {
-    sendToTracker(getDownloadTrackEvent({
+    sendToTracker(getDownloadToEventTracker({
       downloadDataType: `${path.dirname(fileName).split('/')[0]}${req?.headers?.range ? ' (Partial)' : ''}`,
       downloadFileName: fileName,
       nbDownload: 1


### PR DESCRIPTION
Actuellement, les téléchargement qui on lieu sur l'URL `/data` ne sont pas comptabilisé parmi les évènements de Matomo. Cette PR a pour but de corriger cette erreur.

### Comment tester :

- S'assurer d'avoir : 
   - Un fichier `.env` à jour 
   - Une valeur définit pour la variable `PATH_STATIC_FILE` de ce fichier `.env`, qui pointe sur un dossier de votre disque dur (qui, idéalement, possède quelques fichiers CSV, PDF ou autre - ⚠ Les noms de ces fichiers seront remontés dans Matomo ⚠). Ex : PATH_STATIC_FILE=/User/user_name/repertoire_de_test_possedant_quelques_fichiers/ 
   - Des valeurs valide pour les variable `NEXT_PUBLIC_MATOMO_URL` et `NEXT_PUBLIC_MATOMO_SITE_ID` du fichier `.env`
   - Un token valide pour la variable `MATOMO_TOKEN_AUTH` du fichier `.env`
- Démarrer le projet en mode DEV : `yarn dev`
 - Se rendre sur l'URL `localhost:3000/data` (si besoin, adapter l'URL selon votre propre configuration)
 - Télécharger quelques fichiers visibles dans la liste.
 - Apres un (long... Très longgggg...) moment, vérifier sur Matomo que les évènement ait bien était remonté : 
    - L'évènement `DEVMODE - Download` devrait être présent (`DEVMODE` sera présent car le projet est lancé en mode développement) 
    - L'évènement `DEVMODE - Download` devrait posséder pour valeurs, les nom des fichiers téléchargés.