### PR TITLE
fix: console moissonneur when other source published

### DIFF
--- a/src/components/Partenaires/Moissonnage/MoissonneurBAL.tsx
+++ b/src/components/Partenaires/Moissonnage/MoissonneurBAL.tsx
@@ -21,6 +21,20 @@ export default function MoissonneurBal({ partenaireDeLaCharte }: MoissonneurBalP
   const [isLoading, setIsLoading] = useState(true)
   const [sources, setSources] = useState<ExtendedSourceMoissoneurType[]>([])
   const [aggregatedPerimeters, setAggregatedPerimeters] = useState<PerimeterType[]>([])
+  const [openAccordions, setOpenAccordions] = useState<Set<string>>(new Set())
+
+  const handleAccordionToggle = (sourceId: string, expanded: boolean) => {
+    setOpenAccordions((prev) => {
+      const newSet = new Set(prev)
+      if (expanded) {
+        newSet.add(sourceId)
+      }
+      else {
+        newSet.delete(sourceId)
+      }
+      return newSet
+    })
+  }
 
   useEffect(() => {
     async function fetchData() {
@@ -50,52 +64,56 @@ export default function MoissonneurBal({ partenaireDeLaCharte }: MoissonneurBalP
           <Perimeters perimeters={aggregatedPerimeters} style={{ marginBottom: '1rem' }} />
           <section>
             <p>Les fichiers BAL mis à disposition sont quotidiennement moissonnés sur la plateforme ouverte des données publiques françaises (data.gouv.fr).</p>
-            <div className="fr-accordions-group">
-              {sources.map(source => (
-                <Accordion
-                  id={source.id}
-                  key={source.id}
-                  label={(
+            {sources.map(source => (
+              <Accordion
+                id={source.id}
+                key={source.id}
+                expanded={openAccordions.has(source.id)}
+                onExpandedChange={(expanded: boolean) => handleAccordionToggle(source.id, expanded)}
+                label={(
+                  <div>
+                    <p style={{ marginBottom: 5 }}>{source.title}</p>
                     <div>
-                      <p style={{ marginBottom: 5 }}>{source.title}</p>
-                      <div>
-                        {source.deletedAt
-                          ? (
-                              <Badge severity="error" style={{ marginRight: 5, marginBottom: 2 }}>
-                                Supprimé
-                              </Badge>
-                            )
-                          : (source.enabled
-                              ? (
-                                  <Badge severity="success" style={{ marginRight: 5, marginBottom: 2 }}>
-                                    Activé
-                                  </Badge>
-                                )
-                              : (
-                                  <Badge severity="error" style={{ marginRight: 5, marginBottom: 2 }}>
-                                    Désactivé
-                                  </Badge>
-                                ))}
-                        {(source.harvestError || (source.nbRevisionError && source.nbRevisionError > 0))
-                          ? (
-                              <Badge severity="error" style={{ marginRight: 5, marginBottom: 2 }}>
-                                Erreur(s)
-                              </Badge>
-                            )
-                          : (
-                              <Badge severity="success" style={{ marginRight: 5, marginBottom: 2 }}>
-                                Aucune Erreur
-                              </Badge>
-                            )}
-                      </div>
+                      {source.deletedAt
+                        ? (
+                            <Badge severity="error" style={{ marginRight: 5, marginBottom: 2 }}>
+                              Supprimé
+                            </Badge>
+                          )
+                        : (source.enabled
+                            ? (
+                                <Badge severity="success" style={{ marginRight: 5, marginBottom: 2 }}>
+                                  Activé
+                                </Badge>
+                              )
+                            : (
+                                <Badge severity="error" style={{ marginRight: 5, marginBottom: 2 }}>
+                                  Désactivé
+                                </Badge>
+                              ))}
+                      {(source.harvestError || (source.nbRevisionError && source.nbRevisionError > 0))
+                        ? (
+                            <Badge severity="error" style={{ marginRight: 5, marginBottom: 2 }}>
+                              Erreur(s)
+                            </Badge>
+                          )
+                        : (
+                            <Badge severity="success" style={{ marginRight: 5, marginBottom: 2 }}>
+                              Aucune Erreur
+                            </Badge>
+                          )}
                     </div>
-                  )}
-                >
-                  <MoissonneurHarvestList sourceId={source.id} />
-                  <MoissonneurRevisionsList sourceId={source.id} />
-                </Accordion>
-              ))}
-            </div>
+                  </div>
+                )}
+              >
+                {openAccordions.has(source.id) && (
+                  <>
+                    <MoissonneurHarvestList sourceId={source.id} />
+                    <MoissonneurRevisionsList sourceId={source.id} />
+                  </>
+                )}
+              </Accordion>
+            ))}
           </section>
         </Section>
       )

--- a/src/components/Partenaires/Moissonnage/moissonneur-revision/MoissonneurRevisionItem.tsx
+++ b/src/components/Partenaires/Moissonnage/moissonneur-revision/MoissonneurRevisionItem.tsx
@@ -5,8 +5,11 @@ import Badge from '@codegouvfr/react-dsfr/Badge'
 import UpdateStatusBadge from '../../UpdateStatus'
 import { getFileLink } from '@/lib/api-moissonneur-bal'
 import Button from '@codegouvfr/react-dsfr/Button'
-import { PublicationMoissoneurType, RevisionMoissoneurType } from '@/types/api-moissonneur-bal.types'
+import { PublicationMoissoneurType, RevisionMoissoneurType, RevisionStatusMoissoneurEnum } from '@/types/api-moissonneur-bal.types'
 import { env } from 'next-runtime-env'
+import { Revision } from '@/types/api-depot.types'
+import { useEffect, useState } from 'react'
+import { getCurrentRevision } from '@/lib/api-depot'
 
 const otherClients = [
   {
@@ -23,38 +26,85 @@ const otherClients = [
   },
 ]
 
-function PublicationStatusBadge({ status, currentClientId, errorMessage }: PublicationMoissoneurType) {
-  if (status === 'provided-by-other-client') {
-    const client = otherClients.find(({ id }) => id === currentClientId)
+export interface RevisionPublicationProps {
+  publicationMoissoneur: PublicationMoissoneurType
+  revisionApiDepot?: Revision
+}
+
+export const PublicationStatusBadge = ({
+  publicationMoissoneur,
+  revisionApiDepot,
+}: RevisionPublicationProps) => {
+  if (
+    publicationMoissoneur?.status === RevisionStatusMoissoneurEnum.PROVIDED_BY_OTHER_CLIENT
+  ) {
     return (
-      <Tooltip message={client?.name || 'Client api depot'}>
-        <Badge severity="warning" noIcon>Publiée par un autre client</Badge>
+      <Tooltip message={publicationMoissoneur?.currentClientId || 'inconnue'}>
+        <Badge severity="warning" noIcon>
+          Publiée par un autre client
+        </Badge>
       </Tooltip>
     )
   }
 
-  if (status === 'provided-by-other-source') {
-    return <Badge severity="error" noIcon>Publiée par un autre Moissonneur</Badge>
-  }
-
-  if (status === 'published') {
-    return <Badge severity="success" noIcon>Publiée</Badge>
-  }
-
-  if (status === 'error') {
+  if (
+    publicationMoissoneur?.status === RevisionStatusMoissoneurEnum.PROVIDED_BY_OTHER_SOURCE
+  ) {
     return (
-      <Tooltip message={errorMessage}>
-        <Badge severity="error" noIcon>Erreur</Badge>
+      <Tooltip message={publicationMoissoneur?.currentSourceId || 'inconnue'}>
+        <Badge severity="error" noIcon>
+          Publiée par une autre source
+        </Badge>
       </Tooltip>
     )
   }
 
-  return (
-    <Badge noIcon>Non publiée</Badge>
-  )
+  if (
+    publicationMoissoneur?.status === RevisionStatusMoissoneurEnum.PUBLISHED
+  ) {
+    if (
+      revisionApiDepot && revisionApiDepot.id !== publicationMoissoneur.publishedRevisionId
+    ) {
+      return (
+        <Badge severity="info" noIcon>
+          Remplacée par {revisionApiDepot.client.nom}
+        </Badge>
+      )
+    }
+    return (
+      <Badge severity="success" noIcon>
+        Publiée
+      </Badge>
+    )
+  }
+
+  if (publicationMoissoneur?.status === RevisionStatusMoissoneurEnum.ERROR) {
+    return (
+      <Tooltip message={publicationMoissoneur?.errorMessage}>
+        <Badge severity="error" noIcon>
+          Erreur
+        </Badge>
+      </Tooltip>
+    )
+  }
+
+  return <Badge noIcon>Non publiée</Badge>
 }
 
 export default function MoissonneurRevisionItem({ codeCommune, createdAt, validation, updateStatus, updateRejectionReason, publication, fileId }: RevisionMoissoneurType) {
+  const [revision, setRevision] = useState<Revision | undefined>(undefined)
+
+  useEffect(() => {
+    const fetchRevision = async () => {
+      if (codeCommune) {
+        const results = await getCurrentRevision(codeCommune)
+        setRevision(results)
+      }
+    }
+
+    fetchRevision()
+  }, [codeCommune])
+
   return (
     <tr>
       <td className="fr-col fr-my-1v">
@@ -70,7 +120,7 @@ export default function MoissonneurRevisionItem({ codeCommune, createdAt, valida
         <UpdateStatusBadge status={updateStatus} error={updateRejectionReason} />
       </td>
       <td className="fr-col fr-my-1v" style={{ textAlign: 'center' }}>
-        {publication && <PublicationStatusBadge {...publication} />}
+        {publication && <PublicationStatusBadge publicationMoissoneur={publication} revisionApiDepot={revision} />}
       </td>
       <td className="fr-col fr-my-1v">
         {fileId && <Button linkProps={{ href: getFileLink(fileId) }}>Télécharger</Button>}


### PR DESCRIPTION
## CONTEXT

Sur les consoles de visualisations des partenaires qui moissonnent, il manque l'indication lorsque la BAL est publiée via un autre client (Mes Adresses). Exemple avec Mayran, sur la page du SMICA on a l'impression que tout est ok sur cette commune, le moissonnage n'a aucune erreur, les mises à jour bien récupérées... saufc que Mayran est publié via Mes Adresses https://adresse.data.gouv.fr/commune/12142

## FONCTIONNALITE

- Optimisation: lancement des requêtes pour récupérer les harvests et révisions du moissonneur lorsque l'on ouvre l'Accordion de la source, pour éviter de lancer des 100ain requêtes au chargement de la page comme pour https://adresse.data.gouv.fr/partenaires/64ecadcef5e9efbd57bdcfe7

- Ajout de la comparaison avec la revision courante pour savoir si la révision du moissonneur a été remplacée
<img width="1188" height="693" alt="Capture d’écran 2025-08-13 à 15 24 18" src="https://github.com/user-attachments/assets/2e0b041e-aa99-4c0b-84a6-ede2dbcb1f2b" />
