### PR TITLE
issue2162: Modification wording certificat

### DIFF
--- a/src/app/carte-base-adresse-nationale/components/PanelAddress/PanelAddressFooter.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelAddress/PanelAddressFooter.tsx
@@ -81,8 +81,8 @@ function AsideFooterAddress({ banItem: address, withCertificate, children, onCli
                   id={address.id}
                   message={(
                     <>
-                      Les certifications d’adresses sur la commune de {address.commune.nom} sont
-                      réalisées directement par la mairie.<br />
+                      L&apos;émission de certificats d&apos;adressage sur la commune de {address.commune.nom} est
+                      réalisée directement par la mairie.<br />
                       <Link className="fr-link" href={mairiePageURL || ''} target="_blank">Contactez-la</Link> pour obtenir un certificat d’adressage ou toute autre information.
                     </>
                   )}


### PR DESCRIPTION
Modification du wording pour le certificat d'adressage sur la carte s'il est indisponible pour la commune
Fix : #2162 

Après modification voici le résultat :
![Capture d’écran du 2025-06-06 14-27-54](https://github.com/user-attachments/assets/59e2d1b7-7e9d-4452-9575-b46109a820d4)
