### PR TITLE
Force la page blog à un rendu dynamique

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -18,6 +18,8 @@ import {
 
 import AsideContent from './components/AsideContent'
 
+export const dynamic = 'force-dynamic'
+
 export default async function BlogPost({ params }: { params: { slug: string } }) {
   const pageUrl = `https://adresse.data.gouv.fr/blog/${params.slug}`
   const blogPost = await getSinglePost(params.slug) || {}


### PR DESCRIPTION
**Contenu**
Force le rendu dynamique de la page blog. 


**Contexte**
Les pages blog sont peu visité, et  sont en cache par défaut.
Si l'article est mis à jour, la page du site n'est pas recalculer : Nous n'avons pas de back office pour relancer les regénérations des pages en cache ou static (de plus dans un environnement multi node).

Avec ces constats, le rendu dynamique semble une solution adapté pour que les modifications sur les articles soient accessibles.