### PR TITLE
Ajout adresse Lab T3 2024

### DIFF
--- a/events.json
+++ b/events.json
@@ -400,5 +400,21 @@
     "instructions": "",
     "startHour": "09:30",
     "endHour": "16:00"
+  },
+  {
+    "title": "Adresse_Lab",
+    "subtitle": "Point d'échange trimestriel T3 2024",
+    "description": "Actualités et point d'avancement des chantiers en cours. Il n’est pas nécessaire de « s’inscrire à l’événement ». Le lien d’inscription correspond au lien à utiliser pour se connecter au webinaire.",
+    "type": "adresselab",
+    "target": "utilisateurs de la donnée adresse",
+    "date": "2024-06-25",
+    "tags": ["Technique", "Base Adresse Nationale", "Utilisateurs"],
+    "isOnlineOnly": true,
+    "address": {},
+    "href": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_Y2QwZDU3OWEtM2I5My00ZjliLTllODEtYjdkZjY3ZjAxMGYz%40thread.v2/0?context=%7b%22Tid%22%3a%223876b373-7e2c-4857-b024-53326b5b4bb2%22%2c%22Oid%22%3a%22b6c5bcc6-2261-4874-9aa5-508a6afa334e%22%7d",
+    "isSubscriptionClosed": false,
+    "instructions": "",
+    "startHour": "10:30",
+    "endHour": "12:00"
   }
 ]


### PR DESCRIPTION
Ajout adresse Lab T3 2024 du mardi 25 Juin 
Fix: #1754 
![Capture d’écran du 2024-06-05 15-14-57](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/b67ce9de-e4a5-4b99-bb9f-ad4db2de1e92)
![Capture d’écran du 2024-06-05 15-14-39](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/7579317/83213ca1-951b-4fe8-bcc6-d1943c4cb552)
