### PR TITLE
[Current App] - Migrated get config from district to address

### DIFF
--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -8,7 +8,7 @@ import colors from '@/styles/colors'
 import theme from '@/styles/theme'
 
 import Alert from '@/components/alert'
-import {getNumeroComplet, isNumeroCertifiable} from '@/lib/ban'
+import {getNumeroComplet, isAddressCertifiable} from '@/lib/ban'
 
 import Certification from '../certification'
 import ParcellesList from '../parcelles-list'
@@ -43,7 +43,8 @@ function Numero({
   codePostal,
   cleInterop,
   banId,
-  districtConfig,
+  config,
+  withBanId,
   lat,
   lon,
   isMobile,
@@ -178,8 +179,8 @@ function Numero({
         </b>
       </div>
 
-      {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED && districtConfig?.certificate &&
-        (isNumeroCertifiable({banId, sources: sourcePosition, certifie, parcelles}) ?
+      {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED && config?.certificate &&
+        (isAddressCertifiable({banId, sources: sourcePosition, certifie, parcelles, withBanId}) ?
           <div className='certificate'>
             <DownloadCertificate
               id={id}
@@ -302,9 +303,10 @@ Numero.propTypes = {
   codePostal: PropTypes.string,
   cleInterop: PropTypes.string.isRequired,
   banId: PropTypes.string,
-  districtConfig: PropTypes.shape({
+  config: PropTypes.shape({
     certificate: PropTypes.object,
   }),
+  withBanId: PropTypes.bool.isRequired,
   positionType: PropTypes.string,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,

--- a/lib/api-ban.js
+++ b/lib/api-ban.js
@@ -34,10 +34,6 @@ export function getAddress(idAddress) {
   return _fetch(`${API_BAN_URL}/lookup/${idAddress}`)
 }
 
-export function getDistrict(banIdDistrict) {
-  return _fetch(`${API_BAN_URL}/api/district/${banIdDistrict}`)
-}
-
 export function getStats() {
   return _fetch(`${API_BAN_URL}/ban/stats`)
 }

--- a/lib/ban.js
+++ b/lib/ban.js
@@ -26,7 +26,7 @@ export function isCOM(codeCommune) {
  * @param {*} numero (sources liste, certifie bool, parecelle liste)
  * @returns bool
  */
-export function isNumeroCertifiable({banId, sources, certifie, parcelles}) {
+export function isAddressCertifiable({banId, sources, certifie, parcelles, withBanId}) {
   return (
     // Check has banId
     banId &&
@@ -35,7 +35,9 @@ export function isNumeroCertifiable({banId, sources, certifie, parcelles}) {
     // Check is certifié
     certifie &&
     // Check has parcelle
-    parcelles?.length > 0
+    parcelles?.length > 0 &&
+    // Check if the address is on the postgresql database system
+    withBanId
   )
 }
 

--- a/pages/api/certificat/pdf/[id-adresse].js
+++ b/pages/api/certificat/pdf/[id-adresse].js
@@ -2,45 +2,13 @@ import getConfig from 'next/config'
 import ReactPDF from '@react-pdf/renderer'
 
 import {CertificatNumerotation} from '@/components/document/numerotation/certificat'
-import {getAddress, getDistrict} from '@/lib/api-ban'
+import {getAddress} from '@/lib/api-ban'
+import {isAddressCertifiable} from '@/lib/ban'
 import QRCode from 'qrcode'
 import {getMairie} from '@/lib/api-etablissements-public'
 
 const {NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED, NEXT_PUBLIC_ADRESSE_URL, NEXT_PUBLIC_API_BAN_URL} = getConfig().publicRuntimeConfig
 const {BAN_API_TOKEN} = process.env
-
-const isAddressCertifiable = async ({banId, sources, certifie, parcelles}) => {
-  return (
-    // Check has banId
-    banId &&
-    // Check is bal
-    sources?.includes('bal') &&
-    // Check is certifié
-    certifie &&
-    // Check has parcelle
-    parcelles?.length > 0
-  )
-}
-
-const isDistrictCertifiable = async banIdDistrict => {
-  // Check if district is certifiable
-  if (!banIdDistrict) {
-    return false
-  }
-
-  const rawResponse = await getDistrict(banIdDistrict)
-  const district = rawResponse.response
-  if (!district) {
-    return false
-  }
-
-  const districtConfig = district.config || {}
-  if (!districtConfig.certificate) {
-    return false
-  }
-
-  return true
-}
 
 export default async function handler(req, res) {
   if (!NEXT_PUBLIC_CERTIFICAT_NUMEROTATION_ENABLED) {
@@ -57,7 +25,7 @@ export default async function handler(req, res) {
     return res.status(404).send()
   }
 
-  const isCertifiable = (await isDistrictCertifiable(address.banIdDistrict)) && isAddressCertifiable(address)
+  const isCertifiable = address?.config?.certificate && isAddressCertifiable(address)
   if (!isCertifiable) {
     return res.status(404).send('Adresse incompatible avec le service')
   }

--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import maplibregl from 'maplibre-gl'
 
-import {getAddress, getDistrict} from '@/lib/api-ban'
+import {getAddress} from '@/lib/api-ban'
 
 import Page from '@/layouts/main'
 import {Desktop, Mobile} from '@/layouts/base-adresse-nationale'
@@ -121,7 +121,7 @@ BaseAdresseNationale.propTypes = {
       nomVoie: PropTypes.string
     }),
     displayBBox: PropTypes.array,
-    districtConfig: PropTypes.shape({
+    config: PropTypes.shape({
       certificate: PropTypes.object,
     })
   })
@@ -164,16 +164,8 @@ export async function getServerSideProps({query}) {
       }
     }
 
-    let districtConfig = {}
-    const {banIdDistrict} = address
-    if (banIdDistrict) {
-      const districtRawResponse = await getDistrict(banIdDistrict)
-      const district = districtRawResponse.response
-      districtConfig = district.config || {}
-    }
-
     return {
-      props: {address: {...address, districtConfig}}
+      props: {address}
     }
   } catch {
     return {


### PR DESCRIPTION
# Context 

The BAN lookup api now retrieve the `config` (config of the district) and the `withBanId` (boolean that says if the address is from our new technical architecture) fields from the address.

# Enhancement 

This PR aims to : 
- reduce the number of calls to the ban-plateforme API to create a certificate by retrieving the district `config` directly from the address (and not from the district that was requiring a call to our main database).
- add the condition `withBanId` to the certificate as the certificate can only be activated on data that is part of our new system.