### PR TITLE
fix: correct page partenaire

### DIFF
--- a/components/bases-locales/charte/partenaires/moissonneur-bal/index.js
+++ b/components/bases-locales/charte/partenaires/moissonneur-bal/index.js
@@ -61,7 +61,6 @@ function MoissonneurBal({sources}) {
  
         .fr-accordion {
           border: 1px solid grey;
-          padding: 2em;
           border-radius: 5px;
           margin: 1em 0;
         }
@@ -72,6 +71,7 @@ function MoissonneurBal({sources}) {
           content: none;
         }
         .fr-accordion__btn {
+          padding: 2em;
           font-size: 16px;
         }
         .accordion-header {

--- a/components/bases-locales/charte/partenaires/moissonneur-bal/revisions/revision-item.js
+++ b/components/bases-locales/charte/partenaires/moissonneur-bal/revisions/revision-item.js
@@ -7,6 +7,7 @@ import {getFileLink} from '@/lib/moissonneur-bal'
 import Tooltip from '@/components/base-adresse-nationale/tooltip'
 import Badge from '@codegouvfr/react-dsfr/Badge'
 import {formatDate} from '@/lib/date'
+import {findCommuneName} from '@/lib/cog'
 
 const {NEXT_PUBLIC_CLIENT_GUICHET_ADRESSE: CLIENT_GUICHET_ADRESSE} = getConfig().publicRuntimeConfig
 const {NEXT_PUBLIC_CLIENT_MES_ADRESSE: CLIENT_MES_ADRESSE} = getConfig().publicRuntimeConfig
@@ -68,7 +69,7 @@ function MoissonneurRevisionItem({codeCommune, _created, nbRows, nbRowsWithError
   return (
     <tr>
       <td className='fr-col fr-my-1v'>
-        <p>{codeCommune}</p>
+        <p>{findCommuneName(codeCommune)} ({codeCommune})</p>
       </td>
       <td className='fr-col fr-my-1v'>
         <p>{formatDate(_created)}</p>

--- a/components/bases-locales/charte/partenaires/moissonneur-bal/revisions/revisions-list.js
+++ b/components/bases-locales/charte/partenaires/moissonneur-bal/revisions/revisions-list.js
@@ -29,7 +29,7 @@ function MoissonneurRevisionsList({sourceId}) {
           <table>
             <thead>
               <tr>
-                <th scope='col'>Code Commune</th>
+                <th scope='col'>Commune</th>
                 <th scope='col'>Date</th>
                 <th scope='col'>
                   <Tooltip message='Nombre de ligne totale du fichier / nombre de ligne comportant des erreurs dans celui-ci' width='200px'>


### PR DESCRIPTION
Le button de l'accordion est maintenant entièrement cliquable 

<img width="1058" alt="Capture d’écran 2024-07-02 à 12 04 23" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/b4b1e923-5474-4294-90ca-008098e7ff87">

Le nom de la commune est affichée en plus du code

<img width="960" alt="Capture d’écran 2024-07-02 à 12 04 15" src="https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/assets/8143924/78111e9d-198b-49a9-a53c-d95ee3b8adb2">
