### PR TITLE
Add space between number and suffix

### DIFF
--- a/lib/ban.js
+++ b/lib/ban.js
@@ -1,13 +1,13 @@
 export function getNumeroComplet({numero, suffixe}) {
-  suffixe = suffixe?.trim() // Supprime les espaces en début et fin de chaîne
-  const suffixeCode = suffixe?.codePointAt(0) || null
+  const suffixeTrim = suffixe?.trim() // Supprime les espaces en début et fin de chaîne
+  const suffixeCode = suffixeTrim?.codePointAt(0) || null
 
   // Check if suffixeCode is a String number
   if (suffixeCode > 47 && suffixeCode < 58) {
-    return `${numero}-${suffixe || ''}`
+    return `${numero}-${suffixeTrim || ''}`
   }
 
-  return `${numero} ${suffixe || ''}`
+  return `${numero} ${suffixeTrim || ''}`
 }
 
 export function isCOM(codeCommune) {

--- a/lib/ban.js
+++ b/lib/ban.js
@@ -1,4 +1,5 @@
 export function getNumeroComplet({numero, suffixe}) {
+  suffixe = suffixe?.trim() // Supprime les espaces en début et fin de chaîne
   const suffixeCode = suffixe?.codePointAt(0) || null
 
   // Check if suffixeCode is a String number
@@ -6,7 +7,7 @@ export function getNumeroComplet({numero, suffixe}) {
     return `${numero}-${suffixe || ''}`
   }
 
-  return `${numero}${suffixe || ''}`
+  return `${numero} ${suffixe || ''}`
 }
 
 export function isCOM(codeCommune) {

--- a/lib/ban.js
+++ b/lib/ban.js
@@ -7,6 +7,10 @@ export function getNumeroComplet({numero, suffixe}) {
     return `${numero}-${suffixeTrim || ''}`
   }
 
+  if (suffixeTrim && suffixeTrim.length === 1) {
+    return `${numero}${suffixeTrim}`
+  }
+
   return `${numero} ${suffixeTrim || ''}`
 }
 


### PR DESCRIPTION
Issue #1738 
Dans le panneau latéral, les suffixes sont collés.

Exemple :
avant : 
![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/47464438/63473fe9-0b3e-449c-818e-38f07f09cdea)


Après :
![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/47464438/80354b88-ad20-4368-872e-7b2e5afcf432)
