### PR TITLE
fix: update doc link

### DIFF
--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -219,7 +219,7 @@ export default function Header(
           {
             iconId: 'fr-icon-book-2-fill',
             linkProps: {
-              href: '/ressources-et-documentations',
+              href: '/documentation-bal',
             },
             text: <Tooltip kind="hover" title="Ressources & Documentations">La Documentation</Tooltip>,
           },


### PR DESCRIPTION
Changement : Le bouton "La documentation" dans le bandeau du haut redirige vers la page "Documentation adressage" (https://adresse.data.gouv.fr/documentation-bal)