### PR TITLE
Modification lien page documentation 

### DIFF
--- a/public/markdown/ressources-et-documentations/documentation.md
+++ b/public/markdown/ressources-et-documentations/documentation.md
@@ -6,7 +6,7 @@ title: Ressources et documentations
 # Documentation technique de la BAN
 
 ## Architecture
-L'écosystème Base Adresse Nationale est complexe. Les nombreux composants nécessaires à la production de l'adresse,la gestion de la base de donnée puis son exploitation sont étroitement imbriqués. Des dépendances avec des composants sous responsabilités d'autres organismes sont également nécessaires pour assurer la cohérence d'ensemble.   Le schéma d'architecture globale est accessible ici : [Schéma d'architecture BAN - BAL](https://github.com/BaseAdresseNationale/ban-plateforme/wiki/Sch%C3%A9ma-g%C3%A9n%C3%A9ral-d%E2%80%99architecture-BAN-BAL-(5-janvier-2022))
+L'écosystème Base Adresse Nationale est complexe. Les nombreux composants nécessaires à la production de l'adresse,la gestion de la base de donnée puis son exploitation sont étroitement imbriqués. Des dépendances avec des composants sous responsabilités d'autres organismes sont également nécessaires pour assurer la cohérence d'ensemble.   Le schéma d'architecture globale est accessible ici : [Schéma d'architecture BAN - BAL](https://github.com/BaseAdresseNationale/ban-plateforme/wiki/Schéma-général-d’architecture-BAN-BAL-(fev-2025))
 
 
 ## Structure de données interne BAN


### PR DESCRIPTION
Modification d'un lien cassé vers le schéma d'architecture sur la page documentation
Fix: #2233 