### PR TITLE
Use Matomo token Auth for Stats API

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -71,8 +71,7 @@ NEXT_PUBLIC_MES_SIGNALEMENTS_SOURCE_ID=
 
 NEXT_PUBLIC_MATOMO_URL=
 NEXT_PUBLIC_MATOMO_SITE_ID=
-# The Matomo Token is actualy not required
-# MATOMO_TOKEN_AUTH=
+MATOMO_TOKEN_AUTH=
 
 # --------------------------------------
 # --- Connexion au S3 pour les datas ---

--- a/src/app/stats/[slug]/route.tsx
+++ b/src/app/stats/[slug]/route.tsx
@@ -15,16 +15,17 @@ import { env } from 'next-runtime-env'
 
 const NEXT_PUBLIC_MATOMO_URL = env('NEXT_PUBLIC_MATOMO_URL')
 const NEXT_PUBLIC_MATOMO_SITE_ID = env('NEXT_PUBLIC_MATOMO_SITE_ID')
+const MATOMO_TOKEN_AUTH = process.env.MATOMO_TOKEN_AUTH
 
 if (!NEXT_PUBLIC_MATOMO_URL || !NEXT_PUBLIC_MATOMO_SITE_ID) {
   throw new Error('MATOMO_URL and MATOMO_ID is not defined in the environment')
 }
 
-const URL_GET_STATS_MONTHLY_DOWNLOAD = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&module=API&format=JSON&period=month&date=previous12&method=Events.getCategory&filter_pattern=^download&format_metrics=1&expanded=1`
-const URL_GET_STATS_MONTHLY_LOOKUP = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&module=API&format=JSON&period=month&date=previous12&method=Events.getAction&label=Lookup&filter_limit=-1&format_metrics=1&expanded=1`
-const URL_GET_STATS_DAILY_DOWNLOAD = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&module=API&format=JSON&period=day&date=previous30&method=Events.getCategory&expanded=1&filter_limit=10`
-const URL_GET_STATS_DAILY_LOOKUP = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&module=API&format=JSON&period=day&date=previous30&method=Events.getAction&expanded=1&filter_limit=10&filter_pattern=^Lookup`
-const URL_GET_STAT_VISIT = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&module=API&format=JSON&period=month&date=previous12&method=API.get&filter_limit=100&format_metrics=1&expanded=1`
+const URL_GET_STATS_MONTHLY_DOWNLOAD = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&token_auth=${MATOMO_TOKEN_AUTH}&module=API&format=JSON&period=month&date=previous12&method=Events.getCategory&filter_pattern=^download&format_metrics=1&expanded=1`
+const URL_GET_STATS_MONTHLY_LOOKUP = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&token_auth=${MATOMO_TOKEN_AUTH}&module=API&format=JSON&period=month&date=previous12&method=Events.getAction&label=Lookup&filter_limit=-1&format_metrics=1&expanded=1`
+const URL_GET_STATS_DAILY_DOWNLOAD = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&token_auth=${MATOMO_TOKEN_AUTH}&module=API&format=JSON&period=day&date=previous30&method=Events.getCategory&expanded=1&filter_limit=10`
+const URL_GET_STATS_DAILY_LOOKUP = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&token_auth=${MATOMO_TOKEN_AUTH}&module=API&format=JSON&period=day&date=previous30&method=Events.getAction&expanded=1&filter_limit=10&filter_pattern=^Lookup`
+const URL_GET_STAT_VISIT = `${NEXT_PUBLIC_MATOMO_URL}/index.php?idSite=${NEXT_PUBLIC_MATOMO_SITE_ID}&token_auth=${MATOMO_TOKEN_AUTH}&module=API&format=JSON&period=month&date=previous12&method=API.get&filter_limit=100&format_metrics=1&expanded=1`
 
 // Any : is from matomo's data extracted from helper.js
 type StatValue = Record<string, any>


### PR DESCRIPTION
Cette PR fixe le problème de connexion du site vers les API Matomo.
Pour son bon fonctionnement, il est nécessaire de configurer la variable d'environnement `MATOMO_TOKEN_AUTH` avec un token généré depuis l'interface d'administration de Matomo.