### PR TITLE
Ajout events 04 Juin Rencontre utilisateurs

### DIFF
--- a/events.json
+++ b/events.json
@@ -378,5 +378,27 @@
     "instructions": "",
     "startHour": "10:30",
     "endHour": "12:00"
+  },
+  {
+    "title": "Adresse_Lab",
+    "subtitle": "Rencontre Utilisateurs Nationaux #4",
+    "description": "Journée d'échanges entre les utilisateurs experts de la BAN autour des problématiques communes : emprise d’utilisation large incluant des données d’assemblages, besoin d’historisation de la donnée (souvent lié à la problématique d’adosser des données métier aux adresses de la BAN), des besoins spécifiques sur la qualité et la mise à jour des données.",
+    "type": "adresselab",
+    "target": "SI nationaux utilisateurs avancés de la donnée adresse",
+    "date": "2024-06-04",
+    "tags": ["Technique", "Base Adresse Nationale", "Utilisateurs"],
+    "isOnlineOnly": false,
+    "address": {
+      "nom": "IGN",
+      "numero": "73",
+      "voie": "Avenue de Paris",
+      "codePostal": "94160",
+      "commune": "Saint-Mandé"
+    },
+    "href": "",
+    "isSubscriptionClosed": true,
+    "instructions": "",
+    "startHour": "09:30",
+    "endHour": "16:00"
   }
 ]


### PR DESCRIPTION
Ajout événement rencontre utilisateurs le 04 Juin
 
![Capture d’écran du 2024-05-07 09-34-03](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/a320b394-d9dc-4e9d-8f6d-4ab0328bbac1)

![Capture d’écran du 2024-05-07 09-33-41](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/35707a3a-f41a-40e4-bfe3-00cced8a4e49)

Fix #1736 