### PR TITLE
fix: formulaire upload file bal 50m

### DIFF
--- a/server/proxy-api-depot.js
+++ b/server/proxy-api-depot.js
@@ -162,7 +162,7 @@ app.post('/communes/:codeCommune/revisions', w(createRevision))
 app.get('/revisions/:revisionId', w(getRevision))
 app.put(
   '/revisions/:revisionId/files/bal',
-  express.raw({limit: '10mb', type: 'text/csv'}),
+  express.raw({limit: '50mb', type: 'text/csv'}),
   w(uploadFile)
 )
 app.post('/revisions/:revisionId/compute', w(computeRevision))


### PR DESCRIPTION
## CONTEXT

Les bals de plus de 10mo sont rejeter dans le formulaire de publication par la route `/proxy-api-depot/revisions/:revisionId/files/bal` alors que la limit a été passé a 50mo