### PR TITLE
Fixed district detail on certified addresses

### DIFF
--- a/src/app/carte-base-adresse-nationale/components/PanelDistrict/PanelDistrict.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelDistrict/PanelDistrict.tsx
@@ -69,7 +69,7 @@ function PanelDistrict({ district }: PanelDistrictProps) {
         <DistrictDetailsItem className="ri-map-pin-line">
           <b>{formatNumber(nbAddress)}</b>&nbsp;adresses répertoriées{' '}
           {
-            nbAddressCertified && (
+            nbAddressCertified > 0 && (
               nbAddressCertified === nbAddress
                 ? <>et certifiées</>
                 : (


### PR DESCRIPTION
Fixing interface issue displaying a '0' : 

<img width="902" alt="Capture d’écran 2025-01-13 à 10 25 36" src="https://github.com/user-attachments/assets/d5cebda7-8a21-41c4-ac09-09c8ae848b36" />
