### PR TITLE
Updates curl-doc.js

### DIFF
--- a/components/api-doc/api-adresse/curl-doc.js
+++ b/components/api-doc/api-adresse/curl-doc.js
@@ -126,6 +126,7 @@ function CurlDoc() {
             <p>On peut utiliser le fichier <a href='https://adresse.data.gouv.fr/exemples/search.csv'>https://adresse.data.gouv.fr/exemples/search.csv</a> comme exemple.</p>
             <pre><code>curl -X POST -F data=@search.csv -F columns=adresse -F columns=postcode https://api-adresse.data.gouv.fr/search/csv/</code></pre>
             <p>Enfin, en cas d’industrialisation du géocodage, il peut être pertinent de lister spécifiquement les champs attendus dans la réponse, pour limiter la taille du fichier obtenu, et donc accélérer le transfert et réduire l’empreinte carbone.</p>
+            <p>Les champs disponibles sont : latitude, longitude, result_label, result_score, result_score_next, result_type, result_id, result_housenumber, result_name, result_street, result_postcode, result_city, result_context, result_citycode, result_oldcitycode, result_oldcity, result_district et result_status.</p>
             <pre><code>curl -X POST -F data=@search.csv -F columns=adresse -F columns=postcode -F result_columns=result_id -F result_columns=score https://api-adresse.data.gouv.fr/search/csv/</code></pre>
           </div>
         </div>


### PR DESCRIPTION
Ajout des champs disponibles pour le point de terminaison `/search/csv`. En effet actuellement un utilisateur est tenté d'utiliser les noms des attributs présents dans les réponses des autres points de terminaison alors que le CSV retourné par ce point de terminaison utilise des noms de champs différents.
Je les ai ajouté sous la forme d'un paragraphe mais la ligne est assez longue, cela vaut peut être le coup de le présenter sous forme de liste et peut être d'ajouter un exemple du CSV renvoyé par l'API en réponse.