### PR TITLE
typo curl-doc.js

### DIFF
--- a/components/api-doc/api-adresse/curl-doc.js
+++ b/components/api-doc/api-adresse/curl-doc.js
@@ -126,7 +126,7 @@ function CurlDoc() {
             <p>On peut utiliser le fichier <a href='https://adresse.data.gouv.fr/exemples/search.csv'>https://adresse.data.gouv.fr/exemples/search.csv</a> comme exemple.</p>
             <pre><code>curl -X POST -F data=@search.csv -F columns=adresse -F columns=postcode https://api-adresse.data.gouv.fr/search/csv/</code></pre>
             <p>Enfin, en cas d’industrialisation du géocodage, il peut être pertinent de lister spécifiquement les champs attendus dans la réponse, pour limiter la taille du fichier obtenu, et donc accélérer le transfert et réduire l’empreinte carbone.</p>
-            <pre><code>curl -X POST -F data=@search.csv -F columns=adresse -F columns=postcode -F result_columns=result_id -F result_columns=score https://api-adresse.data.gouv.fr/search/csv/</code></pre>
+            <pre><code>curl -X POST -F data=@search.csv -F columns=adresse -F columns=postcode -F result_columns=result_id -F result_columns=result_score https://api-adresse.data.gouv.fr/search/csv/</code></pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Dans la documentation de l'API de dépot
Le paramètre attendu est result_score et non score 

![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/95912586/45f3e9e8-0d10-4d6f-896c-279eb151b0bc)
