### PR TITLE
Ajout de  last-Modified entete http sur les fichiers à télécharger

### DIFF
--- a/src/views/data/utils/helper.ts
+++ b/src/views/data/utils/helper.ts
@@ -94,6 +94,11 @@ export const asyncSendS3 = (clientS3: AWS.S3) =>
               res.setHeader('Content-Length', ContentLength)
               res.statusCode = 206
             }
+
+            if (req.method === 'HEAD') {
+              return resolve()
+            }
+
             (Body as NodeJS.ReadableStream)
               ?.on('error', (err: Error) => {
                 const formattedDate = getFormatedDate()

--- a/src/views/data/utils/helper.ts
+++ b/src/views/data/utils/helper.ts
@@ -85,7 +85,9 @@ export const asyncSendS3 = (clientS3: AWS.S3) =>
         res.setHeader('Content-Disposition', `attachment; filename="${options.fileName}"`)
 
         clientS3.getObject(options.params)
-          .then(({ Body, AcceptRanges, ContentRange, ContentLength }) => {
+          .then(({ Body, AcceptRanges, ContentRange, ContentLength, LastModified, ETag }) => {
+            res.setHeader('Last-Modified', LastModified?.toUTCString())
+            res.setHeader('Etag', ETag)
             if (AcceptRanges && ContentRange) {
               res.setHeader('Accept-Ranges', AcceptRanges)
               res.setHeader('Content-Range', ContentRange)


### PR DESCRIPTION
Prise en compte des requêtes Head sur les fichiers : évite le téléchargement.

Ajout de last-Modified sur les fichiers fournis sur adresse.data.gouv.fr/data pour réduire les demandes de téléchargements et les clients de vérifier la fraicheur et gérer leur cache.

vérifiable par exemple dans un navigateur
(outil developpeur)
 ou en commande
(HTTP get affiche l'entete)
curl -i https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/lieux-dits-974-beta.csv.gz

HTTP HEAD
curl -I https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/lieux-dits-974-beta.csv.gz

