### PR TITLE
Rollback sur les boutons recherche home

### DIFF
--- a/src/components/SectionSearchBAN/SectionSearchBAN.tsx
+++ b/src/components/SectionSearchBAN/SectionSearchBAN.tsx
@@ -46,20 +46,8 @@ function SectionSearchBAN({ id }: SectionSearchBANProps) {
             <FormDescription>Saisissez votre adresse, une voie, un lieu-dit ou une commune</FormDescription>
           </SearchBAN>
           <FormWrapperFooter>
-            <Button
-              iconId="fr-icon-road-map-line"
-              linkProps={{
-                href: '/carte-base-adresse-nationale',
-              }}
-            >
-              Consulter directement la carte
-            </Button>
-            <Button
-              iconId="fr-icon-questionnaire-line"
-              onClick={handleContactParticuliers}
-            >
-              Vérifier mon adresse
-            </Button>
+            <Link className="fr-link fr-link--icon-left fr-icon-road-map-line" href={`.${URL_CARTOGRAPHY_BAN}`}>Consultez directement la carte</Link>
+            <ButtonLink className="fr-link fr-link--icon-left fr-icon-questionnaire-line" href="#" onClick={handleContactParticuliers}>J’ai un souci avec mon adresse</ButtonLink>
           </FormWrapperFooter>
         </FormWrapper>
       </Wrapper>


### PR DESCRIPTION
Retour en arrière sur les boutons sur la home page en dessous de la barre de recherche.
Mise en place de lien simple comme avant
Fix : #1928 
