### PR TITLE
Modification lien flux rss

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -97,7 +97,7 @@ NEXT_PUBLIC_SOCIAL_NETWORKS_URL_MASTODON=https://social.numerique.gouv.fr/@adres
 NEXT_PUBLIC_SOCIAL_NETWORKS_URL_FACEBOOK=https://www.facebook.com/BasesAdressesLocales
 NEXT_PUBLIC_SOCIAL_NETWORKS_URL_LINKEDIN=https://www.linkedin.com/company/base-adresse-nationale/
 NEXT_PUBLIC_SOCIAL_NETWORKS_URL_GITHUB=https://github.com/BaseAdresseNationale
-NEXT_PUBLIC_SOCIAL_NETWORKS_URL_RSS=https://ghost.adresse.data.gouv.fr/5292cca6f01921e2f0abc4b671d706/rss/
+NEXT_PUBLIC_SOCIAL_NETWORKS_URL_RSS=https://ghost.adresse.data.gouv.fr/rss/
 NEXT_PUBLIC_SOCIAL_NETWORKS_BLUESKY_KEY_DNS=YOUR_BLUESKY_KEY_DNS
 
 # -------------------------------


### PR DESCRIPTION
Modification lien flux rss sur la page blog et le footer qui renvoie actuellement une erreur 404
Il faut changer  dans le .env la valeur de la variable : NEXT_PUBLIC_SOCIAL_NETWORKS_URL_RSS par : https://ghost.adresse.data.gouv.fr/rss/

Fix: #2245 
