### PR TITLE
fix url image pour firefox

### DIFF
--- a/src/app/carte-base-adresse-nationale/components/PanelAddress/PanelAddressHeader.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelAddress/PanelAddressHeader.tsx
@@ -48,7 +48,7 @@ function AddressCard({ address }: AddressCardProps) {
         </AddressMicroTopoLabel>
         {microToponym?.nomVoieAlt && Object.entries(microToponym.nomVoieAlt).map(([lang, odonyme]) => (
           <PanelMicroTopoLabelAlt key={lang}>
-            <PanelMicroTopoLabelAltFlag src={`./img/flags/${lang}.svg`} alt={`Drapeau ${lang}`} />{' '}
+            <PanelMicroTopoLabelAltFlag src={`/img/flags/${lang}.svg`} alt={`Drapeau ${lang}`} />{' '}
             {odonyme}
           </PanelMicroTopoLabelAlt>
         ))}

--- a/src/app/carte-base-adresse-nationale/components/PanelMicroToponym/PanelMicroToponymHeader.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelMicroToponym/PanelMicroToponymHeader.tsx
@@ -28,7 +28,7 @@ function PanelMicroToponymHeader({ microToponym }: PanelMicroToponymHeaderProps)
           {microToponym.nomVoie}
           {microToponym?.nomVoieAlt && Object.entries(microToponym.nomVoieAlt).map(([lang, odonyme]) => (
             <PanelMicroTopoLabelAlt key={lang}>
-              <PanelMicroTopoLabelAltFlag src={`./img/flags/${lang}.svg`} alt={`Drapeau ${lang}`} />{' '}
+              <PanelMicroTopoLabelAltFlag src={`/img/flags/${lang}.svg`} alt={`Drapeau ${lang}`} />{' '}
               {odonyme}
             </PanelMicroTopoLabelAlt>
           ))}

--- a/src/app/contenu-de-la-ban/page.tsx
+++ b/src/app/contenu-de-la-ban/page.tsx
@@ -22,7 +22,7 @@ export default async function Home() {
           <SectionHero
             pageTitle={heroData?.title || ''}
             picture={{
-              src: './img/pages/contenu_de_la_ban/construire-ban.svg',
+              src: '/img/pages/contenu_de_la_ban/construire-ban.svg',
               alt: 'Illustration "Construire la Base Adresse Nationale"',
               width: 400,
               height: 194,

--- a/src/app/decouvrir-la-BAN/page.tsx
+++ b/src/app/decouvrir-la-BAN/page.tsx
@@ -22,7 +22,7 @@ export default async function Home() {
           <SectionHero
             pageTitle={heroData?.title || ''}
             picture={{
-              src: './img/pages/decouvrir_la_BAN/illustration-ban.svg',
+              src: '/img/pages/decouvrir_la_BAN/illustration-ban.svg',
               alt: 'Illustration de "La Base Adresse Nationale"',
               width: 400,
               height: 310,

--- a/src/app/outils/page.tsx
+++ b/src/app/outils/page.tsx
@@ -27,7 +27,7 @@ export default async function Outils() {
           <SectionHero
             pageTitle={heroData?.title || ''}
             picture={{
-              src: './img/pages/outils/in-progress.svg',
+              src: '/img/pages/outils/in-progress.svg',
               alt: 'Illustration des "Outils et APIs"',
               width: 400,
               height: 310,
@@ -49,7 +49,7 @@ export default async function Outils() {
               titleAs="h5"
               desc="Chercher des adresses dans la Base Adresse Nationale."
               imageAlt="explorateur ban"
-              imageUrl="./img/pages/outils/outils-ban.png"
+              imageUrl="/img/pages/outils/outils-ban.png"
               className="fr-card--horizontal-tier fr-card--md"
               footer={(
                 <Button
@@ -67,7 +67,7 @@ export default async function Outils() {
               titleAs="h5"
               desc="Télécharger les données de la Base Adresse Nationale (BAN)"
               imageAlt="download data"
-              imageUrl="./img/pages/outils/outils-ban.png"
+              imageUrl="/img/pages/outils/outils-ban.png"
               className="fr-card--md fr-card--horizontal-tier"
               footer={(
                 <ul className="fr-btns-group fr-btns-group--equisized fr-btns-group--sm fr-btns-group--inline-reverse fr-btns-group--inline-lg">
@@ -222,7 +222,7 @@ export default async function Outils() {
             desc="Permettre aux communes de modifier les adresses de son territoire."
             className="fr-card--horizontal-tier fr-card--md"
             imageAlt="mes-adresses"
-            imageUrl="./img/pages/outils/outils-ban.png"
+            imageUrl="/img/pages/outils/outils-ban.png"
             footer={(
               <Button
                 linkProps={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,7 @@ export default async function Home() {
       <SectionHero
         pageTitle="La Base Adresse Nationale"
         picture={{
-          src: './img/home_page_hero_ban.svg',
+          src: '/img/home_page_hero_ban.svg',
           alt: 'Illustration de "La Base Adresse Nationale"',
           width: 400,
           height: 310,

--- a/src/app/ressources-et-documentations/page.tsx
+++ b/src/app/ressources-et-documentations/page.tsx
@@ -20,7 +20,7 @@ export default async function DocumentationPage() {
           <SectionHero
             pageTitle={heroData?.title || ''}
             picture={{
-              src: './img/pages/documentation/image_documentation.svg',
+              src: '/img/pages/documentation/image_documentation.svg',
               alt: 'Illustration pour la documentation',
               width: 400,
               height: 310,

--- a/src/components/SectionHero/SectionHero.stories.tsx
+++ b/src/components/SectionHero/SectionHero.stories.tsx
@@ -49,7 +49,7 @@ const meta = {
         target: '_blank',
       }],
       picture: {
-        src: './img/home_page_hero_ban.svg',
+        src: '/img/home_page_hero_ban.svg',
         alt: 'Illustration de "La base adresse nationale"',
         width: 400,
         height: 310,
@@ -86,7 +86,7 @@ export const Default: Story = {
       target: '_blank',
     }],
     picture: {
-      src: './img/home_page_hero_ban.svg',
+      src: '/img/home_page_hero_ban.svg',
       alt: 'Illustration de "La base adresse nationale"',
       width: 400,
       height: 310,

--- a/src/components/SectionSearchBAN/SectionSearchBAN.tsx
+++ b/src/components/SectionSearchBAN/SectionSearchBAN.tsx
@@ -38,7 +38,7 @@ function SectionSearchBAN({ id }: SectionSearchBANProps) {
       <Wrapper>
         <IntroWrapper>
           <Title>Votre adresse est elle bien renseignée ?</Title>
-          <Image src="./img/map.svg" alt="picto map" width={141} height={140} />
+          <Image src="/img/map.svg" alt="picto map" width={141} height={140} />
         </IntroWrapper>
         <FormWrapper>
           <SearchBAN>

--- a/src/data/sample-actions.json
+++ b/src/data/sample-actions.json
@@ -1,7 +1,7 @@
 [
   {
     "title": "Je débute sur Mes Adresses",
-    "picto": "./img/picto-fr/calendar.svg",
+    "picto": "/img/picto-fr/calendar.svg",
     "link": {
       "href": "/formation-en-ligne",
       "target": "_self"
@@ -10,7 +10,7 @@
   },
   {
     "title": "Comprendre la Base Adresse Locale",
-    "picto": "./img/picto-fr/video.svg",
+    "picto": "/img/picto-fr/video.svg",
     "link": {
       "href": "https://peertube.adresse.data.gouv.fr/w/toyKNe4rKyVD7mUovsWLKd",
       "target": "_self"
@@ -19,7 +19,7 @@
   },
   {
     "title": "Comment mettre à jour ma Base Adresse Locale ?",
-    "picto": "./img/picto-fr/document.svg",
+    "picto": "/img/picto-fr/document.svg",
     "link": {
       "href": "https://doc.adresse.data.gouv.fr/mettre-a-jour-sa-base-adresse-locale/publier-une-base-adresse-locale",
       "target": "_self"
@@ -28,7 +28,7 @@
   },
   {
     "title": "Installer un géocodeur sur son serveur",
-    "picto": "./img/picto-fr/coding.svg",
+    "picto": "/img/picto-fr/coding.svg",
     "link": {
       "href": "https://github.com/BaseAdresseNationale/addok-docker#installer-une-instance-avec-les-donn%C3%A9es-de-la-base-adresse-nationale",
       "target": "_github"

--- a/src/data/sample-bal-info.json
+++ b/src/data/sample-bal-info.json
@@ -3,7 +3,7 @@
     "title": "Faire l’état des lieux",
     "description": "Repérez les adresses manquantes, les doublons...",
     "detail": "Créer une base pour ma commune",
-    "picto": "./img/picto/road.svg",
+    "picto": "/img/picto/road.svg",
     "link": {
       "href": "/programme-bal#creer-sa-base-adresse-locale",
       "target": "_self"
@@ -13,7 +13,7 @@
     "title": "Harmoniser vos adresses",
     "description": "Complétez votre base, consultez la population et délibérez en Conseil municipal.",
     "detail": "Découvrez les bonnes pratiques",
-    "picto": "./img/picto/city-hall.svg",
+    "picto": "/img/picto/city-hall.svg",
     "link": {
       "href": "/documentation-bal#guide-bonnes-pratiques",
       "target": "_self"
@@ -23,7 +23,7 @@
     "title": "Diffuser votre base",
     "description": "Publiez votre base, placez des panneaux et informez vos habitants et partenaires.",
     "detail": "Découvrez les méthodes de publication",
-    "picto": "./img/picto/map-target.svg",
+    "picto": "/img/picto/map-target.svg",
     "link": {
       "href": "https://doc.adresse.data.gouv.fr/mettre-a-jour-sa-base-adresse-locale/publier-une-base-adresse-locale",
       "target": "_blank"

--- a/src/data/sample-ban-info.json
+++ b/src/data/sample-ban-info.json
@@ -2,7 +2,7 @@
   {
     "title": "Comprendre comment utiliser la Base Adresse Nationale ?",
     "description": "Vous souhaitez utiliser la Base Adresse Nationale, explorez les différentes possibilités.",
-    "picto": "./img/picto/map-location.svg",
+    "picto": "/img/picto/map-location.svg",
     "link": {
       "href": "/decouvrir-la-BAN",
       "target": "_self"
@@ -11,7 +11,7 @@
   {
     "title": "Découvrir nos outils et APIs",
     "description": "Vous avez besoin de données toujours à jour ? Découvrez les APIs.",
-    "picto": "./img/picto/api-and-cloud.svg",
+    "picto": "/img/picto/api-and-cloud.svg",
     "link": {
       "href": "/outils",
       "target": "_self"
@@ -20,7 +20,7 @@
   {
     "title": "Télécharger les données",
     "description": "Il est possible de télécharger les données afin de les héberger et de les utiliser chez vous.",
-    "picto": "./img/picto/bdd.svg",
+    "picto": "/img/picto/bdd.svg",
     "link": {
       "href": "/outils/telechargements",
       "target": "_self"


### PR DESCRIPTION
Sur firefox les images pouvaient ne pas s'afficher si on commence la navigation pas une url profonde http://adresse.data.gouv.fr//outils/telechargements et revenir sur l'accueil par exemple

fix #1993