### PR TITLE
Modification page geocodage et outils

### DIFF
--- a/public/markdown/apis/api-adresse.md
+++ b/public/markdown/apis/api-adresse.md
@@ -1,11 +1,22 @@
 ---
-title: API Adresse
+title: Service de géocodage Géoplateforme
 ---
 
-L’API adresse permet notamment d’effectuer rapidement une recherche d’adresse, mais aussi de pouvoir associer des coordonnées à une adresse ("géocoder") selon plusieurs critères. On vous explique tout en détail ici : [Guide sur l’API Adresse](https://guides.data.gouv.fr/reutiliser-des-donnees/utiliser-les-api-geographiques/utiliser-lapi-adresse).
+
+Le Service de géocodage Géoplateforme permet d'effectuer rapidement une recherche d’adresse, mais aussi associer selon plusieurs critères des coordonnées à une adresse, un point d'intérêt ou une parcelle cadastrale.
+
+Il existe 2 types de geoocodage (direct et inverse):
+
+* Le service de géocodage **direct**  permet de fournir les coordonnées géographiques d’une adresse postale, d’un lieu ou de parcelles cadastrales à partir d’une requête HTTP.
+* Le service de géocodage **inverse** a pour but de retourner, à partir d’un ou plusieurs points géographiques indiqués en latitude/longitude, la ou les entités géolocalisées les plus proches correspondantes, parmi les adresses, toponymes, parcelles cadastrales, et/ou unités administratives.
+
+Vous pouvez avoir plus d'informations sur les fonctionnalités en consultant [la documentation Service Géoplateforme de Géocodage](https://geoservices.ign.fr/documentation/services/services-geoplateforme/geocodage)
 
 Vous atteignez fréquemment la limite de requête de l’API, fixée à 50 appels / seconde/ IP ?
 
 2 options s’offrent à vous :
 *  Vous pouvez installer une instance de l’API sur vos propres serveurs. Nous vous indiquons la marche à suivre sur cette page : [Installer une instance docker avec les données de la BAN](https://github.com/BaseAdresseNationale/addok-docker#installer-une-instance-avec-les-donn%C3%A9es-de-la-base-adresse-nationale)
-*  Vous êtes un acteur public ET vous ne pouvez pas installer d’instance sur votre Système d’Information : vous pouvez demander une levée de cette limite au moyen de cette Démarche Simplifiée : [Demander une levée de limite](https://www.demarches-simplifiees.fr/commencer/demande-de-levee-de-limite-de-l-api-base-adresse)
+*  Vous êtes un acteur public ET vous ne pouvez pas installer d’instance sur votre Système d’Information : vous pouvez demander une levée de cette limite en remplissant un formulaire sur [la page contact géoservices de l'IGN](https://geoservices.ign.fr/contact)
+*  
+
+

--- a/public/markdown/apis/service-geocodage--intro.md
+++ b/public/markdown/apis/service-geocodage--intro.md
@@ -1,0 +1,16 @@
+---
+title: Service de géocodage Géoplateforme
+---
+
+Le Service de géocodage Géoplateforme permet d'effectuer rapidement une recherche d’adresse, mais aussi associer selon plusieurs critères des coordonnées à une adresse, un point d'intérêt ou une parcelle cadastrale.
+
+Il existe 2 types de geocodage (direct et inverse):
+
+* Le service de géocodage **direct**  permet de fournir les coordonnées géographiques d’une adresse postale, d’un lieu ou de parcelles cadastrales à partir d’une requête HTTP.
+* Le service de géocodage **inverse** a pour but de retourner, à partir d’un ou plusieurs points géographiques indiqués en latitude/longitude, la ou les entités géolocalisées les plus proches correspondantes, parmi les adresses, toponymes, parcelles cadastrales, et/ou unités administratives.
+
+Vous pouvez avoir plus d'informations sur l'utilisation en consultant [la documentation du Service Géoplateforme de Géocodage](https://geoservices.ign.fr/documentation/services/services-geoplateforme/geocodage)
+
+
+
+

--- a/public/markdown/apis/service-geocodage--la-base-adresse-nationale.md
+++ b/public/markdown/apis/service-geocodage--la-base-adresse-nationale.md
@@ -1,0 +1,10 @@
+---
+title: Service de géocodage Géoplateforme - La Base Adresse Nationale
+---
+
+### Caractéristiques
+
+- Producteur : IGN
+- Licence : [Licence Ouverte](https://www.etalab.gouv.fr/licence-ouverte-open-licence/)
+- Fréquence de mise à jour du géocodeur : Tous les lundis
+- Couverture : France entière (y compris les collectivités d’outremer)

--- a/public/markdown/apis/service-geocodage.md
+++ b/public/markdown/apis/service-geocodage.md
@@ -1,0 +1,15 @@
+---
+title: Service de Géocodage Géoplateforme
+aside: [{attach: "la-base-adresse-nationale", filename: "service-geocodage--la-base-adresse-nationale"}]
+---
+
+## Utilisation importante du service du Géocodage de la Géoplateforme ?
+
+Vous atteignez fréquemment la limite de requête de l’API, fixée à 50 appels / seconde/ IP ?
+
+2 options s’offrent à vous :
+*  Vous pouvez installer une instance de l’API sur vos propres serveurs. Nous vous indiquons la marche à suivre sur cette page : [Installer une instance docker avec les données de la BAN](https://github.com/BaseAdresseNationale/addok-docker#installer-une-instance-avec-les-donn%C3%A9es-de-la-base-adresse-nationale)
+*  Vous êtes un acteur public ET vous ne pouvez pas installer d’instance sur votre Système d’Information : vous pouvez demander une levée de cette limite en remplissant un formulaire sur [la page contact géoservices de l'IGN](https://geoservices.ign.fr/contact)
+ 
+
+

--- a/src/app/outils/api-doc/adresse/page.styled.tsx
+++ b/src/app/outils/api-doc/adresse/page.styled.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import styled, { css } from 'styled-components'
+
+export const TextWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1rem;
+
+    div~fr-card {
+    width: 588px;
+    height: 256px;
+    gap: 0px;
+    border: 1px 0px 0px 0px;
+    opacity: 0px;
+
+    }
+`
+
+const gap = '1rem'
+export const CardContainer = styled.div<{ $cols?: number }>`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: ${gap};
+
+  
+  & > div {
+    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: ${({ $cols = 3 }) => css`calc(${(100 / $cols).toFixed(2)}% - ${gap})`};
+    min-width: 250px;
+}
+`

--- a/src/app/outils/api-doc/adresse/page.tsx
+++ b/src/app/outils/api-doc/adresse/page.tsx
@@ -2,12 +2,17 @@ import Breadcrumb from '@/layouts/Breadcrumb'
 import { getMarkdown } from '@/lib/markdown'
 import type { DataType } from '@/lib/markdown'
 import { Suspense } from 'react'
+import { CallOut } from '@codegouvfr/react-dsfr/CallOut'
+import Section from '@/components/Section'
 import SectionHero from '@/components/SectionHero'
 import HtmlViewer from '@/components/HtmlViewer'
-import CurlDoc from './components/curl-doc'
+
+import { TextWrapper } from './page.styled'
 
 async function ApiAdresse() {
-  const { contentHtml: heroContentHtml, data: heroData }: { contentHtml?: string, data?: DataType } = await getMarkdown('/apis/api-adresse') || {}
+  const { contentHtml: heroContentHtml, data: heroData }: { contentHtml?: string, data?: DataType } = await getMarkdown('/apis/service-geocodage--intro') || {}
+  const { contentHtml, data }: { contentHtml?: string, data?: DataType } = await getMarkdown('/apis/service-geocodage') || {}
+
   return (
     <>
       <base target="_blank"></base>
@@ -38,7 +43,29 @@ async function ApiAdresse() {
           </SectionHero>
         )}
       </Suspense>
-      <CurlDoc />
+
+      <Section>
+        <TextWrapper>
+          <Suspense fallback={<p>Chargement...</p>}>
+            <article>
+              {contentHtml && <HtmlViewer html={contentHtml} />}
+            </article>
+            {
+              data?.aside && (
+                <aside>{data?.aside?.map(
+                  ({ data }) =>
+                    data?.contentHtml && (
+                      <CallOut key={`${data?.data?.title}`}>
+                        <HtmlViewer html={data?.contentHtml} />
+                      </CallOut>
+                    )
+                )}
+                </aside>
+              )
+            }
+          </Suspense>
+        </TextWrapper>
+      </Section>
     </>
   )
 }

--- a/src/app/outils/page.tsx
+++ b/src/app/outils/page.tsx
@@ -98,20 +98,18 @@ export default async function Outils() {
 
             />
             <Card
-              title="Api de géocodage (Nouveau)"
+              title="Service de géocodage Géoplateforme"
               titleAs="h5"
               desc="Effectuer rapidement une recherche d’adresse, mais aussi associer selon plusieurs critères des coordonnées à une adresse, un point d'intérêt ou une parcelle cadastrale."
               className="fr-card--horizontal-tier fr-card--md"
               footer={(
                 <Button
-                  iconId="fr-icon-code-s-slash-line"
                   linkProps={{
-                    href: 'https://geoservices.ign.fr/documentation/services/services-geoplateforme/geocodage',
-                    target: '_blank',
+                    href: '/outils/api-doc/adresse',
                   }}
                   size="small"
                 >
-                  Documentation
+                  Service de géocodage Géoplateforme
                 </Button>
               )}
             />
@@ -146,23 +144,6 @@ export default async function Outils() {
                   size="small"
                 >
                   Géocodeur CSV
-                </Button>
-              )}
-            />
-            <Card
-              title="API Adresse (en cours de transfert vers le Service de géocodage de la Géoplateforme)"
-              titleAs="h5"
-              desc="Effectuer rapidement une recherche d’adresse pour y associer des coordonnées (géocoder) suivant plusieurs critères."
-              className="fr-card--horizontal-tier fr-card--md"
-              footer={(
-                <Button
-                  iconId="fr-icon-code-s-slash-line"
-                  linkProps={{
-                    href: '/outils/api-doc/adresse',
-                  }}
-                  size="small"
-                >
-                  API adresse
                 </Button>
               )}
             />


### PR DESCRIPTION
- Modification de la page api-adresse qui devient service Geocodage de la géoplateforme
- Modification de la page outils pour supprimer l'ancien bloc api geocodage dinum
-Fix: #2152 