### PR TITLE
hotfix HEAD request

### DIFF
--- a/src/views/data/utils/helper.ts
+++ b/src/views/data/utils/helper.ts
@@ -96,6 +96,7 @@ export const asyncSendS3 = (clientS3: AWS.S3) =>
             }
 
             if (req.method === 'HEAD') {
+              res.end()
               return resolve()
             }
 


### PR DESCRIPTION
une HEAD HTTP Request sur les fichiers en téléchargement ne renvoie pas les les bonnes informations (mixed), la requete continuai et gênerai un html

BUG 
Content-Type , la taille, sont aberrants pour la ressource demandée

```console
curl -I https://adresse.data.gouv.fr/data/ban/adresses/2025-01-29/addok/addok-france-bundle.zip 
HTTP/1.1 200 Connection established

HTTP/1.1 200 OK
Date: Thu, 30 Jan 2025 16:19:05 GMT
Content-Type: text/html; charset=utf-8 
Content-Length: 29040
Connection: keep-alive
Content-Disposition: attachment; filename="addok-france-bundle.zip"
Last-Modified: Thu, 30 Jan 2025 04:01:51 GMT
ETag: "cpx33ug08gmcd"
X-Powered-By: Next.js
Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
Vary: Accept-Encoding
Strict-Transport-Security: max-age=31536000; includeSubDomains
```

devrait ressembler à cela
```console
HTTP/1.1 200 OK
Content-Length: 2324611452
Content-Disposition: attachment; filename="addok-france-bundle.zip"
Last-Modified: Thu, 30 Jan 2025 04:01:51 GMT
Etag: "d5d47a86e3a873569bc8c602eeb382e3-444"
Date: Thu, 30 Jan 2025 17:08:17 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```