### PR TITLE
fix: horaires list past revisions

### DIFF
--- a/src/components/Commune/CommuneCertificationBar/index.tsx
+++ b/src/components/Commune/CommuneCertificationBar/index.tsx
@@ -4,10 +4,12 @@ import { assemblageSources } from '@/lib/api-ban'
 import { BANCommune } from '@/types/api-ban.types'
 import formatNumber from '@/app/carte-base-adresse-nationale/tools/formatNumber'
 import { StyledWrapper } from './CommuneCertificationBar.styles'
+import { format, parseISO } from 'date-fns'
+import { fr } from 'date-fns/locale'
 
 interface CommuneCertificationBarProps {
   commune: BANCommune
-  lastRevisionsDetails: (string | JSX.Element)[][] | null
+  lastRevisionsDetails: (string | JSX.Element | null)[][] | null
   certificationPercentage: number
   communeHasBAL: boolean
 }
@@ -69,7 +71,7 @@ export function CommuneCertificationBar({ commune, certificationPercentage, comm
           </label>
           <div>
             {!communeHasBAL && '-'}
-            {communeHasBAL && lastRevisionsDetails && (lastRevisionsDetails[0][1] as string).split(' à ')[0]}
+            {communeHasBAL && lastRevisionsDetails && format(parseISO(lastRevisionsDetails[0][1] as string), '\'le\' dd MMMM yyyy \'à\' HH:mm', { locale: fr })}
           </div>
         </div>
       </CardWrapper>

--- a/src/components/Commune/CommuneUpdatesSection.tsx
+++ b/src/components/Commune/CommuneUpdatesSection.tsx
@@ -3,9 +3,12 @@
 import styled from 'styled-components'
 import Section from '../Section'
 import Table from '@codegouvfr/react-dsfr/Table'
+import { useMemo } from 'react'
+import { format, parseISO } from 'date-fns'
+import { fr } from 'date-fns/locale'
 
 interface CommuneUpdatesSectionProps {
-  lastRevisionsDetails: (string | JSX.Element)[][]
+  lastRevisionsDetails: (string | JSX.Element | null)[][]
 }
 
 const StyledWrapper = styled.div`
@@ -55,6 +58,16 @@ const StyledWrapper = styled.div`
 `
 
 export function CommuneUpdatesSection({ lastRevisionsDetails }: CommuneUpdatesSectionProps) {
+  const data = useMemo(() => {
+    return lastRevisionsDetails.map((revision) => {
+      return [
+        revision[0],
+        format(parseISO(revision[1] as string), '\'le\' dd MMMM yyyy \'à\' HH:mm', { locale: fr }),
+        ...revision.slice(2),
+      ]
+    })
+  }, [lastRevisionsDetails])
+
   return (
     <Section title="Les dernières mises à jour">
       <StyledWrapper>
@@ -66,7 +79,7 @@ export function CommuneUpdatesSection({ lastRevisionsDetails }: CommuneUpdatesSe
             'Source',
             'Télécharger',
           ]}
-          data={lastRevisionsDetails}
+          data={data}
         />
       </StyledWrapper>
     </Section>

--- a/src/lib/api-depot.tsx
+++ b/src/lib/api-depot.tsx
@@ -1,4 +1,6 @@
 import { customFetch } from '@/lib/fetch'
+import { format, parseISO } from 'date-fns'
+import { fr } from 'date-fns/locale'
 import { ClientApiDepotWithChefDeFileType, Habilitation, Revision } from '@/types/api-depot.types'
 import { getDataset } from './api-data-gouv'
 import { BANCommune } from '@/types/api-ban.types'
@@ -140,7 +142,7 @@ export const getRevisionDetails = async (revision: Revision, commune: BANCommune
 
   return [
     revision.isCurrent ? <Tooltip message="Révision courante"><span className="fr-icon-success-line" aria-hidden="true" /></Tooltip> : '',
-    `le ${frDateFormatter.format(new Date(revision.createdAt))} à ${new Date(revision.createdAt).toLocaleTimeString('fr', { hour12: false }).split(':').slice(0, 2).join(':')}`,
+    format(parseISO(revision.createdAt), '\'le\' dd MMMM yyyy \'à\' HH:mm', { locale: fr }),
     modeDePublication,
     source,
     <a className="fr-btn" key={revision.id} href={getRevisionDownloadUrl(revision.id)} download><span className="fr-icon-download-line" aria-hidden="true" /></a>,

--- a/src/lib/api-depot.tsx
+++ b/src/lib/api-depot.tsx
@@ -108,8 +108,6 @@ export const getCurrentRevisionDownloadUrl = (codeCommune: string) => {
   return `${env('NEXT_PUBLIC_API_DEPOT_URL')}/communes/${codeCommune}/current-revision/files/bal/download`
 }
 
-const frDateFormatter = new Intl.DateTimeFormat('fr', { day: 'numeric', month: 'long', year: 'numeric' })
-
 export const getRevisionDetails = async (revision: Revision, commune: BANCommune) => {
   let modeDePublication = '-'
   if (revision?.context?.extras?.sourceId) {
@@ -142,7 +140,7 @@ export const getRevisionDetails = async (revision: Revision, commune: BANCommune
 
   return [
     revision.isCurrent ? <Tooltip message="Révision courante"><span className="fr-icon-success-line" aria-hidden="true" /></Tooltip> : '',
-    format(parseISO(revision.createdAt), '\'le\' dd MMMM yyyy \'à\' HH:mm', { locale: fr }),
+    revision.publishedAt,
     modeDePublication,
     source,
     <a className="fr-btn" key={revision.id} href={getRevisionDownloadUrl(revision.id)} download><span className="fr-icon-download-line" aria-hidden="true" /></a>,


### PR DESCRIPTION
Les horaires de a liste des révision n'est pas bien converti en prod et avance de 2h
-> Petit fix pour avoir la bonne horaire

![Capture d’écran 2025-05-27 à 14 30 52](https://github.com/user-attachments/assets/f0497d52-b4f2-4d1c-983f-682a41b6aff9)
