### PR TITLE
fix: validator v3.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",
-        "@ban-team/validateur-bal": "^3.5.1",
+        "@ban-team/validateur-bal": "^3.5.3",
         "@codegouvfr/react-dsfr": "^1.31.1",
         "@etalab/decoupage-administratif": "^6.0.0",
         "@gouvfr/dsfr": "^1.14.4",
@@ -1250,19 +1250,19 @@
       }
     },
     "node_modules/@ban-team/shared-data": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@ban-team/shared-data/-/shared-data-1.4.2.tgz",
-      "integrity": "sha512-GBdEmqIJEcx89EKq+PkyL2YR7hfoiKyDlfNy/vob0N5ro4pCdKZ9cMfPvod35FSC9KOEwaUZuOJz5fFwfSqufA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@ban-team/shared-data/-/shared-data-1.4.3.tgz",
+      "integrity": "sha512-2kvWdj/a8kuAyAgiBSuKdW6f0Xv7L7UufxgAVTSTaXITPBrTDAdaOFBxGXXUBnDuNiK99I0122uhMRX1F7FEiw==",
       "license": "MIT"
     },
     "node_modules/@ban-team/validateur-bal": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-3.5.1.tgz",
-      "integrity": "sha512-OGkZY6Wb/ksQQxFfdinc+VABk1BWHKe6wpT+KLMFurzXRcMoUYnYl5O80+UxHgP5TRolDru94ERnLmGvL0EJgw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-3.5.3.tgz",
+      "integrity": "sha512-YqbrjZyIgCxFlo7UL5yyuvAz1/ITtXDy7kFvV1MdRTOD0cLVIhl5xFvaPRIsMR1UzKFsZqYmfoZmk1tFGCcS8Q==",
       "license": "MIT",
       "dependencies": {
         "@ban-team/adresses-util": "^0.9.0",
-        "@ban-team/shared-data": "^1.4.2",
+        "@ban-team/shared-data": "^1.4.3",
         "@etalab/project-legal": "^0.6.0",
         "blob-to-buffer": "^1.2.9",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.645.0",
-    "@ban-team/validateur-bal": "^3.5.1",
+    "@ban-team/validateur-bal": "^3.5.3",
     "@codegouvfr/react-dsfr": "^1.31.1",
     "@etalab/decoupage-administratif": "^6.0.0",
     "@gouvfr/dsfr": "^1.14.4",


### PR DESCRIPTION
## CONTEXT

https://mattermost.incubateur.net/fab-geocommuns/pl/m14ddincpbbsxxfmazj1gg6eha

## AMELIORATION

Maintenant la fonction autofix (mise en forme) du package validator-bal utilise le code_voie pour différentier les numéros qui n'appartiennent pas a la même voie