### PR TITLE
Added new DILA api route to get mairie info

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -4,7 +4,7 @@ NEXT_PUBLIC_ADRESSE_URL=http://localhost:3000
 #  Parametres URL Externe autre projet BAN
 # ---------------------------------------------------------------------------------------------------------------
 NEXT_PUBLIC_API_GEO_URL=https://geo.api.gouv.fr/2023
-NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=https://etablissements-publics.api.gouv.fr/v3
+NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC=https://api-lannuaire.service-public.fr/api/explore/v2.1
 
 NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
 NEXT_PUBLIC_API_ADRESSE=https://api-adresse.data.gouv.fr

--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -40,12 +40,11 @@ function Partner({partnerInfos, isCommune}) {
   const getMairieInfos = useCallback(async () => {
     if (isCommune && codeCommune) {
       const mairie = await getMairie(codeCommune)
-      const {properties} = mairie.features[0]
 
       setMairieContact(
         {
-          mail: properties.email,
-          phone: properties.telephone
+          mail: mairie.email,
+          phone: mairie.telephone
         }
       )
     }

--- a/components/search-commune-contact/index.js
+++ b/components/search-commune-contact/index.js
@@ -26,10 +26,9 @@ function SearchCommuneContact() {
     setLoading(true)
     setMairie(null)
 
-    const results = await getMairie(commune.code)
-    const mairie = results.features[0]
+    const mairie = await getMairie(commune.code)
     if (mairie) {
-      setMairie(results.features[0].properties)
+      setMairie(mairie)
     } else {
       const error = new Error(`Aucune information disponible pour la mairie de ${commune.nom}.`)
       setError(error)

--- a/lib/api-etablissements-public.js
+++ b/lib/api-etablissements-public.js
@@ -1,7 +1,5 @@
 import getConfig from 'next/config'
 
-import {isCOM} from '@/lib/ban'
-
 import HttpError from './http-error'
 
 const {NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC: API_ETABLISSEMENTS_PUBLIC} = getConfig().publicRuntimeConfig
@@ -30,9 +28,48 @@ export async function _fetch(url) {
   throw new Error('Une erreur est survenue')
 }
 
-export function getMairie(codeCommune) {
-  const type = isCOM(codeCommune) && 'mairie_com'
-  const url = `${API_ETABLISSEMENTS_PUBLIC}/communes/${codeCommune}/${type ? type : 'mairie'}`
+const formatMairie = rawMairie => {
+  return {
+    nom: rawMairie.nom,
+    telephone: rawMairie.telephone ? JSON.parse(rawMairie.telephone)[0]?.valeur : undefined,
+    email: rawMairie.adresse_courriel,
+    horaires: rawMairie.plage_ouverture ? JSON.parse(rawMairie.plage_ouverture).map(openingRange => formatOpeningRange(openingRange)) : undefined
+  }
+}
 
-  return _fetch(url)
+const formatOpeningRange = openingRange => {
+  return {
+    du: openingRange.nom_jour_debut,
+    au: openingRange.nom_jour_fin,
+    heures: formatOpeningHourRange(openingRange)
+  }
+}
+
+const formatOpeningHourRange = openingRange => {
+  const totalTimeRange = Object.entries(openingRange).filter(([key, value]) => key.includes('valeur_heure_debut') && value).length
+  const openingTimeRanges = []
+  for (let i = 1; i <= totalTimeRange; i++) {
+    openingTimeRanges.push({
+      de: openingRange[`valeur_heure_debut_${i}`],
+      a: openingRange[`valeur_heure_fin_${i}`]
+    })
+  }
+
+  return openingTimeRanges
+}
+
+export async function getMairie(codeCommune) {
+  // Documentation : https://api-lannuaire.service-public.fr/explore/dataset/api-lannuaire-administration/information/
+  const route = 'catalog/datasets/api-lannuaire-administration/records'
+  const query = `select=plage_ouverture,nom,telephone,adresse_courriel&where=code_insee_commune="${codeCommune}" and pivot LIKE "mairie"`
+  const url = `${API_ETABLISSEMENTS_PUBLIC}/${route}?${query}`
+
+  const response = await _fetch(url)
+  const rawMairie = response?.results?.[0]
+  if (!rawMairie) {
+    return null
+  }
+
+  const mairie = formatMairie(rawMairie)
+  return mairie
 }

--- a/pages/commune/[codeCommune].js
+++ b/pages/commune/[codeCommune].js
@@ -61,7 +61,7 @@ Commune.getInitialProps = async ({query}) => {
   return {
     codeCommune,
     communeInfos: commune,
-    mairieInfos: mairie.features[0]?.properties,
+    mairieInfos: mairie,
     revisions,
     currentRevision,
     typeCompositionAdresses


### PR DESCRIPTION
# Context

The api used to get "mairie"  information (name, email, telephone and opening hours) is now deprecated : https://api.gouv.fr/les-api/api_etablissements_publics (deprecated)
The new API to use is the one from the DILA : https://api.gouv.fr/les-api/api-annuaire-administration-services-publics

# Enhancement

This PR : 
- Replace the deprecated api by the DILA api
- Format the result to get same format used in our code to display "mairie" information.

# How to test 

1- Clone this branch and start the app
2- Scroll down the main page in the section "Obtenez des informations sur les adresses d’une commune" and search for any "commune". Select a "commune" : it will open the "commune" page with all the related info. (exemple for "Bordeaux" : `localhost:5000/commune/33063` <= adapt the port if you are running the app on another port than `5000`)
3- Scroll down the "commune" page to the section "Contacter la commune" and click on the button "Contacter la mairie".
4- It opens a modal with the "mairie" information : name, email, phone number and opening hours

<img width="1431" alt="Capture d’écran 2024-04-10 à 11 02 22" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/b1182402-c873-4961-a724-20bc73eb3860">

5- You can also go to the "contact" page : `http://localhost:5000/nous-contacter` <= adapt the port if you are running the app on another port than `5000`
6- Click on the button : "Je suis un particulier ou une entreprise et j’ai constaté une adresse manquante ou incorrecte."
7- In the search field, enter a "commune" and click on the selected one.
8- It should display the "mairie" information also.

<img width="1231" alt="Capture d’écran 2024-04-10 à 11 02 47" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/52679050/2b280a26-0f2b-4b0d-917c-9def0f644082">
