### PR TITLE
fix: /deploiement-bal suivi mes adresses

### DIFF
--- a/components/bases-locales/deploiement-bal/bal-card.js
+++ b/components/bases-locales/deploiement-bal/bal-card.js
@@ -13,7 +13,7 @@ function BaseLocaleCard({bal}) {
     return null
   }
 
-  const balUrl = `${MES_ADRESSE_URL}/bal/${bal._id}`
+  const balUrl = `${MES_ADRESSE_URL}/bal/${bal.id}`
 
   return (
     <div>
@@ -21,7 +21,7 @@ function BaseLocaleCard({bal}) {
         <div className='card-header'>
           <div className='card-header-title'>
             <h4>{bal.commune} {bal.nom}</h4>
-            <p><i>Modifié le {sanitizedDate(bal._updated)}</i></p>
+            <p><i>Modifié le {sanitizedDate(bal.updatedAt)}</i></p>
           </div>
           <StatusBadge status={bal.status} sync={bal.sync} />
         </div>
@@ -58,10 +58,10 @@ function BaseLocaleCard({bal}) {
 
 BaseLocaleCard.propTypes = {
   bal: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired,
     commune: PropTypes.string.isRequired,
-    _updated: PropTypes.string,
+    updatedAt: PropTypes.string,
     status: PropTypes.oneOf([
       'replaced',
       'published',

--- a/components/bases-locales/deploiement-bal/commune-bal-list.js
+++ b/components/bases-locales/deploiement-bal/commune-bal-list.js
@@ -31,7 +31,7 @@ function CommuneBALList({codeCommune, balsCommune}) {
       {balsCommune.length > 0 ? (
         <StyledAccordion label={title} className='accordion'>
           {balsCommune.map(bal => (
-            <BaseLocaleCard key={bal._id} bal={bal} />
+            <BaseLocaleCard key={bal.id} bal={bal} />
           ))}
         </StyledAccordion>
       ) : (

--- a/components/bases-locales/deploiement-bal/panel-bal.js
+++ b/components/bases-locales/deploiement-bal/panel-bal.js
@@ -68,7 +68,7 @@ function PanelBal({filteredCodesCommmune}) {
     }
 
     async function loadBals() {
-      const fields = ['_id', 'commune', 'status', 'nom', '_updated', 'sync']
+      const fields = ['id', 'commune', 'status', 'nom', 'updatedAt', 'sync']
       const balsFiltered = await getStatsBals(fields, filteredCodesCommmune)
       setBals(balsFiltered)
       const statusData = [


### PR DESCRIPTION
## CONTEXT

Depuis la migration postgres de mes-adresses la page /deploiement-bal est cassé.
On ne voit pas le graph et les bal, si on selectionne un departement et qu'on est sur l'onglet `suivi mes-adresses`

<img width="1586" alt="Capture d’écran 2024-09-30 à 09 58 11" src="https://github.com/user-attachments/assets/01a26792-c4ea-4082-a718-af9936e93cc2">

## FIX

Remplacer les champs `_id` et `'_updated` par `ìd` et `updatedAt` dans les pages de  /deploiement-bal