### PR TITLE
fix: remove beta badges on signalement buttons

### DIFF
--- a/src/app/carte-base-adresse-nationale/components/PanelAddress/ActionComponents/ActionSignalementAddress.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelAddress/ActionComponents/ActionSignalementAddress.tsx
@@ -5,7 +5,6 @@ import { ActionMessage } from './ActionComponents.styles'
 import { env } from 'next-runtime-env'
 import { matomoTrackEvent } from '@/lib/matomo'
 import { SignalementTypeEnum } from '@/types/api-signalement.types'
-import Badge from '@codegouvfr/react-dsfr/Badge'
 import { useSignalementCommuneStatus } from '@/hooks/useSignalementCommuneStatus'
 
 interface ActionSignalementAddressProps {
@@ -29,7 +28,7 @@ const ActionSignalementAddress: React.FC<ActionSignalementAddressProps> = ({ add
         priority="tertiary no outline"
         style={disabled ? { color: 'var(--text-disabled-grey)' } : {}}
       >
-        Signaler un problème<Badge severity="info" noIcon style={{ marginLeft: '0.4rem' }}>Beta</Badge>
+        Signaler un problème
       </Button>
       {
         isExtended && (

--- a/src/app/carte-base-adresse-nationale/components/PanelMicroToponym/ActionComponents/ActionSignalementMicroToponym.tsx
+++ b/src/app/carte-base-adresse-nationale/components/PanelMicroToponym/ActionComponents/ActionSignalementMicroToponym.tsx
@@ -5,7 +5,6 @@ import { ActionMessage } from '../../PanelAddress/ActionComponents/ActionCompone
 import { env } from 'next-runtime-env'
 import { matomoTrackEvent } from '@/lib/matomo'
 import { SignalementTypeEnum } from '@/types/api-signalement.types'
-import Badge from '@codegouvfr/react-dsfr/Badge'
 import { useSignalementCommuneStatus } from '@/hooks/useSignalementCommuneStatus'
 
 interface ActionSignalementMicroToponymProps {
@@ -29,7 +28,7 @@ const ActionSignalementMicroToponym: React.FC<ActionSignalementMicroToponymProps
         priority="tertiary no outline"
         style={disabled ? { color: 'var(--text-disabled-grey)' } : {}}
       >
-        Signaler un problème<Badge severity="info" noIcon style={{ marginLeft: '0.4rem' }}>Beta</Badge>
+        Signaler un problème
       </Button>
       {
         isExtended && (


### PR DESCRIPTION
Comme vu ensemble lors du point, nous pouvons désormais retirer les badges Beta des boutons de signalement, le dispositif étant assez mature.