### PR TITLE
update: version validateur 2.18.2

### DIFF
--- a/components/bases-locales/validator/index.js
+++ b/components/bases-locales/validator/index.js
@@ -1,6 +1,7 @@
 import {useState, useEffect} from 'react'
 import {validate, profiles} from '@ban-team/validateur-bal'
 import {Check, X} from 'react-feather'
+import Link from 'next/link'
 
 import {getFileExtension} from '@/lib/bal/file'
 
@@ -85,14 +86,35 @@ function BALValidator() {
             {Object.values(profiles).filter(p => p.isUsed).map(p => (
               <option key={p.code} value={p.code}>
                 {p.name}
-                {defaultProfil === p.code && ' (défaut)'}
               </option>
             ))}
           </select>
         </div>
-        <ButtonLink href='/bases-locales/validator-documentation' title='Documentation Validateur'>
-          Documentation
-        </ButtonLink>
+        <div>
+          <ButtonLink href='/bases-locales/validator-documentation' title='Documentation Validateur'>
+            Documentation du validateur
+          </ButtonLink>
+        </div>
+      </div>
+      <div>
+        <Link
+          style={{display: 'block'}}
+          href='https://aitf-sig-topo.github.io/voies-adresses/files/AITF_SIG_Topo_Format_Base_Adresse_Locale_v1.3.pdf'
+          target='_blank'
+          rel='noreferrer'
+          title='Documentation du format BAL 1.3'
+        >
+          Documentation du format BAL 1.3
+        </Link>
+        <Link
+          style={{display: 'block'}}
+          href='https://aitf-sig-topo.github.io/voies-adresses/files/AITF_SIG_Topo_Format_Base_Adresse_Locale_v1.4.pdf'
+          target='_blank'
+          rel='noreferrer'
+          title='Documentation du format BAL 1.4'
+        >
+          Documentation du format BAL 1.4
+        </Link>
       </div>
       {inProgress &&
         <Section title='Analyse en cours'>
@@ -126,7 +148,6 @@ function BALValidator() {
         }
         .profil-selector {
           display: flex;
-          align-items: self-end;
         }
         .profil-selector > label {
           margin-right: 10px;

--- a/components/bases-locales/validator/validateur-documentation/index.js
+++ b/components/bases-locales/validator/validateur-documentation/index.js
@@ -14,15 +14,26 @@ function ValidatorDocumentation() {
         <p>Il est utilisé pour s&apos;assurer avant la publication que toutes les adresses d&apos;une BAL remonteront correctement dans la Base Adresse Nationale.</p>
 
         <span>
-          Il existe deux profils sur le validateur :
+          Il existe trois profils sur le validateur :
           <ul>
-            <li><strong>BAL 1.3</strong> est le profil par défaut. Il assure une conformité complète avec la spécification de l&apos;AITF.</li>
-            <li><strong>BAL 1.3 Relax </strong> est un profil exceptionnel déprécié. Il permet plus de tolérance tout en assurant une intégrité minimale de la donnée adresse.</li>
+            <li>
+              <a href='https://aitf-sig-topo.github.io/voies-adresses/files/AITF_SIG_Topo_Format_Base_Adresse_Locale_v1.3.pdf' target='_blank' rel='noreferrer'>
+                <strong>BAL 1.3</strong>
+              </a> est le profil par défaut. Il permet plus de tolérance tout en assurant une intégrité minimale de la donnée adresse.</li>
+            <li>
+              <a href='https://aitf-sig-topo.github.io/voies-adresses/files/AITF_SIG_Topo_Format_Base_Adresse_Locale_v1.3.pdf' target='_blank' rel='noreferrer'>
+                <strong>BAL 1.3 Strict</strong>
+              </a> Il assure une conformité complète avec la spécification de l&apos;AITF.</li>
+            <li>
+              <a href='https://aitf-sig-topo.github.io/voies-adresses/files/AITF_SIG_Topo_Format_Base_Adresse_Locale_v1.4.pdf' target='_blank' rel='noreferrer'>
+                <strong>BAL 1.4 Strict (beta)</strong>
+              </a> est le profil du format BAL 1.4. Il prend en compte les spécification relatif aux nouvelles colonne id_ban_commune, id_ban_toponyme et id_ban_adresse.</li>
           </ul>
         </span>
 
         <p>Si le fichier est invalide, le validateur BAL affiche un rapport en deux parties.</p>
         <span>
+          <h2>Validation générale</h2>
           Tout d&apos;abord une validation générale sur tout le fichier qui renvoie les éléments suivants :
           <ul>
             <li><strong>Les erreurs</strong> sont bloquantes et entraînent un rejet du fichier BAL. Il sera considéré comme non valide.</li>
@@ -34,6 +45,7 @@ function ValidatorDocumentation() {
         ))}
         <br />
         <span>
+          <h2>Validation ligne par ligne</h2>
           Puis une validation adresse par adresse qui renvoie les éléments suivants :
           <ul>
             <li><strong>Les erreurs</strong> sont bloquantes et entraînent un rejet de l&apos;adresse concernée. La BAL publiée sera alors incomplète.</li>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.7",
     "@ban-team/shared-data": "^1.2.0",
-    "@ban-team/validateur-bal": "^2.16.0",
+    "@ban-team/validateur-bal": "^2.18.2",
     "@codegouvfr/react-dsfr": "^0.41.0",
     "@etalab/decoupage-administratif": "^3.0.0",
     "@react-pdf/renderer": "^3.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,10 +1345,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.2.0.tgz#0e29e84a00f7df3b17e5821bde1405a2bfa656b5"
   integrity sha512-35jz6ITHHufUKxXAfa8ReSMl6lZarnfVBkS++wgHpk27e9K52bXyAHo+n3X331n2mSzoIQXxFK7SEcPob7a5cA==
 
-"@ban-team/validateur-bal@^2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.16.0.tgz#0ef7754334e58dc9cc80a791731616b5cd82a896"
-  integrity sha512-OO/rpOfnU7VfzAH57v6pQttoMCNnHB5sKFmLUtFJ6AGGsgvZJoUJ32XAGvofK5QVHvT7QUv/Xrn21zpoo0Lx9A==
+"@ban-team/validateur-bal@^2.18.2":
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.18.2.tgz#59266d403285acdc012d7eb23bd6d89d94c6ffa8"
+  integrity sha512-TSACYhyS6NNs7Pc/gk1xdCsgUkPqFwC88shECOMcMby3RiheA2viWzBLIExH+uO+LqJBfOLTgYS6lwFwPQPOHQ==
   dependencies:
     "@ban-team/shared-data" "^1.2.0"
     "@etalab/project-legal" "^0.6.0"
@@ -1361,6 +1361,7 @@
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
     papaparse "^5.3.2"
+    uuidv4 "^6.2.13"
     yargs "^17.5.1"
 
 "@codegouvfr/react-dsfr@^0.41.0":
@@ -2236,6 +2237,11 @@
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.0.tgz#199a3f473f0c3a6f6e4e1b17cdbc967f274bdc6b"
   integrity sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==
+
+"@types/uuid@8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@typescript-eslint/eslint-plugin@^4.22.0":
   version "4.33.0"
@@ -7848,6 +7854,19 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuidv4@^6.2.13:
+  version "6.2.13"
+  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.2.13.tgz#8f95ec5ef22d1f92c8e5d4c70b735d1c89572cb7"
+  integrity sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==
+  dependencies:
+    "@types/uuid" "8.3.4"
+    uuid "8.3.2"
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
## Context

- Mise a jour du package validateur-bal v2.18.2 qui prends en compte le format BAL 1.4 et les erreurs relatif a id_ban_commune, id_ban_toponyme et id_ban_adresses

- Un seul nouveau profile mis en ligne pour le moment, pour ne pas trop embrouillé les utilisateur avec les différents profiles du format 1.4

- Mise a jour de la documentation du validateur

## Resultat

![Capture d’écran 2024-03-11 à 16 56 48](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/1c5a8a3f-e0f4-46e0-80dc-71be44ba7f99)

![Capture d’écran 2024-03-11 à 16 57 16](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/4de7b631-eb90-47ad-832a-995e6fc6cfbd)

