### PR TITLE
Modif evenements BAN septembre

### DIFF
--- a/src/data/ban-events.json
+++ b/src/data/ban-events.json
@@ -537,13 +537,13 @@
     "instructions": ""
   },
   {
-    "title": "Adresse_Lab",
+    "title": "Adresse-Lab T3 2025",
     "subtitle": "Point d'échange trimestriel T3 2025",
     "description": "Actualités BAN - Point d'échange trimestriel T3 2025",
     "type": "adresselab",
     "target": "utilisateurs de la donnée adresse",
     "date": "2025-09-16",
-    "tags": ["Technique", "Base Adresse Nationale", "Utilisateurs"],
+    "tags": ["Technique", "Utilisateurs", "Base Adresse Nationale"],
     "isOnlineOnly": true,
     "address": {},
     "href": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_Y2QwZDU3OWEtM2I5My00ZjliLTllODEtYjdkZjY3ZjAxMGYz%40thread.v2/0?context=%7b%22Tid%22%3a%223876b373-7e2c-4857-b024-53326b5b4bb2%22%2c%22Oid%22%3a%22b6c5bcc6-2261-4874-9aa5-508a6afa334e%22%7d",
@@ -553,14 +553,14 @@
     "endHour": "12:00"
   },
   {
-    "title" : "Rencontre Utilisateurs Nationaux BAN#9",
+    "title" : "Rencontre Utilisateurs Nationaux BAN",
     "subtitle" : "Adresse_Lab",
     "description" : "Journée d'échanges entre les utilisateurs experts, autour des problématiques partagées : emprise d’utilisation large incluant données d’assemblage, besoin d’historisation de la donnée, adosser des données métier aux adresses de la BAN, besoins spécifiques sur la qualité et la mise à jour des données.",
     "target": "Les SI nationaux utilisateurs avancés de la donnée adresse",
     "date": "2025-09-23",
     "startHour": "10:00",
     "endHour": "16:00",
-    "tags": ["Technique", "Utilisateurs", "BAN"],
+    "tags": ["Technique", "Utilisateurs", "Base Adresse Nationale"],
     "isOnlineOnly": false,
      "address": {
         "nom": "IGN",


### PR DESCRIPTION
Sur les 2 événements de Septembre BAN, faire les modifications ci-dessous:
- sur l'adresse lab, rajouter au titre Adresse-Lab T3 2025
- sur la rencontre des utilisateurs nationaux, enlever le #9
- Mettre un tag Base Adresse Nationale pour les 2 événements au lieu de BAN
-  Harmoniser les tags en mettant TECHNIQUE UTILISATEURS BASE ADRESSE NATIONALE

Rendu des 2 événements:
 
<img width="948" height="437" alt="Capture d’écran du 2025-08-27 09-49-00" src="https://github.com/user-attachments/assets/b1aac854-329c-4405-9355-bfc1ccecb366" />
