### PR TITLE
[New App] - Migrated get config from district to address

### DIFF
--- a/src/app/api/certificat/[idAdresse]/route.tsx
+++ b/src/app/api/certificat/[idAdresse]/route.tsx
@@ -1,27 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getAddress, getDistrict } from '@/lib/api-ban'
+import { getAddress, getCommune } from '@/lib/api-ban'
+import { isAddressCertifiable } from '@/lib/ban'
 import { env } from 'next-runtime-env'
 
 const NEXT_PUBLIC_API_BAN_URL = env('NEXT_PUBLIC_API_BAN_URL')
 const BAN_API_TOKEN = env('BAN_API_TOKEN')
-
-const isAddressCertifiable = async ({ banId, sources, certifie, parcelles }: any): Promise<boolean> => {
-  return !!banId && sources?.includes('bal') && certifie && parcelles?.length > 0
-}
-
-const isDistrictCertifiable = async (banIdDistrict: string | null): Promise<boolean> => {
-  if (!banIdDistrict) {
-    return false
-  }
-  const rawResponse = await getDistrict(banIdDistrict)
-  const district = rawResponse.response
-  if (!district) {
-    return false
-  }
-
-  const districtConfig = district.config || {}
-  return !!districtConfig.certificate
-}
 
 export async function GET(request: NextRequest, { params }: { params: { idAdresse: string } }) {
   let address
@@ -35,7 +18,7 @@ export async function GET(request: NextRequest, { params }: { params: { idAdress
     return new NextResponse(null, { status: 404 })
   }
 
-  const isCertifiable = (await isDistrictCertifiable(address.banIdDistrict)) && await isAddressCertifiable(address)
+  const isCertifiable = address?.config?.certificate && await isAddressCertifiable(address)
   if (!isCertifiable) {
     return new NextResponse('Adresse incompatible avec le service', { status: 404 })
   }

--- a/src/app/carte-base-adresse-nationale/components/PanelAddress/PanelAddressFooter.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelAddress/PanelAddressFooter.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import Button from '@codegouvfr/react-dsfr/Button'
 
-import { isNumeroCertifiable } from '@/lib/ban'
+import { isAddressCertifiable } from '@/lib/ban'
 
 import { useFocusOnMap } from '../ban-map/BanMap.context'
 import DownloadCertificate from './DownloadCertificate'
@@ -24,11 +24,12 @@ interface AsideFooterAddressProps {
 function AsideFooterAddress({ banItem: address, withCertificate, children }: AsideFooterAddressProps) {
   const focusOnMap = useFocusOnMap(address)
 
-  const isCertifiable = useMemo(() => isNumeroCertifiable({
+  const isCertifiable = useMemo(() => isAddressCertifiable({
     banId: address.banId ?? '',
     sources: Array.isArray(address.sourcePosition) ? address.sourcePosition : [address.sourcePosition],
     certifie: address.certifie,
     parcelles: address.parcelles,
+    withBanId: address.withBanId,
   }), [address])
 
   const handleClick = (evt: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/app/carte-base-adresse-nationale/page.tsx
+++ b/src/app/carte-base-adresse-nationale/page.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { MapRef } from 'react-map-gl/maplibre'
 
 import { getCommuneFlag } from '@/lib/api-wikidata'
-import { getBanItem, getDistrict } from '@/lib/api-ban'
+import { getBanItem } from '@/lib/api-ban'
 
 import Aside from './components/Aside'
 import LoadingBar from './components/LoadingBar'
@@ -164,15 +164,8 @@ function CartoView() {
         }
         else if (typeItem === 'address') {
           setMapBreadcrumbPath(getAddressBreadcrumbPath(banItem as TypeAddressExtended))
-          let districtConfig: { certificate: boolean } = { certificate: false }
-          const { banIdDistrict } = banItem as TypeAddressExtended
-
-          if (banIdDistrict) {
-            const districtRawResponse = await getDistrict(banIdDistrict)
-            const district = districtRawResponse.response
-            districtConfig = district.config || { certificate: false }
-          }
-          setWithCertificate(districtConfig.certificate)
+          const config = (banItem as TypeAddressExtended).config
+          setWithCertificate(config?.certificate ? true : false)
         }
         const { displayBBox = [] } = banItem
         const bbox = displayBBox

--- a/src/app/carte-base-adresse-nationale/types/LegacyBan.types.ts
+++ b/src/app/carte-base-adresse-nationale/types/LegacyBan.types.ts
@@ -48,6 +48,10 @@ export interface TypeDistrict extends TypeDistrictPartial {
   code: string
 }
 
+export interface TypeDistrictConfig {
+  certificate?: {}
+}
+
 export interface TypeDistrictExtended extends TypeDistrictPartial {
   type: TypeItem
   codeCommune: string
@@ -64,6 +68,7 @@ export interface TypeDistrictExtended extends TypeDistrictPartial {
   idRevision?: string | null
   dateRevision?: string | null
   voies: TypeMicroToponym[]
+  config?: TypeDistrictConfig
 }
 
 export interface TypeAddress {
@@ -119,4 +124,8 @@ export interface TypeAddressExtended {
   cleInterop: string
   voie: TypeMicroToponymPartial
   commune: TypeDistrict
+  withBanId: boolean
+  config?: {
+    certificate: {}
+  }
 }

--- a/src/app/commune/[codeCommune]/ResumeDistrict.tsx
+++ b/src/app/commune/[codeCommune]/ResumeDistrict.tsx
@@ -30,32 +30,32 @@ function ResumeDistrict({ district, actionProps }: ResumeDistrictProps) {
       <ResumeDistrictWrapper>
         <ul>
           <DistrictDetailsItem className="ri-group-line">
-            <b>{formatNumber(district.data.population)}</b>&nbsp;habitants
+            <b>{formatNumber(district.population)}</b>&nbsp;habitants
           </DistrictDetailsItem>
           <DistrictDetailsItem className="ri-shield-check-line">
             {
-              Number(district.data.nbNumerosCertifies) > 1
-                ? <><b>{formatNumber(district.data.nbNumerosCertifies)}</b>&nbsp;adresses certifiées</>
-                : <>{district.data.nbNumerosCertifies || 'Aucune'} adresse certifiée</>
+              Number(district.nbNumerosCertifies) > 1
+                ? <><b>{formatNumber(district.nbNumerosCertifies)}</b>&nbsp;adresses certifiées</>
+                : <>{district.nbNumerosCertifies || 'Aucune'} adresse certifiée</>
             }{'\u00A0/\u00A0'}
-            <b>{formatNumber(district.data.nbNumeros)}</b>&nbsp;adresses répertoriées{' '}
-            <b>({Math.round((district.data.nbNumerosCertifies / district.data.nbNumeros) * 100)}%)</b>
+            <b>{formatNumber(district.nbNumeros)}</b>&nbsp;adresses répertoriées{' '}
+            <b>({Math.round((district.nbNumerosCertifies / district.nbNumeros) * 100)}%)</b>
           </DistrictDetailsItem>
           <DistrictDetailsItem className="ri-signpost-line">
             {
-              Number(district.data.codesPostaux.length) > 1
-                ? <><b>{formatNumber(district.data.codesPostaux.length)}</b>&nbsp;codes Postaux</>
-                : <>{district.data.codesPostaux.length || 'Aucune'} code Postal</>
+              Number(district.codesPostaux.length) > 1
+                ? <><b>{formatNumber(district.codesPostaux.length)}</b>&nbsp;codes Postaux</>
+                : <>{district.codesPostaux.length || 'Aucune'} code Postal</>
             }{' '}
-            <b>({district.data.codesPostaux.map(formatNumber).join(', ')})</b>
+            <b>({district.codesPostaux.map(formatNumber).join(', ')})</b>
           </DistrictDetailsItem>
         </ul>
 
         <ul>
-          <DistrictDetailsItem className="ri-edit-box-line">Source des données BAN : <b>{district.data.typeComposition === 'bal' ? 'Base Adresse Local (BAL)' : 'Assemblage IGN'}</b></DistrictDetailsItem>
+          <DistrictDetailsItem className="ri-edit-box-line">Source des données BAN : <b>{district.typeComposition === 'bal' ? 'Base Adresse Local (BAL)' : 'Assemblage IGN'}</b></DistrictDetailsItem>
           <DistrictDetailsItem className="ri-key-line">Identifiant district BAN : <b>{district.id}</b></DistrictDetailsItem>
           <DistrictDetailsItem className="ri-shield-keyhole-line">Identificateur d’adresse :{' '}
-            <b>{district.data.voies?.[0]?.banId ? 'Stable (Identifiants BAN)' : 'Volatile (Clé d’interoprabilité)'}</b>
+            <b>{district.voies?.[0]?.banId ? 'Stable (Identifiants BAN)' : 'Volatile (Clé d’interoprabilité)'}</b>
           </DistrictDetailsItem>
           <DistrictDetailsItem className="ri-file-paper-2-line">Certificat d’adressage :{' '}
             <b>{ district.config?.certificate ? 'Activé' : 'Non activé'}</b>
@@ -88,7 +88,7 @@ function ResumeDistrict({ district, actionProps }: ResumeDistrictProps) {
         </Button>
       </ResumeDistrictActionsWrapper>
 
-      <Section title={`Configuration des options pour la commune de ${district.data.nomCommune}`} theme="grey" isVisible={isConfigDistrictVisible}>
+      <Section title={`Configuration des options pour la commune de ${district.nomCommune}`} theme="grey" isVisible={isConfigDistrictVisible}>
         <p>
           <i>
             Cette fonctionnalité est en développement.

--- a/src/app/commune/[codeCommune]/page.tsx
+++ b/src/app/commune/[codeCommune]/page.tsx
@@ -5,7 +5,6 @@ import { Table } from '@codegouvfr/react-dsfr/Table'
 import CardWrapper from '@/components/CardWrapper'
 import Section from '@/components/Section'
 import {
-  getDistrict,
   getCommune as getBANCommune,
   assemblageSources,
 } from '@/lib/api-ban'
@@ -35,18 +34,15 @@ export default async function CommunePage({ params }: CommunePageProps) {
     getAPIGeoCommune(codeCommune),
   ])
 
-  const { banId: banIdDistrict, id: legacyId } = commune
   const communeHasBAL = commune.typeComposition !== 'assemblage'
   const certificationPercentage = Math.round(commune.nbNumerosCertifies / commune.nbNumeros * 100)
 
   const [
-    districtRawResponse,
     mairiePageUrl,
     communeFlagUrl,
     EPCI,
     lastRevisionsDetails,
   ] = await Promise.all([
-    getDistrict(banIdDistrict as string),
     getMairiePageURL(codeCommune),
     getCommuneFlag(codeCommune),
     getEPCI(APIGeoCommune?.codeEpci),
@@ -57,8 +53,7 @@ export default async function CommunePage({ params }: CommunePageProps) {
       ),
   ])
 
-  const district = { ...districtRawResponse.response, data: commune }
-  const districtMapURL = `/carte-base-adresse-nationale?id=${district?.data?.codeCommune}`
+  const districtMapURL = `/carte-base-adresse-nationale?id=${commune.codeCommune}`
 
   return (
     <>
@@ -155,7 +150,7 @@ export default async function CommunePage({ params }: CommunePageProps) {
           </div>
 
           <ResumeDistrict
-            district={district}
+            district={commune}
             actionProps={[
               {
                 iconId: 'fr-icon-road-map-line',

--- a/src/lib/api-ban.ts
+++ b/src/lib/api-ban.ts
@@ -13,9 +13,6 @@ export function getAddress(idAddress: string) {
   return customFetch(`${API_BAN_SEARCH_URL}/lookup/${idAddress}`)
 }
 
-export function getDistrict(banIdDistrict: string) {
-  return customFetch(`${API_BAN_SEARCH_URL}/api/district/${banIdDistrict}`)
-}
 export function getBanItem(idBanItem: string, signal?: AbortSignal): Promise<BANCommune | BANVoie | BANAddress> {
   return customFetch(`${API_BAN_SEARCH_URL}/lookup/${idBanItem}`, signal ? { signal } : {})
 }

--- a/src/lib/ban.ts
+++ b/src/lib/ban.ts
@@ -3,6 +3,7 @@ interface NumeroData {
   sources: string[]
   certifie: boolean
   parcelles: string[]
+  withBanId: boolean
 }
 
 /**
@@ -10,12 +11,13 @@ interface NumeroData {
    * @param numeroData - Les données du numéro comprenant l'identifiant BAN, les sources, l'état de certification et les parcelles.
    * @returns boolean - Renvoie true si le numéro est éligible, false sinon.
    */
-export function isNumeroCertifiable(numeroData: NumeroData): boolean {
-  const { banId, sources, certifie, parcelles } = numeroData
+export function isAddressCertifiable(numeroData: NumeroData): boolean {
+  const { banId, sources, certifie, parcelles, withBanId } = numeroData
   return (
     !!banId
     && sources?.includes('bal')
     && certifie
     && parcelles?.length > 0
+    && withBanId
   )
 }

--- a/src/types/api-ban.types.ts
+++ b/src/types/api-ban.types.ts
@@ -28,6 +28,10 @@ export type BANVoie = {
   nbNumerosCertifies: number
 }
 
+export type BANConfig = {
+  certificate: {}
+}
+
 export type BANCommune = {
   id: string
   type: string
@@ -48,6 +52,7 @@ export type BANCommune = {
   idRevision: string
   dateRevision: string
   voies: BANVoie[]
+  config: BANConfig
 }
 
 export type BANStats = {


### PR DESCRIPTION
# Context 

The BAN lookup api now retrieve the `config` (config of the district) and the `withBanId` (boolean that says if the address is from our new technical architecture) fields from the address.

# Enhancement 

This PR aims to : 
- reduce the number of calls to the ban-plateforme API to create a certificate by retrieving the district `config` directly from the address (and not from the district that was requiring a call to our main database).
- add the condition `withBanId` to the certificate as the certificate can only be activated on data that is part of our new system.