### PR TITLE
Fix bug redirection route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -143,6 +143,11 @@ const redirects = async () => [
     permanent: true,
   },
   {
+    source: '/api-doc/adresse',
+    destination: '/outils/api-doc/adresse',
+    permanent: true,
+  },
+  {
     source: '/api',
     destination: '/outils',
     permanent: true,


### PR DESCRIPTION
Fix redirection for [adresse.data.gouv.fr/api-doc/adresse](https://adresse.data.gouv.fr/api-doc/adresse)  ==> [https://adresse.data.gouv.fr/outils/api-doc/adress](https://adresse.data.gouv.fr/outils/api-doc/adresse)