### PR TITLE
Probleme mail commune

### DIFF
--- a/lib/api-etablissements-public.js
+++ b/lib/api-etablissements-public.js
@@ -65,9 +65,14 @@ export async function getMairie(codeCommune) {
   const url = `${API_ETABLISSEMENTS_PUBLIC}/${route}?${query}`
 
   const response = await _fetch(url)
-  const rawMairie = response?.results?.[0]
-  if (!rawMairie) {
+  if (!response?.results) {
     return null
+  }
+
+  let rawMairie = response.results.find(result => !result.nom.toLowerCase().includes('mairie déléguée'))
+
+  if (!rawMairie) {
+    rawMairie = response.results[0]
   }
 
   const mairie = formatMairie(rawMairie)

--- a/lib/api-etablissements-public.js
+++ b/lib/api-etablissements-public.js
@@ -65,7 +65,7 @@ export async function getMairie(codeCommune) {
   const url = `${API_ETABLISSEMENTS_PUBLIC}/${route}?${query}`
 
   const response = await _fetch(url)
-if (!response?.results || response.results.length === 0) {
+  if (!response?.results || response.results.length === 0) {
     return null
   }
 

--- a/lib/api-etablissements-public.js
+++ b/lib/api-etablissements-public.js
@@ -65,16 +65,12 @@ export async function getMairie(codeCommune) {
   const url = `${API_ETABLISSEMENTS_PUBLIC}/${route}?${query}`
 
   const response = await _fetch(url)
-  if (!response?.results) {
+if (!response?.results || response.results.length === 0) {
     return null
   }
 
-  let rawMairie = response.results.find(result => !result.nom.toLowerCase().includes('mairie déléguée'))
-
-  if (!rawMairie) {
-    rawMairie = response.results[0]
-  }
-
+  const mainMarie = response.results.find(result => !result.nom.toLowerCase().includes('mairie déléguée'))
+  const rawMairie = mainMarie || response.results[0]
   const mairie = formatMairie(rawMairie)
   return mairie
 }


### PR DESCRIPTION
Sur adresse.data.gouv.fr (par exemple sur la page commune https://adresse.data.gouv.fr/commune/48009) n'avaient pas le bon mail pour les contacter.

Pour la commune 48009,ça affiche [mairie.stecolombepeyre@orange.fr](mailto:mairie.stecolombepeyre@orange.fr) alors que cela devrait être [peyreenaubrac@orange.fr](mailto:peyreenaubrac@orange.fr).

![image](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/47464438/4dba460d-1de0-447f-84d4-943a6b30368f)


fix: #1514

