### PR TITLE
hotfix: change type revision and habilitation

### DIFF
--- a/src/components/FormulaireDePublication/index.tsx
+++ b/src/components/FormulaireDePublication/index.tsx
@@ -22,7 +22,7 @@ import Link from 'next/link'
 
 const getStepIndex = (revision?: Revision, habilitation?: Habilitation) => {
   if (revision && habilitation) {
-    if (revision.status === 'published' && revision.current) {
+    if (revision.status === 'published' && revision.isCurrent) {
       // La révision est publiée, fin du formulaire
       return 4
     }
@@ -32,7 +32,7 @@ const getStepIndex = (revision?: Revision, habilitation?: Habilitation) => {
       return 3
     }
 
-    if (revision.ready && habilitation.status === HabilitationStatus.PENDING) {
+    if (revision.isReady && habilitation.status === HabilitationStatus.PENDING) {
       // Code envoyé par email, on affiche le champ de saisi
       if (habilitation?.strategy?.type === 'email') {
         return 2
@@ -124,8 +124,8 @@ export default function FormulaireDePublication({ initialHabilitation, initialRe
         throw new Error('Une erreur est survenue')
       }
       setIsLoading(true)
-      await sendHabilitationPinCode(habilitation._id)
-      const updatedHabilitation = await getHabilitation(habilitation._id)
+      await sendHabilitationPinCode(habilitation.id)
+      const updatedHabilitation = await getHabilitation(habilitation.id)
       setHabilitation(updatedHabilitation)
     }
     catch (error) {
@@ -142,8 +142,8 @@ export default function FormulaireDePublication({ initialHabilitation, initialRe
         throw new Error('Une erreur est survenue')
       }
       setIsLoading(true)
-      await validateHabilitationPinCode(habilitation._id, pinCode)
-      const updatedHabilitation = await getHabilitation(habilitation._id)
+      await validateHabilitationPinCode(habilitation.id, pinCode)
+      const updatedHabilitation = await getHabilitation(habilitation.id)
       setHabilitation(updatedHabilitation)
     }
     catch (error) {
@@ -160,8 +160,8 @@ export default function FormulaireDePublication({ initialHabilitation, initialRe
         throw new Error('Une erreur est survenue')
       }
       setIsLoading(true)
-      const publishedRevision = await publishRevision(revision._id, JSON.stringify({
-        habilitationId: habilitation._id,
+      const publishedRevision = await publishRevision(revision.id, JSON.stringify({
+        habilitationId: habilitation.id,
       }))
       setRevision(publishedRevision)
     }

--- a/src/components/FormulaireDePublication/steps/HablitationMethod.tsx
+++ b/src/components/FormulaireDePublication/steps/HablitationMethod.tsx
@@ -30,7 +30,7 @@ export function HabilitationMethod({ revision, habilitation, sendPinCode }: Habi
   const franceConnectUrl = `${habilitation.franceconnectAuthenticationUrl}?redirectUrl=${encodeURIComponent(redirectUrl)}`
 
   useEffect(() => {
-    const redirectUrl = `${window.location.href}?revisionId=${revision._id}&habilitationId=${habilitation._id}`
+    const redirectUrl = `${window.location.href}?revisionId=${revision.id}&habilitationId=${habilitation.id}`
     setRedirectUrl(redirectUrl)
   }, [revision, habilitation])
 

--- a/src/lib/api-depot.tsx
+++ b/src/lib/api-depot.tsx
@@ -70,13 +70,13 @@ export async function createRevision(codeCommune: string, file: File): Promise<R
     type: 'text/csv',
   })
 
-  await customFetch(`/api/proxy-api-depot/revisions/${revision._id}/files/bal`, {
+  await customFetch(`/api/proxy-api-depot/revisions/${revision.id}/files/bal`, {
     method: 'PUT',
     headers: { 'Content-Type': 'text/csv' },
     body: _file,
   })
 
-  const computedRevision = await customFetch(`/api/proxy-api-depot/revisions/${revision._id}/compute`, {
+  const computedRevision = await customFetch(`/api/proxy-api-depot/revisions/${revision.id}/compute`, {
     method: 'POST',
   })
 
@@ -131,6 +131,6 @@ export const getRevisionDetails = async (revision: Revision, commune: BANCommune
     `le ${frDateFormatter.format(new Date(revision.createdAt))} à ${new Date(revision.createdAt).toLocaleTimeString().split(':').slice(0, 2).join(':')}`,
     modeDePublication,
     source,
-    <a key={revision._id} href={getRevisionDownloadUrl(revision._id)} download>Fichier CSV</a>,
+    <a key={revision.id} href={getRevisionDownloadUrl(revision.id)} download>Fichier CSV</a>,
   ]
 }

--- a/src/types/api-depot.types.ts
+++ b/src/types/api-depot.types.ts
@@ -1,13 +1,13 @@
 export type Revision = {
-  _id: string
+  id: string
   codeCommune: string
   client: {
-    _id: string
+    id: string
     nom: string
     mandataire: string
   }
   status: string
-  ready: any
+  isReady: any
   validation: {
     valid: boolean
     validatorVersion: string
@@ -22,10 +22,9 @@ export type Revision = {
   publishedAt: string
   createdAt: string
   updatedAt: string
-  __v: number
-  current: boolean
+  isCurrent: boolean
   habilitation: {
-    _id: string
+    id: string
     codeCommune: string
     emailCommune: string
     strategy: any
@@ -42,7 +41,7 @@ export enum HabilitationStatus {
 }
 
 export type Habilitation = {
-  _id: string
+  id: string
   codeCommune: string
   emailCommune: string
   franceconnectAuthenticationUrl: string


### PR DESCRIPTION
## CONTEXT

Depuis la migration de l'api-depot les type `revision` et `habilitation` ont le `_id` remplacer par `id` ce qui créer de nombreux petit bug