### PR TITLE
hotfix: update package validateur to 2.22.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",
-        "@ban-team/validateur-bal": "^2.22.0",
+        "@ban-team/validateur-bal": "^2.22.1",
         "@codegouvfr/react-dsfr": "^1.14.1",
         "@etalab/decoupage-administratif": "^4.0.0",
         "@next/bundle-analyzer": "^14.2.13",
@@ -2978,9 +2978,9 @@
       "license": "MIT"
     },
     "node_modules/@ban-team/validateur-bal": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-2.22.0.tgz",
-      "integrity": "sha512-MULBYYnHbxXwiLnnIHH/oEC2xgdfKquPByI26ITWY6QVLlClnUgBRpqJejten8M7QV/NIsVex2vXRsQ8mj555A==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-2.22.1.tgz",
+      "integrity": "sha512-PZkfA3WJ1IYiurgTfjy/8FeSpS0nfA0qn+7IDlNw9bKbSlESxSRbsNMh+YUN5iR/PrNa5afJ8eejsAkC/bmZ1Q==",
       "license": "MIT",
       "dependencies": {
         "@ban-team/shared-data": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.645.0",
-    "@ban-team/validateur-bal": "^2.22.0",
+    "@ban-team/validateur-bal": "^2.22.1",
     "@codegouvfr/react-dsfr": "^1.14.1",
     "@etalab/decoupage-administratif": "^4.0.0",
     "@next/bundle-analyzer": "^14.2.13",


### PR DESCRIPTION
## CONTEXT

- Le validateur en ligne ne marche plus a cause d'une redirection casser dans la package
- Mise a jour du package corrigé 2.22.1