### PR TITLE
Fix home page stats dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Environment config
+.env*
+
+# Runtime
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Logs
+logs
+*.log
+npm-debug.log*
+CHANGELOG.md
+
+# Mac
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Build
+.next
+
+# Cache
+.yarn-cache
+.npm
+.eslintcache
+.changelog
+
+# Node
+node_modules
+
+# Reports
+coverage
+reports
+
+# Git config
+.git
+.github
+.gitignore
+
+#Editor Config
+.editorconfig
+
+#Docker config
+Dockerfile*
+docker-compose.yml
+.dockerignore
+
+#Babel config
+.babelrc
+
+#Scalingo config
+scalingo.json
+
+#Other
+*.md
+LICENSE

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM node:16.19.0-alpine
 WORKDIR /app
 
 # installing dependencies
-COPY package.json yarn.lock .
+COPY package.json yarn.lock ./
 RUN mkdir public
 RUN yarn install
 

--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -111,9 +111,11 @@ const BasesLocales = React.memo(({stats}) => {
         </div>
       </Section>
 
-      <Section background='color' title='État du déploiement des Bases Adresses Locales'>
-        <MapBalSection stats={stats} />
-      </Section>
+      {stats && (
+        <Section background='color' title='État du déploiement des Bases Adresses Locales'>
+          <MapBalSection stats={stats} />
+        </Section>
+      )}
 
       <style jsx>{`
         .notification-content {

--- a/components/maplibre/ban-map/index.js
+++ b/components/maplibre/ban-map/index.js
@@ -31,6 +31,8 @@ import {flatten, forEach} from 'lodash'
 import DeviceContext from '@/contexts/device'
 import {Layer, Source, useMap, Popup} from 'react-map-gl/maplibre'
 
+const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr'
+
 let hoveredFeature = null
 
 const SOURCES = ['adresses', 'toponymes']
@@ -322,7 +324,7 @@ function BanMap({address, bbox, onSelect, isMobile}) {
         type='vector'
         format='pbf'
         tiles={[
-          'https://plateforme.adresse.data.gouv.fr/tiles/ban/{z}/{x}/{y}.pbf'
+          `${API_BAN_URL}/tiles/ban/{z}/{x}/{y}.pbf`
         ]}
         minzoom={10}
         maxzoom={14}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,42 @@ services:
       dockerfile: 'Dockerfile.dev'
     container_name: frontend
     volumes:
-    - ./:/app
-    - /app/node_modules
-    - /app/.next
+      - ./build/:/app/build
+      - ./components/:/app/components
+      - ./contexts/:/app/contexts
+      - ./data/:/app/data
+      - ./hooks/:/app/hooks
+      - ./layouts/:/app/layouts
+      - ./lib/:/app/lib
+      - ./pages/:/app/pages
+      - ./public/:/app/public
+      - ./scripts/:/app/scripts
+      - ./server/:/app/server
+      - ./styles/:/app/styles
+      - ./views/:/app/views
+      - ./events.json:/app/events.json
+      - ./next.config.js:/app/next.config.js
+      - ./.babelrc:/app/.babelrc
     ports:
-      - "${PORT:-3000}:${PORT:-3000}"
+      - "${PORT:-3000}:3000"
+    environment:
+      - NEXT_PUBLIC_ADRESSE_URL=${NEXT_PUBLIC_ADRESSE_URL}
+      - NEXT_PUBLIC_API_GEO_URL=${NEXT_PUBLIC_API_GEO_URL}
+      - NEXT_PUBLIC_API_BAN_URL=${NEXT_PUBLIC_API_BAN_URL}
+      - NEXT_PUBLIC_API_ADRESSE=${NEXT_PUBLIC_API_ADRESSE}
+      - NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=${NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC}
+      - NEXT_PUBLIC_MATOMO_URL=${NEXT_PUBLIC_MATOMO_URL}
+      - NEXT_PUBLIC_MATOMO_SITE_ID=${NEXT_PUBLIC_MATOMO_SITE_ID}
+      - MATOMO_TOKEN_AUTH=${MATOMO_TOKEN_AUTH}
+      - ENABLE_HELMET=${ENABLE_HELMET}
+      - NEXT_PUBLIC_API_DEPOT_URL=${NEXT_PUBLIC_API_DEPOT_URL}
+      - API_DEPOT_TOKEN=${API_DEPOT_TOKEN}
+      - SESSION_SECRET=${SESSION_SECRET}
+      - NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED=${NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED}
+      - PATH_STATIC_FILE=${PATH_STATIC_FILE}
+      - GHOST_KEY=${GHOST_KEY}
+      - NEXT_PUBLIC_GHOST_URL=${NEXT_PUBLIC_GHOST_URL}
+      - NEXT_PUBLIC_GHOST_URL_IMAGES_SOURCE=${NEXT_PUBLIC_GHOST_URL_IMAGES_SOURCE}
+      - NEXT_PUBLIC_BAL_ADMIN_API_URL=${NEXT_PUBLIC_BAL_ADMIN_API_URL}
+      - NEXT_PUBLIC_BAL_API_URL=${NEXT_PUBLIC_BAL_API_URL}
+      - NEXT_PUBLIC_MES_ADRESSES=${NEXT_PUBLIC_MES_ADRESSES}

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -3,24 +3,30 @@ import HttpError from './http-error'
 export const API_BAN_URL = process.env.NEXT_PUBLIC_API_BAN_URL || 'https://plateforme.adresse.data.gouv.fr'
 
 export async function _fetch(url, customOptions = {}) {
-  const options = {
-    mode: 'cors',
-    method: 'GET',
-    ...customOptions
+  try {
+    const options = {
+      mode: 'cors',
+      method: 'GET',
+      ...customOptions
+    }
+
+    const response = await fetch(url, options)
+    const contentType = response.headers.get('content-type')
+
+    if (!response.ok) {
+      throw new HttpError(response)
+    }
+
+    if (response.ok && contentType && contentType.includes('application/json')) {
+      return response.json()
+    }
+
+    throw new Error('Une erreur est survenue')
+  } catch (error) {
+    console.error(error)
   }
 
-  const response = await fetch(url, options)
-  const contentType = response.headers.get('content-type')
-
-  if (!response.ok) {
-    throw new HttpError(response)
-  }
-
-  if (response.ok && contentType && contentType.includes('application/json')) {
-    return response.json()
-  }
-
-  throw new Error('Une erreur est survenue')
+  return null
 }
 
 export function getAddress(idAddress) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -180,11 +180,12 @@ export async function getServerSideProps() {
 }
 
 Home.defaultProps = {
-  posts: null
+  posts: null,
+  stats: null
 }
 
 Home.propTypes = {
-  stats: PropTypes.object.isRequired,
+  stats: PropTypes.object,
   posts: PropTypes.array
 }
 

--- a/pages/programme-bal.js
+++ b/pages/programme-bal.js
@@ -177,9 +177,11 @@ function ProgrammeBAL({stats}) {
               <img className='fr-responsive-img' src='/images/bal-landing-page/checkbox.png' alt='' width='100%' />
             </div>
           </div>
-          <div style={{marginTop: 50}} className='fr-grid-row'>
-            <h2>Déjà <strong>{stats.bal.nbCommunesCouvertes}</strong> communes ont mis jour leurs bases d’adresses</h2>
-          </div>
+          {stats && (
+            <div style={{marginTop: 50}} className='fr-grid-row'>
+              <h2>Déjà <strong>{stats.bal.nbCommunesCouvertes}</strong> communes ont mis jour leurs bases d’adresses</h2>
+            </div>
+          )}
           <div className='fr-grid-row space-between-row'>
             <div className='fr-col-md-5 verbatim-card'>
               <Image src='/images/bal-landing-page/verbatim.svg' alt='icone verbatim' width={30} height={30} />
@@ -377,8 +379,12 @@ export async function getServerSideProps() {
   }
 }
 
+ProgrammeBAL.defaultProps = {
+  stats: null,
+}
+
 ProgrammeBAL.propTypes = {
-  stats: PropTypes.object.isRequired,
+  stats: PropTypes.object,
 }
 
 export default ProgrammeBAL


### PR DESCRIPTION
# Context

Currently on adresse.data.gouv, if there is an issue with ban-plateforme API, some pages, the home page included, will display an error message (error 404 or error 500)

# Enhancement

This PR aims to withdraw the stats dependencies on : 
- the "Home" page
- the "Programme Bal" page


Before : 

Home page & Programme Bal page  : 
<img width="1440" alt="Capture d’écran 2024-01-12 à 16 20 28" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/92ea093b-2649-485a-adac-2237b080f813">

After : 

Home Page : 
<img width="1456" alt="Capture d’écran 2024-01-12 à 16 32 21" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/2a2270d8-0de7-40ba-b5fe-f805dc35449c">

--------------------------------------------------------

<img width="1308" alt="Capture d’écran 2024-01-12 à 16 32 33" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/d6a1ec93-9ce3-4237-af29-ebb1665eca37">


Programme Bal : 
<img width="1339" alt="Capture d’écran 2024-01-12 à 16 19 40" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/9eefaef1-cac3-4f10-bc3c-b3526d8f3a89">

--------------------------------------------------------

<img width="1412" alt="Capture d’écran 2024-01-12 à 16 33 16" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/9cc1536f-311a-4cbf-a140-599392f45155">




