### PR TITLE
fix: /deploiement-bal color features

### DIFF
--- a/components/bases-locales/deploiement-bal/bal-cover-map.js
+++ b/components/bases-locales/deploiement-bal/bal-cover-map.js
@@ -90,12 +90,21 @@ const paintLayers = {
         {
           expression: [
             ['==', ['get', 'statusBals'], 'published'],
+            ['==', ['get', 'idClient'], 'mes-adresses']
+          ], // Mes Adresses
+          color: theme.colors.mapGreen
+        },
+        {
+          expression: [
+            ['==', ['get', 'statusBals'], 'replaced'],
+            ['==', ['get', 'idClient'], 'mes-adresses']
           ], // Mes Adresses
           color: theme.colors.mapGreen
         },
         {
           expression: [
             ['==', ['get', 'statusBals'], 'draft'],
+            ['==', ['get', 'idClient'], 'mes-adresses']
           ], // Mes Adresses
           color: theme.colors.mapYellow
         },


### PR DESCRIPTION
## CONTEXT

- Dans l'onglet `suivi de mes adresses` les BAL en conflit étaient affiché `Autre source` (exemple Gonneville le-theil)
- Dans l'onglet `suivi de mes adresses` si une bal avait une ancienne bal, c'est cette derniere qui était affiché (exemple Nouainville, qui est actuellement publié avec le formulaire mais on affichait la bal en brouillon)

<img width="1610" alt="Capture d’écran 2024-09-30 à 14 48 03" src="https://github.com/user-attachments/assets/74020112-fca3-4e0a-9219-3a92caaeae54">

## FIX

Ajouter des filtre sur les couleurs des features

<img width="1540" alt="Capture d’écran 2024-09-30 à 14 47 20" src="https://github.com/user-attachments/assets/d4fbf480-b347-4baa-9889-90350acc7497">
