### PR TITLE
force horaire de revision en h24

### DIFF
--- a/src/lib/api-depot.tsx
+++ b/src/lib/api-depot.tsx
@@ -140,7 +140,7 @@ export const getRevisionDetails = async (revision: Revision, commune: BANCommune
 
   return [
     revision.isCurrent ? <Tooltip message="Révision courante"><span className="fr-icon-success-line" aria-hidden="true" /></Tooltip> : '',
-    `le ${frDateFormatter.format(new Date(revision.createdAt))} à ${new Date(revision.createdAt).toLocaleTimeString().split(':').slice(0, 2).join(':')}`,
+    `le ${frDateFormatter.format(new Date(revision.createdAt))} à ${new Date(revision.createdAt).toLocaleTimeString('fr', { hour12: false }).split(':').slice(0, 2).join(':')}`,
     modeDePublication,
     source,
     <a className="fr-btn" key={revision.id} href={getRevisionDownloadUrl(revision.id)} download><span className="fr-icon-download-line" aria-hidden="true" /></a>,


### PR DESCRIPTION
Sur la page  commune, affichage de l'horaire au format 24h des dernières publications de bal. 

fixed #2094 

NB: la date et l'horaire sont au format/local du serveur 

**Aperçu du bug**
![image](https://github.com/user-attachments/assets/a9f3d9f7-240e-451f-a4fa-81c547e245fa)
