### PR TITLE
Desactivation demande activation certificat adressage

### DIFF
--- a/src/components/Commune/CommuneActions/index.tsx
+++ b/src/components/Commune/CommuneActions/index.tsx
@@ -44,15 +44,14 @@ function CommuneActions({ district, actionProps }: CommuneActionsProps) {
                   </CommuneConfigItem>
                 </Tooltip>
               )
-            : (
-                <Button
+            : null}
+          {/* <Button
                   key="set-config"
                   iconId="ri-file-paper-2-line"
                   onClick={() => setIsConfigDistrictVisible(!isConfigDistrictVisible)}
                 >
                   Demander l’activation du certificat d’adressage
-                </Button>
-              )}
+                </Button> */}
         </CommuneActionsActionsWrapper>
         <Section title={`Demande d'activation du certificat d'adressage pour la commune de ${district.nomCommune}`} theme="grey" isVisible={isConfigDistrictVisible}>
           <p>


### PR DESCRIPTION
Temporairement il faut désactiver l'activation du certificat d'adressage pour traiter les demandes en cours et améliorer le système.