### PR TITLE
Reduced docker image size from 3.15Go to 1.19Go

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Étape 1 : Construction de l'image avec les variables d'environnement injectées
-FROM node:20.15.1 as builder
+FROM node:20.15.1-alpine as builder
 
 # Définit le répertoire de travail
 WORKDIR /app
@@ -49,7 +49,7 @@ RUN npm i sharp
 RUN npm run build
 
 # Étape 2 : Image de production
-FROM node:20.15.1
+FROM node:20.15.1-alpine
 
 # Définit le répertoire de travail
 WORKDIR /app

--- a/dockerfile
+++ b/dockerfile
@@ -56,13 +56,8 @@ WORKDIR /app
 
 # Copie les fichiers nécessaires de l'étape de build
 COPY --from=builder /app/package.json ./
-COPY --from=builder /app/package-lock.json ./
-COPY --from=builder /app/next.config.mjs ./
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/src ./src
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/.env.default ./
 
 RUN mkdir -p /app/data && chown -R node:node /app/data
 


### PR DESCRIPTION
As the nextjs app is using the 'standalone' mode, there are useless folders that are copied into the image (such as node_modules) that are already copied in the standalone folder

- Removing those useless folder reduces the docker image size by more than **1Go**
- Using alpine image version also reduces the docker image size by more than **1Go**

Result : image size reduced from **3.15Go** to **1.19Go**