### PR TITLE
Improved certificate experience

### DIFF
--- a/components/base-adresse-nationale/numero/download-certificate.js
+++ b/components/base-adresse-nationale/numero/download-certificate.js
@@ -1,10 +1,10 @@
 import {Download} from '@codegouvfr/react-dsfr/Download'
 import PropTypes from 'prop-types'
 
-function DownloadCertificate({cleInterop, title}) {
+function DownloadCertificate({id, title}) {
   return (
     <Download label={title} details='PDF' linkProps={{
-      href: `/api/certificat/pdf/${cleInterop}`,
+      href: `/api/certificat/pdf/${id}`,
       target: '_blank'
     }} />
   )
@@ -13,7 +13,7 @@ function DownloadCertificate({cleInterop, title}) {
 export default DownloadCertificate
 
 DownloadCertificate.propTypes = {
-  cleInterop: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   title: PropTypes.string
 }
 

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -24,6 +24,7 @@ import DownloadCertificate from './download-certificate'
 const {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED} = getConfig().publicRuntimeConfig
 
 function Numero({
+  id,
   numero,
   suffixe,
   lieuDitComplementNom,
@@ -181,7 +182,7 @@ function Numero({
         (isNumeroCertifiable({banId, sources: sourcePosition, certifie, parcelles}) ?
           <div className='certificate'>
             <DownloadCertificate
-              cleInterop={cleInterop}
+              id={id}
               title="Télécharger le Certificat d'adressage"
             />
           </div> :
@@ -274,6 +275,7 @@ function Numero({
 }
 
 Numero.propTypes = {
+  id: PropTypes.string.isRequired,
   numero: PropTypes.number.isRequired,
   suffixe: PropTypes.string,
   lieuDitComplementNom: PropTypes.string,

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -1,4 +1,5 @@
-import {useEffect, useContext, useState} from 'react'
+/* eslint-disable complexity */
+import {useContext, useState} from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import getConfig from 'next/config'
@@ -20,11 +21,8 @@ import RegionInfos from '../region-infos'
 import LanguagesPreview from '../languages-preview'
 import DownloadCertificate from './download-certificate'
 
-import {getDistrict} from '@/lib/api-ban'
-
 const {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED} = getConfig().publicRuntimeConfig
 
-// eslint-disable-next-line complexity
 function Numero({
   numero,
   suffixe,
@@ -44,7 +42,7 @@ function Numero({
   codePostal,
   cleInterop,
   banId,
-  banIdDistrict,
+  districtConfig,
   lat,
   lon,
   isMobile,
@@ -53,42 +51,12 @@ function Numero({
   const [copyError, setCopyError] = useState(null)
   const [isCopyAvailable, setIsCopyAvailable] = useState(true)
   const [isCopySucceded, setIsCopySucceded] = useState(false)
-  const [isCertifiable, setIsCertifiable] = useState(false)
-  const [districtConfig, setDistrictConfig] = useState(null)
 
   const coordinates = {lat, lon}
   const copyUnvailableMessage = `Votre navigateur est incompatible avec la copie des coordonnées GPS : ${lat},${lon}`
   const sanitizedType = positionType ?
     positionType.charAt(0).toUpperCase() + positionType.slice(1) :
     'Inconnu'
-
-  useEffect(() => {
-    async function fetchDistrict() {
-      const rawResponse = await getDistrict(banIdDistrict)
-      const district = rawResponse.response
-      const districtConfig = district.config || {}
-      setDistrictConfig(districtConfig)
-
-      if (!district) {
-        setIsCertifiable(false)
-        return
-      }
-
-      if (!districtConfig.certificate) {
-        setIsCertifiable(false)
-        return
-      }
-
-      if (!isNumeroCertifiable({banId, sources: sourcePosition, certifie, parcelles})) {
-        setIsCertifiable(false)
-        return
-      }
-
-      setIsCertifiable(true)
-    }
-
-    fetchDistrict()
-  }, [banIdDistrict, banId, sourcePosition, certifie, parcelles])
 
   return (
     <>
@@ -209,21 +177,18 @@ function Numero({
         </b>
       </div>
 
-      {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED && districtConfig?.certificate && (
-        isCertifiable ? (
-          <div className='ressource'>
+      {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED && districtConfig?.certificate &&
+        (isNumeroCertifiable({banId, sources: sourcePosition, certifie, parcelles}) ?
+          <div className='certificate'>
             <DownloadCertificate
               cleInterop={cleInterop}
               title="Télécharger le Certificat d'adressage"
             />
-          </div>
-        ) : (
-          <div className='ressource'>
+          </div> :
+          <div className='certificate'>
             <div />
             <span>Certificat d&apos;adressage indisponible pour cette adresse, veuillez contacter votre mairie.</span>
-          </div>
-        )
-      )}
+          </div>)}
 
       {isCopySucceded && (
         <Alert
@@ -257,9 +222,6 @@ function Numero({
           flex-direction: column;
           margin: 1.2em 0;
           border-bottom: 1px solid ${colors.lighterGrey};
-        }
-        .ressource {
-          border-bottom: none;
         }
 
         .heading h2 {
@@ -296,6 +258,16 @@ function Numero({
           margin-top: 1em;
           font-style: italic;
         }
+
+        .certificate {
+          margin-top: 1em;
+          margin-bottom: 1em;
+        }
+
+        .certificate-loader {
+          margin-top: 1em;
+          margin-bottom: 1em;
+        }
       `}</style>
     </>
   )
@@ -328,7 +300,9 @@ Numero.propTypes = {
   codePostal: PropTypes.string,
   cleInterop: PropTypes.string.isRequired,
   banId: PropTypes.string,
-  banIdDistrict: PropTypes.string,
+  districtConfig: PropTypes.shape({
+    certificate: PropTypes.object,
+  }),
   positionType: PropTypes.string,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,

--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import maplibregl from 'maplibre-gl'
 
-import {getAddress} from '@/lib/api-ban'
+import {getAddress, getDistrict} from '@/lib/api-ban'
 
 import Page from '@/layouts/main'
 import {Desktop, Mobile} from '@/layouts/base-adresse-nationale'
@@ -120,7 +120,10 @@ BaseAdresseNationale.propTypes = {
     voie: PropTypes.shape({
       nomVoie: PropTypes.string
     }),
-    displayBBox: PropTypes.array
+    displayBBox: PropTypes.array,
+    districtConfig: PropTypes.shape({
+      certificate: PropTypes.object,
+    })
   })
 }
 
@@ -161,8 +164,16 @@ export async function getServerSideProps({query}) {
       }
     }
 
+    let districtConfig = {}
+    const {banIdDistrict} = address
+    if (banIdDistrict) {
+      const districtRawResponse = await getDistrict(banIdDistrict)
+      const district = districtRawResponse.response
+      districtConfig = district.config || {}
+    }
+
     return {
-      props: {address}
+      props: {address: {...address, districtConfig}}
     }
   } catch {
     return {


### PR DESCRIPTION
# Context

When a district has its `certificate` feature activated, a link is available on its addresses (that are certified and have an ban id and at least one parcel). 

# Enhancement
 
This PR improve the user experience
- The is no more loading on client side (the district config is fetched from server side)