### PR TITLE
Actualisé les données sur la home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,8 @@ import dataQuotes from '@/data/sample-quotes.json'
 
 import { CardContainer } from './page.styles'
 
+export const revalidate = 3600 // 1 hour
+
 export default async function Home() {
   const stats = await getStats()
   const highlightedDatas = await getPosts({ limit: 3 })


### PR DESCRIPTION
Les données sur la page d'acceuil sont celle calculer lors  du build (ou deployment ) de la l'application. le nombre de communes et les articles ne suivent pas d'actualité. 

Pour pas avoir trop de requete le s donnée sont cache sur une periode de 1h.

! Voir pour le mécanisme de cache une centralisation pour un déploiement multi-node sans artefact