### PR TITLE
Suppression bandeau alerte Cog 2025

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,9 +38,9 @@ export default function RootLayout({ children }: { children: JSX.Element }) {
     // data: [sampleNotice],
     // data: [],
     data: [{
-      text: 'Operation en cours : Passage du Code officiel géographique 2025.',
+      //text: 'Operation en cours : Passage du Code officiel géographique 2025.',
       // link?: { href: string; target?: string}
-      link: { href: '/outils/telechargements' },
+      //link: { href: '/outils/telechargements' },
     }],
     duration: 4000,
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,9 +38,9 @@ export default function RootLayout({ children }: { children: JSX.Element }) {
     // data: [sampleNotice],
     // data: [],
     data: [{
-      //text: 'Operation en cours : Passage du Code officiel géographique 2025.',
+      // text: 'Operation en cours : Passage du Code officiel géographique 2025.',
       // link?: { href: string; target?: string}
-      //link: { href: '/outils/telechargements' },
+      // link: { href: '/outils/telechargements' },
     }],
     duration: 4000,
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,12 +36,7 @@ export default function RootLayout({ children }: { children: JSX.Element }) {
 
   const dataNotices = {
     // data: [sampleNotice],
-    // data: [],
-    data: [{
-      // text: 'Operation en cours : Passage du Code officiel géographique 2025.',
-      // link?: { href: string; target?: string}
-      // link: { href: '/outils/telechargements' },
-    }],
+    data: [],
     duration: 4000,
   }
 


### PR DESCRIPTION
Comme le cog est fini maintenant, il faut supprimer le bandeau d'alertes sur le site.
Fix: #2167 