### PR TITLE
Added ban-id stat doughnuts on deploiement-bal page

### DIFF
--- a/components/bases-locales/deploiement-bal/panel-source.js
+++ b/components/bases-locales/deploiement-bal/panel-source.js
@@ -25,6 +25,10 @@ function PanelSource({stats, formatedStats}) {
     dataAdressesGereesBAL,
     adressesCertifieesPercent,
     dataAdressesCertifiees,
+    communesAvecBanIdPercent,
+    dataCommunesAvecBanId,
+    adressesAvecBanIdPercent,
+    dataAdressesAvecBanId,
     total
   } = formatedStats
 
@@ -59,6 +63,20 @@ function PanelSource({stats, formatedStats}) {
           data={dataAdressesCertifiees}
           options={options}
         />}
+        <DoughnutCounter
+          title='Communes avec identifiant BAN'
+          valueUp={numFormater(stats.ban.nbCommunesAvecBanId)}
+          valueDown={`${communesAvecBanIdPercent}% des ${numFormater(total.nbCommunes)} communes`}
+          data={dataCommunesAvecBanId}
+          options={options}
+        />
+        <DoughnutCounter
+          title='Adresses avec identifiant BAN'
+          valueUp={numFormater(stats.ban.nbAdressesAvecBanId)}
+          valueDown={`${adressesAvecBanIdPercent}% des ${numFormater(stats.ban.nbAdresses)} d’adresses présentes dans la BAN`}
+          data={dataAdressesAvecBanId}
+          options={options}
+        />
       </div>
 
       <style jsx>{`

--- a/hooks/stats-deploiement.js
+++ b/hooks/stats-deploiement.js
@@ -129,6 +129,11 @@ export function useStatsDeploiement({initialStats}) {
     const allCommunesCouvertesPercent = 100 - Math.round((stats.bal.nbCommunesCouvertes * 100) / total.nbCommunes)
     const dataCommunesCouvertes = toCounterData(communesCouvertesPercent, allCommunesCouvertesPercent)
 
+    // Calcul communes avec l'identifiant BAN
+    const communesAvecBanIdPercent = Math.round((stats.ban.nbCommunesAvecBanId * 100) / total.nbCommunes)
+    const allCommunesAvecBanIdPercent = 100 - Math.round((stats.ban.nbCommunesAvecBanId * 100) / total.nbCommunes)
+    const dataCommunesAvecBanId = toCounterData(communesAvecBanIdPercent, allCommunesAvecBanIdPercent)
+
     // Calcul adresses gerees dans la BAL
     const adressesGereesBALPercent = Math.round((stats.bal.nbAdresses * 100) / stats.ban.nbAdresses)
     const allAdressesGereesBALPercent = 100 - Math.round((stats.bal.nbAdresses * 100) / stats.ban.nbAdresses)
@@ -138,6 +143,11 @@ export function useStatsDeploiement({initialStats}) {
     const adressesCertifieesPercent = Math.round((stats.bal.nbAdressesCertifiees * 100) / stats.ban.nbAdresses)
     const allAdressesCertifieesPercent = 100 - Math.round((stats.bal.nbAdressesCertifiees * 100) / stats.ban.nbAdresses)
     const dataAdressesCertifiees = toCounterData(adressesCertifieesPercent, allAdressesCertifieesPercent)
+
+    // Calcul adresses avec identifiant BAN
+    const adressesAvecBanIdPercent = Math.round((stats.ban.nbAdressesAvecBanId * 100) / stats.ban.nbAdresses)
+    const allAdressesAvecBanIdPercent = 100 - Math.round((stats.ban.nbAdressesAvecBanId * 100) / stats.ban.nbAdresses)
+    const dataAdressesAvecBanId = toCounterData(adressesAvecBanIdPercent, allAdressesAvecBanIdPercent)
 
     return {
       populationCouvertePercent,
@@ -152,6 +162,12 @@ export function useStatsDeploiement({initialStats}) {
       adressesCertifieesPercent,
       allAdressesCertifieesPercent,
       dataAdressesCertifiees,
+      communesAvecBanIdPercent,
+      allCommunesAvecBanIdPercent,
+      dataCommunesAvecBanId,
+      adressesAvecBanIdPercent,
+      allAdressesAvecBanIdPercent,
+      dataAdressesAvecBanId,
       total
     }
   }, [stats])


### PR DESCRIPTION
This PR adds on the page `/deploiement-bal` the stats about ban-id : 
- number of commune that have ban ids (and its percentage)
- number of addresses that have the ban ids (and its percentage)

![Capture d’écran 2024-08-13 à 10 07 42](https://github.com/user-attachments/assets/0f2b0526-a8be-4945-9272-4ad18b138d5b)
